### PR TITLE
docs: Update outdated references in code and documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ The Interactions API provides a unified interface for both models and agents. Ke
 - Support for stateful conversations via `previous_interaction_id`
 
 **Content Structure** (`genai-client/src/models/interactions.rs`):
-- Uses flat `InteractionContent` enum with type-tagged variants (Text, Thought, Image, Audio, Video, FunctionCall, FunctionResponse)
+- Uses flat `InteractionContent` enum with type-tagged variants (Text, Thought, Image, Audio, Video, FunctionCall, FunctionResult)
 - Fields are often optional as API doesn't always return all data
 - Helper functions in `src/interactions_api.rs` provide ergonomic content builders
 
@@ -192,11 +192,9 @@ Tests are organized into two categories:
 
 Integration tests that require a real API key use `#[ignore]` attribute and must be run with `cargo test -- --include-ignored`.
 
-## API Version Support
+## API Version
 
-The library supports different API versions via the `ApiVersion` enum in `genai-client`:
-- Currently defaults to `V1Beta`
-- API version affects URL construction in `genai-client/src/common.rs`
+The library uses the Gemini V1Beta API internally. The API version is configured in `genai-client/src/common.rs` and is not user-configurable.
 
 ## Claude Code Configuration
 

--- a/genai-client/src/models/shared.rs
+++ b/genai-client/src/models/shared.rs
@@ -1,4 +1,4 @@
-// Shared types used by multiple API endpoints (generateContent, interactions, etc.)
+// Shared types used by the Interactions API
 
 use serde::{Deserialize, Serialize};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ impl From<genai_client::InternalError> for GenaiError {
 
 #[cfg(test)]
 mod tests {
-    use super::*; // This will bring in Client, GenerateContentResponse, etc.
+    use super::*; // This will bring in Client, InteractionResponse, etc.
     use genai_client::InternalError;
 
     #[test]


### PR DESCRIPTION
## Summary

Updates outdated comments and documentation to reflect the current Interactions-only API:

- **src/lib.rs**: Update comment mentioning `GenerateContentResponse` → `InteractionResponse`
- **genai-client/src/models/shared.rs**: Update header comment to "Interactions API" only
- **CLAUDE.md**:
  - Change `FunctionResponse` → `FunctionResult` in content variants list
  - Simplify API Version section (no longer user-configurable)

## Test plan

- [x] All unit tests pass
- [x] Clippy passes with no warnings
- [x] Documentation is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)