### PR TITLE
test: Add built-in tools and generation config tests

### DIFF
--- a/tests/tools_and_config_tests.rs
+++ b/tests/tools_and_config_tests.rs
@@ -395,13 +395,19 @@ async fn test_response_modalities_image() {
                 println!("Output {}: {:?}", i, output);
             }
 
-            // Image generation might return base64 data or a URL
+            // Image generation should return image content
             let has_image = response
                 .outputs
                 .iter()
                 .any(|o| matches!(o, rust_genai::InteractionContent::Image { .. }));
 
             println!("Has image output: {}", has_image);
+
+            // Assert we got an image when the model successfully responded
+            assert!(
+                has_image,
+                "Expected image content in response when using IMAGE modality"
+            );
         }
         Err(e) => {
             let error_str = format!("{:?}", e);


### PR DESCRIPTION
## Summary
Add comprehensive e2e tests for built-in tools and generation config (12 tests).

**⚠️ Depends on PR #29** - This PR requires the `tests/common/mod.rs` module from #29 to be merged first.

## Tests Added

### Built-in Tools (documents limitations - see #28)
- `test_google_search_grounding` - Search for current info
- `test_code_execution` - Calculate factorial
- `test_code_execution_complex_calculation` - Sum of primes
- `test_url_context` - Fetch and summarize URL

### Response Formats
- `test_structured_output_json_schema` - Not supported, graceful handling
- `test_structured_output_enum_constraint` - Not supported, graceful handling
- `test_response_modalities_image` - Image generation

### Generation Config
- `test_generation_config_thinking_level_minimal` - Quick responses
- `test_generation_config_thinking_level_high` - Detailed reasoning
- `test_generation_config_top_p` - Nucleus sampling
- `test_generation_config_top_k` - Not supported, graceful handling
- `test_generation_config_combined` - Multiple config options

## Known Limitations
- Built-in tools return content types not yet supported (see #28)
- `json_schema` response format not supported by Interactions API
- `top_k` parameter not supported in GenerationConfig

## Test Flakiness
Per CLAUDE.md, integration tests may occasionally fail due to LLM behavior variability. Re-running usually succeeds.

## Test plan
- [x] `cargo test --test tools_and_config_tests -- --include-ignored`

🤖 Generated with [Claude Code](https://claude.com/claude-code)