### PR TITLE
chore: Address PR #83 code review feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ A Rust client library for interacting with Google's Generative AI (Gemini) API u
 - Stateful conversations with automatic context management via `previous_interaction_id`
 - Function calling with both manual and automatic execution
 - Automatic function discovery at compile time using procedural macros
+- Structured output with JSON schema enforcement via `with_response_format()`
+- Built-in tool support: Google Search grounding, URL context, and code execution
 - Helper functions for building multi-turn conversations
 - Comprehensive error handling with detailed error types
 - Async/await support with Tokio

--- a/examples/structured_output.rs
+++ b/examples/structured_output.rs
@@ -78,7 +78,8 @@ async fn basic_structured_output(client: &Client) -> Result<(), Box<dyn Error>> 
         .create()
         .await?;
 
-    // The response is guaranteed to be valid JSON matching our schema
+    // The response is guaranteed to be valid JSON matching our schema.
+    // Note: In production code, handle the Option properly instead of using expect().
     let text = response.text().expect("Should have text response");
     println!("Raw JSON response:\n{}\n", text);
 
@@ -143,6 +144,7 @@ async fn complex_nested_schema(client: &Client) -> Result<(), Box<dyn Error>> {
         .create()
         .await?;
 
+    // Note: In production code, handle the Option properly instead of using expect().
     let text = response.text().expect("Should have text response");
 
     // Parse and pretty-print the JSON
@@ -197,6 +199,7 @@ async fn structured_with_search(client: &Client) -> Result<(), Box<dyn Error>> {
         .create()
         .await?;
 
+    // Note: In production code, handle the Option properly instead of using expect().
     let text = response.text().expect("Should have text response");
     let json: serde_json::Value = serde_json::from_str(text)?;
     println!("Stock Info JSON:\n{}", serde_json::to_string_pretty(&json)?);

--- a/tests/tools_and_config_tests.rs
+++ b/tests/tools_and_config_tests.rs
@@ -389,7 +389,7 @@ async fn test_structured_output_json_schema() {
     let result = client
         .interaction()
         .with_model("gemini-3-flash-preview")
-        .with_text("Generate a fake user profile with name John Smith, age 30, and email john@example.com. Return ONLY the JSON object, no other text.")
+        .with_text("Generate a fake user profile with a name, age, and email address.")
         .with_response_format(schema)
         .with_store(true)
         .create()


### PR DESCRIPTION
## Summary

Addresses the optional suggestions from the claude-review on PR #83:

- **LLM Flakiness**: Made test prompt more generic ("Generate a fake user profile with a name, age, and email address.") to match the assertions that only check for field presence
- **Error Handling Notes**: Added comments in `examples/structured_output.rs` noting that production code should handle the `Option` properly instead of using `expect()`
- **README Update**: Added structured output and built-in tools to the Features section

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)