### PR TITLE
test: Add advanced function calling tests

### DIFF
--- a/tests/advanced_function_calling_tests.rs
+++ b/tests/advanced_function_calling_tests.rs
@@ -22,6 +22,16 @@ use serde_json::json;
 // =============================================================================
 // Test Functions (registered via macro)
 // =============================================================================
+//
+// NOTE: These functions are marked #[allow(dead_code)] because they're registered
+// with the inventory crate via #[generate_function_declaration]. The macro creates
+// `Callable*` structs that are collected at runtime for automatic function calling.
+//
+// While not all functions are explicitly called in tests, they serve these purposes:
+// - get_weather_test, get_time_test, convert_temperature: Used in parallel/sequential tests
+// - get_server_status: Used in no-argument function tests
+// - search_with_filters: Used in complex argument tests
+// - always_fails: Reserved for future error handling tests (demonstrates panic behavior)
 
 /// Gets the current weather for a city
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary
Add comprehensive e2e tests for function calling scenarios (11 tests).

**⚠️ Depends on PR #29** - This PR requires the `tests/common/mod.rs` module from #29 to be merged first.

## Tests Added
- `test_parallel_function_calls` - Weather + time for same city
- `test_sequential_function_chain` - Weather -> temperature conversion
- `test_function_call_complex_args` - Nested object arguments
- `test_function_call_no_args` - Functions without parameters
- `test_function_call_error_response` - Error handling
- `test_auto_function_calling_registered` - Macro-registered functions
- `test_auto_function_calling_max_loops` - Loop limit enforcement
- `test_thought_signature_parallel_only_first` - Signature on parallel calls
- `test_thought_signature_sequential_each_step` - Signature per step
- `test_streaming_with_function_calls` - Documents known limitation
- `test_streaming_long_response` - Long streaming responses

## Test Functions
The file defines several test functions using `#[generate_function_declaration]` macro. Some functions are defined for potential future tests or to verify macro compilation.

## Known Limitation
Streaming with function calls currently fails due to missing `FunctionCall` variant in `InteractionContentDelta` (see #27). Test gracefully handles this.

## Test Flakiness
Per CLAUDE.md, integration tests may occasionally fail due to LLM behavior variability. Re-running usually succeeds.

## Test plan
- [x] `cargo test --test advanced_function_calling_tests -- --include-ignored`

🤖 Generated with [Claude Code](https://claude.com/claude-code)