### PR TITLE
feat: Add request timeout configuration

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -47,7 +47,8 @@ impl ClientBuilder {
     /// For LLM requests that may take a long time to generate responses,
     /// consider setting a longer timeout (e.g., 120-300 seconds).
     ///
-    /// If not set, uses reqwest's default (no timeout).
+    /// If not set, requests will wait indefinitely (no timeout).
+    /// Connection-level timeouts like TCP keepalive may still apply at the OS level.
     ///
     /// # Example
     ///
@@ -70,7 +71,7 @@ impl ClientBuilder {
     /// This is the maximum time to wait for establishing a connection to the server.
     /// A shorter timeout here can help fail fast if the network is unavailable.
     ///
-    /// If not set, uses reqwest's default.
+    /// If not set, the connection phase will wait indefinitely (no timeout).
     ///
     /// # Example
     ///
@@ -89,6 +90,11 @@ impl ClientBuilder {
     }
 
     /// Builds the `Client`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the underlying HTTP client cannot be constructed. This should only
+    /// happen in exceptional circumstances such as TLS backend initialization failures.
     #[must_use]
     pub fn build(self) -> Client {
         let mut builder = ReqwestClient::builder();


### PR DESCRIPTION
## Summary

Fixes #67 - Add request timeout configuration

Adds `timeout()` and `connect_timeout()` methods to `ClientBuilder` for better control over long-running operations.

## Changes

- Add `timeout()` method to set total request timeout (start to finish)
- Add `connect_timeout()` method to set connection establishment timeout
- Add unit tests for timeout configuration
- Add comprehensive documentation with examples

## Usage

```rust
use rust_genai::Client;
use std::time::Duration;

let client = Client::builder(api_key)
    .timeout(Duration::from_secs(120))      // Total request timeout
    .connect_timeout(Duration::from_secs(10)) // Connection timeout
    .build();
```

## Why This Matters

- LLM requests can take 30+ seconds for complex generations
- reqwest's default timeout may not be appropriate for all use cases
- Users need control to fail fast on connection issues while allowing time for generation

## Test plan

- [x] Unit tests for builder with timeout, connect_timeout, and both
- [x] All existing tests pass
- [x] Clippy and fmt checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)