### PR TITLE
ci: Add CI Gate job for branch protection with path filters

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,13 +6,11 @@ on:
     paths-ignore:
       - '**.md'
       - 'LICENSE'
-      - '.github/workflows/**'
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '**.md'
       - 'LICENSE'
-      - '.github/workflows/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -86,3 +84,28 @@ jobs:
         run: cargo doc --workspace --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: -D warnings
+
+  # Gate job that always runs - use this as the single required check
+  # This allows paths-ignore to skip CI jobs while still satisfying branch protection
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [check, test, test-integration, fmt, clippy, doc]
+    steps:
+      - name: Check required jobs passed
+        run: |
+          # Integration tests are informational (external API dependency)
+          # Only fail on core job failures: check, test, fmt, clippy, doc
+          CORE_RESULTS="${{ needs.check.result }},${{ needs.test.result }},${{ needs.fmt.result }},${{ needs.clippy.result }},${{ needs.doc.result }}"
+          if [[ "$CORE_RESULTS" == *"failure"* ]]; then
+            echo "One or more core jobs failed"
+            exit 1
+          fi
+
+          # Report integration test status but don't block
+          if [[ "${{ needs.test-integration.result }}" == "failure" ]]; then
+            echo "⚠️ Integration tests failed (informational - external API dependency)"
+          fi
+
+          echo "All required jobs passed or were skipped"


### PR DESCRIPTION
## Summary

- Add CI Gate job that always runs and aggregates job results
- Integration tests are informational (don't block merge on failure)
- Remove `.github/workflows/**` from paths-ignore so workflow changes trigger CI

This allows doc-only PRs to merge without running full CI while still protecting code changes via branch protection requiring only "CI Gate".

## Test plan

- [x] CI workflow syntax is valid
- [ ] CI Gate passes when core jobs pass
- [ ] CI Gate passes even when integration tests fail (quota issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)