### PR TITLE
docs: Add module-level docs and test fixture builders

### DIFF
--- a/genai-client/src/lib.rs
+++ b/genai-client/src/lib.rs
@@ -1,3 +1,24 @@
+//! # genai-client
+//!
+//! Internal HTTP client and JSON models for the Gemini Interactions API.
+//!
+//! This crate provides the low-level building blocks used by `rust-genai`.
+//! Most users should use `rust-genai` directly rather than this crate.
+//!
+//! ## Crate Organization
+//!
+//! - [`models`]: JSON types for API requests/responses
+//! - [`interactions`]: HTTP client functions for the Interactions API
+//! - [`errors`]: Error types with structured API error information
+//! - [`sse_parser`]: Server-Sent Events parsing for streaming responses
+//!
+//! ## Forward Compatibility
+//!
+//! Types in this crate follow the Evergreen philosophy:
+//! - Enums like [`InteractionContent`] and [`Tool`] include `Unknown` variants
+//! - These capture unrecognized API types without deserialization failures
+//! - Use `#[non_exhaustive]` to ensure match statements handle future variants
+
 // Declare the models, errors, common, interactions, and sse_parser modules
 pub mod common;
 pub mod error_helpers;

--- a/src/interactions_api.rs
+++ b/src/interactions_api.rs
@@ -542,6 +542,38 @@ pub fn url_context_result_content(
     }
 }
 
