### PR TITLE
refactor: Consolidate error response handling into check_response helper

### DIFF
--- a/genai-client/src/error_helpers.rs
+++ b/genai-client/src/error_helpers.rs
@@ -6,6 +6,22 @@ use reqwest::Response;
 /// Maximum characters to include from error body in context messages
 const ERROR_BODY_PREVIEW_LENGTH: usize = 200;
 
+/// Checks if an HTTP response is successful, returning it if so or an error otherwise.
+///
+/// This helper consolidates the common pattern of checking response status and
+/// extracting error details on failure.
+///
+/// # Errors
+///
+/// Returns an error with status code and body preview on non-success status.
+pub async fn check_response(response: Response) -> Result<Response, InternalError> {
+    if response.status().is_success() {
+        Ok(response)
+    } else {
+        Err(read_error_with_context(response).await)
+    }
+}
+
 /// Reads error response body and creates a detailed InternalError::Api with context.
 ///
 /// Includes:

--- a/genai-client/src/lib.rs
+++ b/genai-client/src/lib.rs
@@ -1,7 +1,7 @@
 // Declare the models, errors, common, core, interactions, and sse_parser modules
 pub mod common;
 pub mod core;
-pub(crate) mod error_helpers; // Internal helpers, not part of public API
+pub mod error_helpers;
 pub mod errors;
 pub mod interactions;
 pub mod models;

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,6 +5,7 @@ use async_stream::try_stream;
 use futures_util::StreamExt;
 use genai_client::ApiVersion;
 use genai_client::construct_url;
+use genai_client::error_helpers::check_response;
 use genai_client::models::request::GenerateContentRequest as InternalGenerateContentRequest;
 use reqwest::Client as ReqwestClient;
 use std::str;
@@ -127,13 +128,7 @@ impl Client {
             .json(&request_body)
             .send()
             .await?;
-
-        if !response.status().is_success() {
-            let error_text = response.text().await?;
-            log::debug!("Response Text: {error_text}");
-            return Err(GenaiError::Api(error_text));
-        }
-
+        let response = check_response(response).await?;
         let response_text = response.text().await?;
         log::debug!("Response Text: {response_text}");
         let response_body: genai_client::models::response::GenerateContentResponse =


### PR DESCRIPTION
Extract common HTTP error response handling pattern into a shared
`check_response` function that checks response status and returns
detailed errors with HTTP status codes.

- Add check_response() in genai-client/src/error_helpers.rs
- Make error_helpers module public for use from root crate
- Update 5 call sites across core.rs, interactions.rs, and client.rs
- Leverage existing read_error_with_context for consistent formatting