### PR TITLE
test: Add multimodal input tests and shared test utilities

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -58,3 +58,8 @@ pub const TINY_WAV_BASE64: &str = "UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACA
 /// This is a minimal valid MP4 container header - the model may report it's empty/corrupt
 #[allow(dead_code)]
 pub const TINY_MP4_BASE64: &str = "AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDE=";
+
+/// Small 1x1 blue PNG image encoded as base64
+/// This is a minimal valid PNG for testing multi-image comparisons
+#[allow(dead_code)]
+pub const TINY_BLUE_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";

--- a/tests/multimodal_tests.rs
+++ b/tests/multimodal_tests.rs
@@ -19,8 +19,8 @@
 mod common;
 
 use common::{
-    SAMPLE_AUDIO_URL, SAMPLE_IMAGE_URL, SAMPLE_VIDEO_URL, TINY_MP4_BASE64, TINY_RED_PNG_BASE64,
-    TINY_WAV_BASE64, get_client,
+    SAMPLE_AUDIO_URL, SAMPLE_IMAGE_URL, SAMPLE_VIDEO_URL, TINY_BLUE_PNG_BASE64, TINY_MP4_BASE64,
+    TINY_RED_PNG_BASE64, TINY_WAV_BASE64, get_client,
 };
 use rust_genai::{
     InteractionInput, InteractionStatus, audio_uri_content, image_data_content, image_uri_content,
@@ -125,14 +125,11 @@ async fn test_multiple_images_single_request() {
         return;
     };
 
-    // Create a tiny blue PNG (1x1 pixel)
-    let tiny_blue_png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
-
     // Send two images in a single request (both base64)
     let contents = vec![
         text_content("I'm showing you two small colored images. What colors are they? List both."),
         image_data_content(TINY_RED_PNG_BASE64, "image/png"),
-        image_data_content(tiny_blue_png, "image/png"),
+        image_data_content(TINY_BLUE_PNG_BASE64, "image/png"),
     ];
 
     let response = client
@@ -452,16 +449,13 @@ async fn test_multimodal_comparison() {
         return;
     };
 
-    // Create a tiny blue PNG for comparison
-    let tiny_blue_png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
-
     // Ask model to compare two base64 images
     let contents = vec![
         text_content(
             "Compare these two colored squares. What are their colors and how do they differ?",
         ),
         image_data_content(TINY_RED_PNG_BASE64, "image/png"),
-        image_data_content(tiny_blue_png, "image/png"),
+        image_data_content(TINY_BLUE_PNG_BASE64, "image/png"),
     ];
 
     let response = client


### PR DESCRIPTION
## Summary
- Add comprehensive e2e tests for multimodal inputs (9 tests)
- Add shared test utilities in `tests/common/mod.rs`

## Tests Added
- `test_image_input_from_uri` - Documents GCS URI limitation
- `test_image_input_from_base64` - Red PNG color detection
- `test_multiple_images_single_request` - Red + blue PNG comparison
- `test_image_with_follow_up_question` - Stateful image conversation
- `test_audio_input_from_uri` - Graceful error handling
- `test_audio_input_from_base64` - Base64 audio processing
- `test_video_input_from_uri` - Graceful error handling
- `test_multimodal_text_and_image_interleaved` - Mixed content
- `test_multimodal_comparison` - Compare two images

## Shared Utilities
- `get_client()` helper for API key handling
- Sample asset URL constants with documentation
- Base64-encoded test assets (tiny PNG, WAV)

## Note
GCS URIs (`gs://`) are not supported by the Interactions API. Tests gracefully handle this limitation and primarily use base64 encoding.

## Test plan
- [x] `cargo test --test multimodal_tests -- --include-ignored`

🤖 Generated with [Claude Code](https://claude.com/claude-code)