### PR TITLE
test: Add Google Search + multi-turn test (#111)

### DIFF
--- a/tests/agents_and_multiturn_tests.rs
+++ b/tests/agents_and_multiturn_tests.rs
@@ -2324,6 +2324,7 @@ async fn test_google_search_multi_turn() {
             .with_model("gemini-3-flash-preview")
             .with_previous_interaction(&response1.id)
             .with_text("Based on the weather information you just found, should I bring an umbrella if I visit Tokyo today?")
+            .with_store(true)
             .create()
             .await
     })


### PR DESCRIPTION
## Summary

Adds test verifying Google Search grounding works across multiple conversation turns.

**Test flow:**
- **Turn 1**: Ask about current weather in Tokyo with `.with_google_search()` and `.with_store(true)`
- **Turn 2**: Follow-up question about bringing an umbrella, referencing the search results

This validates that search context persists via `previous_interaction_id`.

Closes #111

## Test plan

- [x] `cargo test test_google_search_multi_turn -- --include-ignored` passes
- [x] All quality checks pass (fmt, clippy, unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)