+/// Creates a successful URL context result (convenience helper)
+///
+/// Shorthand for creating a result where the URL content was successfully fetched.
+///
+/// # Example
+/// ```
+/// use rust_genai::interactions_api::url_context_success;
+///
+/// let result = url_context_success("https://example.com", "<html>...</html>");
+/// ```
+pub fn url_context_success(
+    url: impl Into<String>,
+    content: impl Into<String>,
+) -> InteractionContent {
+    url_context_result_content(url, Some(content.into()))
+}
+
+/// Creates a failed URL context result (convenience helper)
+///
+/// Shorthand for creating a result where the URL content could not be fetched
+/// (e.g., network errors, blocked URLs, timeouts, or access restrictions).
+///
+/// # Example
+/// ```
+/// use rust_genai::interactions_api::url_context_failure;
+///
+/// let result = url_context_failure("https://example.com/blocked");
+/// ```
+pub fn url_context_failure(url: impl Into<String>) -> InteractionContent {
+    url_context_result_content(url, None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,57 @@
+//! # rust-genai
+//!
+//! A Rust client library for Google's Generative AI (Gemini) API using the Interactions API.
+//!
+//! ## Quick Start
+//!
+//! ```no_run
+//! use rust_genai::Client;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), rust_genai::GenaiError> {
+//!     let client = Client::new(
+//!         std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not set")
+//!     );
+//!
+//!     let response = client
+//!         .interaction()
+//!         .with_model("gemini-3-flash-preview")
+//!         .with_text("Hello, Gemini!")
+//!         .create()
+//!         .await?;
+//!
+//!     println!("{}", response.text().unwrap_or("No response"));
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Features
+//!
+//! - **Fluent Builder API**: Chain methods for readable request construction
+//! - **Streaming**: Real-time response streaming with `create_stream()`
+//! - **Function Calling**: Automatic function discovery and execution via macros
+//! - **Built-in Tools**: Google Search, Code Execution, URL Context
+//! - **Multimodal**: Images, audio, video, and document inputs
+//! - **Thinking Mode**: Access model reasoning with configurable levels
+//!
+//! ## API Stability & Forward Compatibility
+//!
+//! This library is designed for forward compatibility with evolving APIs:
+//!
+//! - **`#[non_exhaustive]` enums**: Match statements require wildcard arms (`_ => ...`)
+//! - **`Unknown` variants**: Unrecognized API types are captured, not rejected
+//! - **Graceful degradation**: New API features won't break existing code
+//!
+//! When Google adds new features, your code continues to work. Unknown content types
+//! and tools are preserved for inspection via helper methods like `has_unknown()`.
+//!
+//! ## Module Organization
+//!
+//! - [`Client`]: Main entry point for API interactions
+//! - [`InteractionBuilder`]: Fluent builder for configuring requests
+//! - [`interactions_api`]: Helper functions for constructing content
+//! - [`function_calling`]: Function registration and execution
+
 // Re-export unified function declaration types from genai_client
 pub use genai_client::{FunctionDeclaration, FunctionDeclarationBuilder, FunctionParameters, Tool};
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -434,3 +434,70 @@ pub const TINY_BLUE_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAf
 /// This is a complete valid PDF for testing document input
 #[allow(dead_code)]
 pub const TINY_PDF_BASE64: &str = "JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCA3MiA3Ml0gL0NvbnRlbnRzIDQgMCBSIC9SZXNvdXJjZXMgPDwgPj4gPj4KZW5kb2JqCjQgMCBvYmoKPDwgL0xlbmd0aCA0NCA+PgpzdHJlYW0KQlQgL0YxIDEyIFRmIDEwIDUwIFRkIChIZWxsbyBXb3JsZCkgVGogRVQKZW5kc3RyZWFtCmVuZG9iagp4cmVmCjAgNQowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMDkgMDAwMDAgbiAKMDAwMDAwMDA1OCAwMDAwMCBuIAowMDAwMDAwMTE1IDAwMDAwIG4gCjAwMDAwMDAyMjQgMDAwMDAgbiAKdHJhaWxlcgo8PCAvU2l6ZSA1IC9Sb290IDEgMCBSID4+CnN0YXJ0eHJlZgozMjAKJSVFT0Y=";
+
+// =============================================================================
+// Test Fixture Builders (Issue #82)
+// =============================================================================
+
+/// Default model used across all tests.
+#[allow(dead_code)]
+pub const DEFAULT_MODEL: &str = "gemini-3-flash-preview";
+
+/// Creates a pre-configured interaction builder with the default model.
+///
+/// This is the standard entry point for integration tests, reducing boilerplate.
+///
+/// # Example
+///
+/// ```ignore
+/// use common::{get_client, interaction_builder};
+///
+/// let client = get_client().unwrap();
+/// let response = interaction_builder(&client)
+///     .with_text("Hello!")
+///     .create()
+///     .await
+///     .expect("Request failed");
+/// ```
+#[allow(dead_code)]
+pub fn interaction_builder(client: &Client) -> rust_genai::InteractionBuilder<'_> {
+    client.interaction().with_model(DEFAULT_MODEL)
+}
+
+/// Creates a stateful interaction builder with storage enabled.
+///
+/// Use this when testing multi-turn conversations that need server-side state.
+///
+/// # Example
+///
+/// ```ignore
+/// let response = stateful_builder(&client)
+///     .with_text("Remember my name is Alice")
+///     .create()
+///     .await?;
+/// ```
+#[allow(dead_code)]
+pub fn stateful_builder(client: &Client) -> rust_genai::InteractionBuilder<'_> {
+    interaction_builder(client).with_store(true)
+}
+
+/// Creates an interaction builder with thinking enabled.
+///
+/// Use this for tests that need model reasoning. Note that thoughts may not
+/// always be visible in the response depending on API behavior.
+///
+/// # Example
+///
+/// ```ignore
+/// let response = thinking_builder(&client)
+///     .with_text("Solve this step by step: 2+2")
+///     .create()
+///     .await?;
+/// if response.has_thoughts() {
+///     println!("Model reasoning: {:?}", response.thoughts());
+/// }
+/// ```
+#[allow(dead_code)]
+pub fn thinking_builder(client: &Client) -> rust_genai::InteractionBuilder<'_> {
+    interaction_builder(client).with_thinking_level(rust_genai::ThinkingLevel::Medium)
+}


### PR DESCRIPTION
## Summary

- Add comprehensive module-level documentation to `src/lib.rs` with Quick Start example, Features list, and Forward Compatibility section
- Add module-level docs to `genai-client/src/lib.rs` explaining crate organization and forward compatibility philosophy
- Add `url_context_success()` and `url_context_failure()` convenience helpers to match the `code_execution_success/error` pattern
- Add test fixture builders to `tests/common/mod.rs` (addresses #82):
  - `interaction_builder()` - standard builder with default model
  - `stateful_builder()` - for multi-turn conversation tests
  - `thinking_builder()` - for reasoning/thinking tests

## Test plan

- [x] `cargo fmt` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib` passes (30 tests)
- [x] `cargo test --doc` passes (45 doc tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)