### PR TITLE
ci: Fix workflow to target main branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Fix CI workflow to target `main` branch instead of `master`.

The default branch is `main` but the workflow was configured for `master`, so CI wasn't running on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)