### PR TITLE
refactor: Rename macro from generate_function_declaration to tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ cargo run --example image_generation
 1. **Public API** (`src/lib.rs`, `src/client.rs`, `src/request_builder.rs`): User-facing `Client`, `InteractionBuilder`, error conversion
 2. **Internal Logic** (`src/function_calling.rs`, `src/interactions_api.rs`): Function registry, content builders
 3. **HTTP Client** (`genai-client/`): Raw API requests, JSON models (`models/interactions.rs`, `models/shared.rs`), SSE streaming
-4. **Macros** (`rust-genai-macros/`): `#[generate_function_declaration]` macro with `inventory` registration
+4. **Macros** (`rust-genai-macros/`): `#[tool]` macro with `inventory` registration
 
 ### Key Patterns
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +978,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "trybuild",
 ]
 
 [[package]]
@@ -1134,6 +1141,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1264,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1280,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1367,6 +1398,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.10+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1505,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e17e807bff86d2a06b52bca4276746584a78375055b6e45843925ce2802b335"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1617,6 +1702,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1809,6 +1903,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,6 @@ inventory = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+trybuild = "1.0.114"
 
 # Workspace-level metadata

--- a/README.md
+++ b/README.md
@@ -278,15 +278,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Automatic Function Calling
 
-The library supports automatic function discovery and execution. Functions decorated with `#[generate_function_declaration]` are automatically discovered and executed when the model requests them:
+The library supports automatic function discovery and execution. Functions decorated with `#[tool]` are automatically discovered and executed when the model requests them:
 
 ```rust
 use rust_genai::{Client, CallableFunction, WithFunctionCalling};
-use rust_genai_macros::generate_function_declaration;
+use rust_genai_macros::tool;
 use std::env;
 
 /// Get the current weather in a location
-#[generate_function_declaration(
+#[tool(
     location(description = "The city and state, e.g. San Francisco, CA"),
     unit(description = "The temperature unit", enum_values = ["celsius", "fahrenheit"])
 )]
@@ -333,13 +333,13 @@ Key features of automatic function calling:
 
 ### Using the Procedural Macro
 
-The `#[generate_function_declaration]` macro provides an ergonomic way to create function declarations:
+The `#[tool]` macro provides an ergonomic way to create function declarations:
 
 ```rust
-use rust_genai_macros::generate_function_declaration;
+use rust_genai_macros::tool;
 
 /// Function to get the weather in a given location
-#[generate_function_declaration(
+#[tool(
     location(description = "The city and state, e.g. San Francisco, CA"),
     unit(description = "The temperature unit to use", enum_values = ["celsius", "fahrenheit"])
 )]
@@ -532,8 +532,8 @@ impl CallableFunction for MyFunction {
     }
 }
 
-// Functions marked with #[generate_function_declaration] are automatically
-// registered in a global registry and discovered by create_with_auto_functions()
+// Functions marked with #[tool] are automatically registered in a global
+// registry and discovered by create_with_auto_functions()
 ```
 
 ## Logging
@@ -581,7 +581,7 @@ The project consists of three main components:
    - Handles the actual HTTP requests and response parsing
 
 3. **Macro Crate (`rust-genai-macros/`)**:
-   - Procedural macro for `#[generate_function_declaration]`
+   - Procedural macro for `#[tool]`
    - Automatic function registration via `inventory` crate
 
 Users of the `rust-genai` crate typically do not need to interact with `genai-client` directly, as its functionalities are exposed through the main `rust-genai` API.
@@ -664,7 +664,7 @@ match result {
 **Function calls not being executed**
 - Ensure you're using `create_with_auto_functions()` for automatic execution
 - For manual execution, check that you're sending the `FunctionResult` back correctly
-- Verify your function is registered via `#[generate_function_declaration]`
+- Verify your function is registered via `#[tool]`
 
 **Image URL not accessible**
 - The API blocks most public HTTP URLs for security

--- a/examples/auto_function_calling.rs
+++ b/examples/auto_function_calling.rs
@@ -17,7 +17,7 @@
 
 use futures_util::StreamExt;
 use rust_genai::{CallableFunction, Client, StreamChunk};
-use rust_genai_macros::generate_function_declaration;
+use rust_genai_macros::tool;
 use std::env;
 use std::io::{Write, stdout};
 
@@ -25,7 +25,7 @@ use std::io::{Write, stdout};
 // in the global function registry for auto-calling.
 
 /// Gets the current weather for a city
-#[generate_function_declaration(city(description = "The city to get weather for"))]
+#[tool(city(description = "The city to get weather for"))]
 fn get_weather(city: String) -> String {
     // In a real application, this would call a weather API
     println!("  [Function called: get_weather(city={})]", city);
@@ -36,7 +36,7 @@ fn get_weather(city: String) -> String {
 }
 
 /// Gets the current time in a timezone
-#[generate_function_declaration(timezone(description = "The timezone like UTC, PST, EST, JST"))]
+#[tool(timezone(description = "The timezone like UTC, PST, EST, JST"))]
 fn get_time(timezone: String) -> String {
     println!("  [Function called: get_time(timezone={})]", timezone);
     format!(

--- a/examples/streaming_auto_functions.rs
+++ b/examples/streaming_auto_functions.rs
@@ -21,14 +21,14 @@
 
 use futures_util::StreamExt;
 use rust_genai::{AutoFunctionStreamChunk, CallableFunction, Client, InteractionContent};
-use rust_genai_macros::generate_function_declaration;
+use rust_genai_macros::tool;
 use std::env;
 use std::io::{Write, stdout};
 
 // Define functions using the macro - automatically registered for auto-calling.
 
 /// Gets the current weather for a city
-#[generate_function_declaration(city(description = "The city to get weather for"))]
+#[tool(city(description = "The city to get weather for"))]
 fn get_weather(city: String) -> String {
     // Simulate some processing time
     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -39,7 +39,7 @@ fn get_weather(city: String) -> String {
 }
 
 /// Gets the current time in a timezone
-#[generate_function_declaration(timezone(description = "The timezone like UTC, PST, EST, JST"))]
+#[tool(timezone(description = "The timezone like UTC, PST, EST, JST"))]
 fn get_time(timezone: String) -> String {
     std::thread::sleep(std::time::Duration::from_millis(100));
     format!(
@@ -49,7 +49,7 @@ fn get_time(timezone: String) -> String {
 }
 
 /// Converts temperature between units
-#[generate_function_declaration(
+#[tool(
     value(description = "The temperature value"),
     from_unit(description = "Source unit: celsius or fahrenheit"),
     to_unit(description = "Target unit: celsius or fahrenheit")

--- a/rust-genai-macros/src/codegen.rs
+++ b/rust-genai-macros/src/codegen.rs
@@ -1,0 +1,254 @@
+//! Code generation for the `#[tool]` macro.
+//!
+//! Generates the `FunctionDeclaration`, `CallableFunction` implementation,
+//! and auto-registration code for functions annotated with `#[tool]`.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{ItemFn, Pat};
+use utoipa::openapi::RefOr;
+use utoipa::openapi::schema::Schema;
+
+use crate::schema::get_type_info;
+
+/// Converts a `serde_json::Value` to a `TokenStream` that constructs an equivalent
+/// `Value` at runtime.
+///
+/// This is used to embed parameter schemas directly in the generated code, avoiding
+/// runtime JSON parsing.
+fn json_value_to_tokens(value: &serde_json::Value) -> TokenStream {
+    match value {
+        serde_json::Value::Null => quote! { ::serde_json::Value::Null },
+        serde_json::Value::Bool(b) => quote! { ::serde_json::Value::Bool(#b) },
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                quote! { ::serde_json::json!(#i) }
+            } else if let Some(f) = n.as_f64() {
+                quote! { ::serde_json::json!(#f) }
+            } else if let Some(u) = n.as_u64() {
+                // u64 that doesn't fit in i64 - convert to f64 at compile time
+                let f = u as f64;
+                quote! { ::serde_json::json!(#f) }
+            } else {
+                // Should not happen for valid JSON numbers
+                quote! { ::serde_json::Value::Null }
+            }
+        }
+        serde_json::Value::String(s) => quote! { ::serde_json::Value::String(#s.to_string()) },
+        serde_json::Value::Array(arr) => {
+            let items = arr.iter().map(json_value_to_tokens);
+            quote! { ::serde_json::Value::Array(vec![#(#items),*]) }
+        }
+        serde_json::Value::Object(obj) => {
+            let pairs = obj.iter().map(|(k, v)| {
+                let v_tokens = json_value_to_tokens(v);
+                quote! { (#k.to_string(), #v_tokens) }
+            });
+            quote! {
+                ::serde_json::Value::Object({
+                    let mut map = ::serde_json::Map::new();
+                    #(
+                        let (k, v) = #pairs;
+                        map.insert(k, v);
+                    )*
+                    map
+                })
+            }
+        }
+    }
+}
+
+/// Generates all the code artifacts for a function annotated with `#[tool]`.
+///
+/// This includes:
+/// - The original function (unchanged)
+/// - A `{FuncName}Callable` struct implementing `CallableFunction`
+/// - A `{func_name}_declaration()` function returning the `FunctionDeclaration`
+/// - A `{func_name}_callable_factory()` function for the registry
+/// - Automatic registration via `inventory::submit!`
+#[allow(clippy::too_many_lines)]
+pub fn generate_declaration_function(
+    func: &ItemFn,
+    func_name: &str,
+    func_description: &str,
+    parameters_schema_ref: &RefOr<Schema>,
+    required_params_for_struct_field: &[String],
+) -> TokenStream {
+    let generated_fn_name =
+        syn::Ident::new(&format!("{func_name}_declaration"), func.sig.ident.span());
+
+    let callable_struct_name_str = func_name
+        .split('_')
+        .map(|s| {
+            s.chars()
+                .next()
+                .map_or_else(|| s.to_string(), |c| c.to_uppercase().to_string() + &s[1..])
+        })
+        .collect::<String>()
+        + "Callable";
+    let callable_struct_name = syn::Ident::new(&callable_struct_name_str, func.sig.ident.span());
+
+    let generated_callable_factory_fn_name = syn::Ident::new(
+        &format!("{func_name}_callable_factory"),
+        func.sig.ident.span(),
+    );
+
+    let required_field_tokens = if required_params_for_struct_field.is_empty() {
+        quote! { ::std::vec::Vec::new() }
+    } else {
+        quote! {
+            ::std::vec![
+                #( #required_params_for_struct_field.to_string() ),*
+            ]
+        }
+    };
+
+    // Convert the schema to a JSON Value to extract properties.
+    // This avoids runtime string parsing - properties are embedded directly in generated code.
+    let parameters_schema_value = match serde_json::to_value(parameters_schema_ref) {
+        Ok(v) => v,
+        Err(e) => {
+            return syn::Error::new(
+                func.sig.ident.span(),
+                format!(
+                    "Failed to serialize parameter schema for '{}': {}",
+                    func_name, e
+                ),
+            )
+            .to_compile_error();
+        }
+    };
+
+    // Extract properties from the schema. For functions with parameters, this should always exist.
+    let properties_value = match parameters_schema_value.get("properties") {
+        Some(props) => props.clone(),
+        None => {
+            // Functions with no parameters will have no properties - that's fine
+            if !required_params_for_struct_field.is_empty() {
+                return syn::Error::new(
+                    func.sig.ident.span(),
+                    format!(
+                        "Internal error: generated schema for '{}' has no properties despite having required parameters",
+                        func_name
+                    ),
+                )
+                .to_compile_error();
+            }
+            serde_json::json!({})
+        }
+    };
+
+    let properties_tokens = json_value_to_tokens(&properties_value);
+
+    let mut arg_names = Vec::new();
+    let mut arg_extraction_tokens = Vec::new();
+
+    for fn_arg in &func.sig.inputs {
+        if let syn::FnArg::Typed(pat_type) = fn_arg
+            && let Pat::Ident(pat_ident) = &*pat_type.pat
+        {
+            let param_name_str = pat_ident.ident.to_string();
+            let param_ident = &pat_ident.ident;
+            let param_type = &pat_type.ty;
+            arg_names.push(param_ident.clone());
+
+            let (is_option, _inner_type) = get_type_info(param_type);
+
+            if is_option {
+                arg_extraction_tokens.push(quote! {
+                    let #param_ident: #param_type = match args.get(#param_name_str) {
+                        Some(val) if !val.is_null() => {
+                            ::serde_json::from_value(val.clone()).map_err(|e| {
+                                ::rust_genai::function_calling::FunctionError::ArgumentMismatch(
+                                    format!("Failed to deserialize optional argument '{}': {}", #param_name_str, e)
+                                )
+                            })?
+                        }
+                        _ => None,
+                    };
+                });
+            } else {
+                arg_extraction_tokens.push(quote! {
+                    let #param_ident: #param_type = args.get(#param_name_str)
+                        .ok_or_else(|| ::rust_genai::function_calling::FunctionError::ArgumentMismatch(format!("Missing required argument '{}'", #param_name_str)))
+                        .and_then(|val| ::serde_json::from_value(val.clone()).map_err(|e| {
+                            ::rust_genai::function_calling::FunctionError::ArgumentMismatch(
+                                format!("Failed to deserialize argument '{}': {}", #param_name_str, e)
+                            )
+                        }))?;
+                });
+            }
+        }
+    }
+
+    let original_fn_ident = &func.sig.ident;
+    let fn_call_args = quote! { #(#arg_names),* };
+
+    let is_async_fn = func.sig.asyncness.is_some();
+    let fn_call_expr = if is_async_fn {
+        quote! { #original_fn_ident(#fn_call_args).await }
+    } else {
+        quote! { #original_fn_ident(#fn_call_args) }
+    };
+
+    let output = quote! {
+        #func
+
+        #[derive(Debug, Clone, Copy)]
+        pub struct #callable_struct_name;
+
+        impl #callable_struct_name {
+            pub const fn new() -> Self {
+                Self
+            }
+        }
+
+        #[::async_trait::async_trait]
+        impl ::rust_genai::function_calling::CallableFunction for #callable_struct_name {
+            fn declaration(&self) -> ::rust_genai::FunctionDeclaration {
+                ::rust_genai::FunctionDeclaration::new(
+                    #func_name.to_string(),
+                    #func_description.to_string(),
+                    ::rust_genai::FunctionParameters::new(
+                        "object".to_string(),
+                        #properties_tokens,
+                        #required_field_tokens,
+                    ),
+                )
+            }
+
+            async fn call(&self, args: ::serde_json::Value) -> Result<::serde_json::Value, ::rust_genai::function_calling::FunctionError> {
+                #(#arg_extraction_tokens)*
+
+                let original_fn_result = #fn_call_expr;
+
+                match ::serde_json::to_value(original_fn_result) {
+                    Ok(value_from_fn_result) => {
+                        // If the value is already a JSON object, return it as is.
+                        // Otherwise, wrap it in a {"result": ...} object.
+                        if value_from_fn_result.is_object() {
+                            Ok(value_from_fn_result)
+                        } else {
+                            Ok(::serde_json::json!({ "result": value_from_fn_result }))
+                        }
+                    }
+                    Err(e) => Err(::rust_genai::function_calling::FunctionError::ExecutionError(Box::new(e)))
+                }
+            }
+        }
+
+        pub fn #generated_fn_name() -> ::rust_genai::FunctionDeclaration {
+             #callable_struct_name::new().declaration()
+        }
+
+        pub fn #generated_callable_factory_fn_name() -> Box<dyn ::rust_genai::function_calling::CallableFunction> {
+            Box::new(#callable_struct_name::new())
+        }
+
+        ::rust_genai::function_calling::submit! {
+            ::rust_genai::function_calling::CallableFunctionFactory::new(#generated_callable_factory_fn_name)
+        }
+    };
+
+    output
+}

--- a/rust-genai-macros/src/lib.rs
+++ b/rust-genai-macros/src/lib.rs
@@ -1,148 +1,24 @@
+#![cfg_attr(test, allow(dead_code))]
+
 use proc_macro::TokenStream;
-use quote::{ToTokens, quote};
-use std::collections::HashMap;
-use syn::parse::{Parse, ParseStream, Result as ParseResult};
-use syn::{
-    Attribute, Expr, ExprArray, ExprLit, Ident, ItemFn, Lit, LitStr, Meta, Pat, Token, Type,
-    parenthesized, parse_macro_input, punctuated::Punctuated,
-};
+use syn::Pat;
 use utoipa::openapi::RefOr;
-use utoipa::openapi::schema::{ArrayBuilder, ObjectBuilder, Schema, Type as OpenApiType};
+use utoipa::openapi::schema::{ObjectBuilder, Schema};
 
-#[derive(Default, Debug, Clone)]
-struct ParamSchemaDetails {
-    description: Option<String>,
-    enum_values: Option<Vec<serde_json::Value>>,
-}
+mod codegen;
+mod parsing;
+mod schema;
 
-// Parses individual parameter config like: name(key="value", ...)
-#[derive(Debug)]
-struct SingleParamConfigInput {
-    name: Ident,
-    description: Option<LitStr>,
-    enum_values: Option<ExprArray>,
-}
-
-impl Parse for SingleParamConfigInput {
-    fn parse(input: ParseStream) -> ParseResult<Self> {
-        let name: Ident = input.parse()?;
-        let content;
-        parenthesized!(content in input);
-
-        let mut description: Option<LitStr> = None;
-        let mut enum_values: Option<ExprArray> = None;
-
-        let metas: Punctuated<Meta, Token![,]> =
-            content.parse_terminated(Meta::parse, Token![,])?;
-
-        for meta in metas {
-            if let Meta::NameValue(nv) = meta {
-                if nv.path.is_ident("description") {
-                    if let Expr::Lit(ExprLit {
-                        lit: Lit::Str(s), ..
-                    }) = nv.value
-                    {
-                        description = Some(s);
-                    } else {
-                        return Err(syn::Error::new_spanned(
-                            nv.value,
-                            "Expected string literal for description",
-                        ));
-                    }
-                } else if nv.path.is_ident("enum_values") {
-                    if let Expr::Array(arr) = nv.value {
-                        enum_values = Some(arr);
-                    } else {
-                        return Err(syn::Error::new_spanned(
-                            nv.value,
-                            "Expected array for enum_values",
-                        ));
-                    }
-                }
-            }
-        }
-
-        Ok(Self {
-            name,
-            description,
-            enum_values,
-        })
-    }
-}
-
-// Parses the whole attribute: param1(...), param2(...)
-#[derive(Debug)]
-struct AllParamsConfigInput {
-    configs: Punctuated<SingleParamConfigInput, Token![,]>,
-}
-
-impl Parse for AllParamsConfigInput {
-    fn parse(input: ParseStream) -> ParseResult<Self> {
-        if input.is_empty() {
-            Ok(Self {
-                configs: Punctuated::new(),
-            })
-        } else {
-            let configs = input.parse_terminated(SingleParamConfigInput::parse, Token![,])?;
-            Ok(Self { configs })
-        }
-    }
-}
-
-fn extract_doc_comments(attrs: &[Attribute]) -> String {
-    attrs
-        .iter()
-        .filter_map(|attr| {
-            if attr.path().is_ident("doc")
-                && let Meta::NameValue(mnv) = &attr.meta
-                && let Expr::Lit(ExprLit {
-                    lit: Lit::Str(lit_str),
-                    ..
-                }) = &mnv.value
-            {
-                return Some(lit_str.value().trim().to_string());
-            }
-            None
-        })
-        .collect::<Vec<String>>()
-        .join("\n")
-}
-
-fn get_type_info(ty: &Type) -> (bool, Type) {
-    if let Type::Path(type_path) = ty
-        && type_path.path.segments.len() == 1
-        && type_path.path.segments[0].ident == "Option"
-        && let syn::PathArguments::AngleBracketed(args) = &type_path.path.segments[0].arguments
-        && let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first()
-    {
-        return (true, inner_ty.clone());
-    }
-    (false, ty.clone())
-}
-
-fn map_rust_type_to_openapi_type(rust_type_path: &Type) -> OpenApiType {
-    let type_str = rust_type_path
-        .to_token_stream()
-        .to_string()
-        .replace(' ', "");
-    match type_str.as_str() {
-        "String" => OpenApiType::String,
-        "i32" | "i64" | "isize" | "u32" | "u64" | "usize" => OpenApiType::Integer,
-        "f32" | "f64" => OpenApiType::Number,
-        "bool" => OpenApiType::Boolean,
-        s if s.starts_with("Vec<") && s.ends_with('>') => OpenApiType::Array,
-        s if s == "Value" || s == "serde_json::Value" => OpenApiType::Object,
-        _ => OpenApiType::Object, // Default for complex types
-    }
-}
+use parsing::parse_input;
+use schema::{build_param_schema, get_type_info};
 
 /// Generates a function that returns a `FunctionDeclaration` for the annotated function.
 ///
 /// # Example
 /// ```ignore
-/// use rust_genai_macros::generate_function_declaration;
+/// use rust_genai_macros::tool;
 ///
-/// #[generate_function_declaration(
+/// #[tool(
 ///     location(description = "The city and state"),
 ///     unit(enum_values = ["celsius", "fahrenheit"])
 /// )]
@@ -154,17 +30,45 @@ fn map_rust_type_to_openapi_type(rust_type_path: &Type) -> OpenApiType {
 /// // pub fn get_weather_declaration() -> rust_genai::FunctionDeclaration { ... }
 /// ```
 #[proc_macro_attribute]
-pub fn generate_function_declaration(attr_input: TokenStream, item: TokenStream) -> TokenStream {
-    let all_params_config = parse_macro_input!(attr_input as AllParamsConfigInput);
-    let func = parse_macro_input!(item as ItemFn);
+pub fn tool(attr_input: TokenStream, item: TokenStream) -> TokenStream {
+    let input = match parse_input(attr_input, item) {
+        Ok(input) => input,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    let func = input.func;
+    let config_map = input.param_configs;
     let func_name = func.sig.ident.to_string();
 
-    let mut config_map: HashMap<String, SingleParamConfigInput> = HashMap::new();
-    for config in all_params_config.configs {
-        config_map.insert(config.name.to_string(), config);
+    // Collect actual function parameter names
+    let mut actual_param_names = std::collections::HashSet::new();
+    for fn_arg in &func.sig.inputs {
+        if let syn::FnArg::Typed(pat_type) = fn_arg
+            && let Pat::Ident(pat_ident) = &*pat_type.pat
+        {
+            actual_param_names.insert(pat_ident.ident.to_string());
+        }
     }
 
-    let func_description = extract_doc_comments(&func.attrs);
+    // Check that all macro-referenced parameters actually exist in the function
+    for referenced_param in config_map.keys() {
+        if !actual_param_names.contains(referenced_param) {
+            return syn::Error::new(
+                func.sig.ident.span(),
+                format!(
+                    "Parameter '{}' referenced in #[tool] attribute does not exist in function '{}'. \
+                     Available parameters: {:?}",
+                    referenced_param,
+                    func_name,
+                    actual_param_names.iter().collect::<Vec<_>>()
+                ),
+            )
+            .to_compile_error()
+            .into();
+        }
+    }
+
+    let func_description = parsing::extract_doc_comments(&func.attrs);
     let mut object_builder = ObjectBuilder::new();
     let mut required_params_for_struct_field = Vec::new();
 
@@ -173,14 +77,9 @@ pub fn generate_function_declaration(attr_input: TokenStream, item: TokenStream)
             && let Pat::Ident(pat_ident) = &*pat_type.pat
         {
             let param_name = pat_ident.ident.to_string();
+            let config = config_map.get(&param_name);
+            let param_schema = build_param_schema(pat_type, config);
 
-            let attr_details = match process_param_config(&param_name, config_map.get(&param_name))
-            {
-                Ok(details) => details,
-                Err(e) => return e.to_compile_error().into(),
-            };
-
-            let param_schema = build_param_schema(pat_type, attr_details);
             object_builder = object_builder.property(param_name.clone(), param_schema);
 
             let (is_option, _) = get_type_info(&pat_type.ty);
@@ -193,255 +92,12 @@ pub fn generate_function_declaration(attr_input: TokenStream, item: TokenStream)
     let parameters_schema_obj = object_builder.build();
     let parameters_schema_ref_or: RefOr<Schema> = RefOr::T(Schema::Object(parameters_schema_obj));
 
-    let parameters_json_string = match serde_json::to_string_pretty(&parameters_schema_ref_or) {
-        Ok(s) => s,
-        Err(e) => {
-            return syn::Error::new_spanned(
-                func.sig.ident,
-                format!("Failed to serialize schema to JSON: {e}"),
-            )
-            .to_compile_error()
-            .into();
-        }
-    };
-
-    generate_declaration_function(
+    codegen::generate_declaration_function(
         &func,
         &func_name,
         &func_description,
-        &parameters_json_string,
+        &parameters_schema_ref_or,
         &required_params_for_struct_field,
     )
-}
-
-fn process_param_config(
-    param_name: &str,
-    config: Option<&SingleParamConfigInput>,
-) -> Result<ParamSchemaDetails, syn::Error> {
-    let mut attr_details = ParamSchemaDetails::default();
-
-    if let Some(config) = config {
-        if let Some(desc_lit) = &config.description {
-            attr_details.description = Some(desc_lit.value());
-        }
-        if let Some(enums_array) = &config.enum_values {
-            let mut enums = Vec::new();
-            for elem_expr in &enums_array.elems {
-                if let Expr::Lit(ExprLit {
-                    lit: Lit::Str(s), ..
-                }) = elem_expr
-                {
-                    enums.push(serde_json::Value::String(s.value()));
-                } else {
-                    return Err(syn::Error::new_spanned(
-                        elem_expr,
-                        format!("Enum values for param '{param_name}' must be string literals."),
-                    ));
-                }
-            }
-            if !enums.is_empty() {
-                attr_details.enum_values = Some(enums);
-            }
-        }
-    }
-
-    Ok(attr_details)
-}
-
-fn build_param_schema(pat_type: &syn::PatType, attr_details: ParamSchemaDetails) -> RefOr<Schema> {
-    let (_, inner_type) = get_type_info(&pat_type.ty);
-    let api_type = map_rust_type_to_openapi_type(&inner_type);
-
-    if api_type == OpenApiType::Array {
-        let mut array_builder = ArrayBuilder::new();
-
-        if let Type::Path(type_path) = &inner_type
-            && let Some(segment) = type_path.path.segments.first()
-            && segment.ident == "Vec"
-            && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
-            && let Some(syn::GenericArgument::Type(inner_ty_of_vec)) = args.args.first()
-        {
-            let inner_api_type = map_rust_type_to_openapi_type(inner_ty_of_vec);
-            let items_schema = ObjectBuilder::new().schema_type(inner_api_type).build();
-            array_builder = array_builder.items(RefOr::T(Schema::Object(items_schema)));
-        }
-
-        RefOr::T(Schema::Array(array_builder.build()))
-    } else {
-        let mut individual_schema_builder = ObjectBuilder::new().schema_type(api_type);
-        if let Some(desc_val) = &attr_details.description
-            && !desc_val.is_empty()
-        {
-            individual_schema_builder =
-                individual_schema_builder.description(Some(desc_val.clone()));
-        }
-        if let Some(enums) = attr_details.enum_values {
-            individual_schema_builder = individual_schema_builder.enum_values(Some(enums));
-        }
-        RefOr::T(Schema::Object(individual_schema_builder.build()))
-    }
-}
-
-#[allow(clippy::too_many_lines)]
-fn generate_declaration_function(
-    func: &ItemFn,
-    func_name: &str,
-    func_description: &str,
-    parameters_json_string: &str,
-    required_params_for_struct_field: &[String],
-) -> TokenStream {
-    let generated_fn_name =
-        syn::Ident::new(&format!("{func_name}_declaration"), func.sig.ident.span());
-    let callable_struct_name_str = func_name
-        .split('_')
-        .map(|s| {
-            s.chars()
-                .next()
-                .map_or_else(|| s.to_string(), |c| c.to_uppercase().to_string() + &s[1..])
-        })
-        .collect::<String>()
-        + "Callable";
-    let callable_struct_name = syn::Ident::new(&callable_struct_name_str, func.sig.ident.span());
-
-    let generated_callable_factory_fn_name = syn::Ident::new(
-        &format!("{func_name}_callable_factory"),
-        func.sig.ident.span(),
-    );
-
-    let required_field_tokens = if required_params_for_struct_field.is_empty() {
-        quote! { ::std::vec::Vec::new() }
-    } else {
-        quote! {
-            ::std::vec![
-                #( #required_params_for_struct_field.to_string() ),*
-            ]
-        }
-    };
-
-    let mut arg_names = Vec::new();
-    let mut arg_extraction_tokens = Vec::new();
-
-    for fn_arg in &func.sig.inputs {
-        if let syn::FnArg::Typed(pat_type) = fn_arg
-            && let Pat::Ident(pat_ident) = &*pat_type.pat
-        {
-            let param_name_str = pat_ident.ident.to_string();
-            let param_ident = &pat_ident.ident;
-            let param_type = &pat_type.ty;
-            arg_names.push(param_ident.clone());
-
-            let (is_option, _inner_type) = get_type_info(param_type);
-
-            if is_option {
-                arg_extraction_tokens.push(quote! {
-                    let #param_ident: #param_type = match args.get(#param_name_str) {
-                        Some(val) if !val.is_null() => {
-                            ::serde_json::from_value(val.clone()).map_err(|e| {
-                                ::rust_genai::function_calling::FunctionError::ArgumentMismatch(
-                                    format!("Failed to deserialize optional argument '{}': {}", #param_name_str, e)
-                                )
-                            })?
-                        }
-                        _ => None,
-                    };
-                });
-            } else {
-                arg_extraction_tokens.push(quote! {
-                    let #param_ident: #param_type = args.get(#param_name_str)
-                        .ok_or_else(|| ::rust_genai::function_calling::FunctionError::ArgumentMismatch(format!("Missing required argument '{}'", #param_name_str)))
-                        .and_then(|val| ::serde_json::from_value(val.clone()).map_err(|e| {
-                            ::rust_genai::function_calling::FunctionError::ArgumentMismatch(
-                                format!("Failed to deserialize argument '{}': {}", #param_name_str, e)
-                            )
-                        }))?;
-                });
-            }
-        }
-    }
-
-    let original_fn_ident = &func.sig.ident;
-    let fn_call_args = quote! { #(#arg_names),* };
-
-    let is_async_fn = func.sig.asyncness.is_some();
-    let fn_call_expr = if is_async_fn {
-        quote! { #original_fn_ident(#fn_call_args).await }
-    } else {
-        quote! { #original_fn_ident(#fn_call_args) }
-    };
-
-    let output = quote! {
-        #func
-
-        #[derive(Debug, Clone, Copy)]
-        pub struct #callable_struct_name;
-
-        impl #callable_struct_name {
-            pub const fn new() -> Self {
-                Self
-            }
-        }
-
-        #[::async_trait::async_trait]
-        impl ::rust_genai::function_calling::CallableFunction for #callable_struct_name {
-            fn declaration(&self) -> ::rust_genai::FunctionDeclaration {
-                // Parse the full OpenAPI schema object
-                let schema: ::serde_json::Value = match ::serde_json::from_str(#parameters_json_string) {
-                    Ok(p) => p,
-                    Err(_e) => {
-                        panic!("Failed to parse generated parameters JSON for '{}': {}", #func_name, _e);
-                    }
-                };
-
-                // Extract just the "properties" field from the schema
-                // The OpenAPI schema has format: {"type": "object", "properties": {...}}
-                // We only need the inner properties object for FunctionParameters
-                let properties = schema.get("properties")
-                    .cloned()
-                    .unwrap_or(::serde_json::json!({}));
-
-                ::rust_genai::FunctionDeclaration::new(
-                    #func_name.to_string(),
-                    #func_description.to_string(),
-                    ::rust_genai::FunctionParameters::new(
-                        "object".to_string(),
-                        properties,
-                        #required_field_tokens,
-                    ),
-                )
-            }
-
-            async fn call(&self, args: ::serde_json::Value) -> Result<::serde_json::Value, ::rust_genai::function_calling::FunctionError> {
-                #(#arg_extraction_tokens)*
-
-                let original_fn_result = #fn_call_expr;
-
-                match ::serde_json::to_value(original_fn_result) {
-                    Ok(value_from_fn_result) => {
-                        // If the value is already a JSON object, return it as is.
-                        // Otherwise, wrap it in a {"result": ...} object.
-                        if value_from_fn_result.is_object() {
-                            Ok(value_from_fn_result)
-                        } else {
-                            Ok(::serde_json::json!({ "result": value_from_fn_result }))
-                        }
-                    }
-                    Err(e) => Err(::rust_genai::function_calling::FunctionError::ExecutionError(Box::new(e)))
-                }
-            }
-        }
-
-        pub fn #generated_fn_name() -> ::rust_genai::FunctionDeclaration {
-             #callable_struct_name::new().declaration()
-        }
-
-        pub fn #generated_callable_factory_fn_name() -> Box<dyn ::rust_genai::function_calling::CallableFunction> {
-            Box::new(#callable_struct_name::new())
-        }
-
-        ::rust_genai::function_calling::submit! {
-            ::rust_genai::function_calling::CallableFunctionFactory::new(#generated_callable_factory_fn_name)
-        }
-    };
-
-    output.into()
+    .into()
 }

--- a/rust-genai-macros/src/parsing.rs
+++ b/rust-genai-macros/src/parsing.rs
@@ -1,0 +1,180 @@
+//! Parsing utilities for the `#[tool]` procedural macro.
+//!
+//! This module handles parsing of:
+//! - Macro attribute arguments (parameter descriptions and enum values)
+//! - Function signatures and their doc comments
+
+use proc_macro::TokenStream;
+use quote::ToTokens;
+use std::collections::HashMap;
+use syn::parse::{Parse, ParseStream, Result as ParseResult};
+use syn::{
+    Attribute, Expr, ExprArray, ExprLit, Ident, ItemFn, Lit, LitStr, Meta, Token, parenthesized,
+    punctuated::Punctuated,
+};
+
+/// Configuration for a single function parameter extracted from the macro attribute.
+#[derive(Default, Debug, Clone)]
+pub struct ParamConfig {
+    /// Optional description for this parameter (used in function declaration).
+    pub description: Option<String>,
+    /// Optional list of allowed values for this parameter.
+    pub enum_values: Option<Vec<serde_json::Value>>,
+}
+
+/// Parses individual parameter config like: `name(description = "...", enum_values = [...])`
+#[derive(Debug)]
+struct SingleParamConfigInput {
+    name: Ident,
+    description: Option<LitStr>,
+    enum_values: Option<ExprArray>,
+}
+
+impl Parse for SingleParamConfigInput {
+    fn parse(input: ParseStream) -> ParseResult<Self> {
+        let name: Ident = input.parse()?;
+        let content;
+        parenthesized!(content in input);
+
+        let mut description: Option<LitStr> = None;
+        let mut enum_values: Option<ExprArray> = None;
+
+        let metas: Punctuated<Meta, Token![,]> =
+            content.parse_terminated(Meta::parse, Token![,])?;
+
+        for meta in metas {
+            if let Meta::NameValue(nv) = meta {
+                if nv.path.is_ident("description") {
+                    if let Expr::Lit(ExprLit {
+                        lit: Lit::Str(s), ..
+                    }) = nv.value
+                    {
+                        description = Some(s);
+                    } else {
+                        return Err(syn::Error::new_spanned(
+                            nv.value,
+                            "Expected string literal for description",
+                        ));
+                    }
+                } else if nv.path.is_ident("enum_values") {
+                    if let Expr::Array(arr) = nv.value {
+                        enum_values = Some(arr);
+                    } else {
+                        return Err(syn::Error::new_spanned(
+                            nv.value,
+                            "Expected array for enum_values",
+                        ));
+                    }
+                } else {
+                    return Err(syn::Error::new_spanned(
+                        &nv.path,
+                        format!(
+                            "Unknown attribute '{}'. Valid attributes are: description, enum_values",
+                            nv.path.to_token_stream()
+                        ),
+                    ));
+                }
+            }
+        }
+
+        Ok(Self {
+            name,
+            description,
+            enum_values,
+        })
+    }
+}
+
+/// Parses the complete macro attribute: `param1(...), param2(...)`
+#[derive(Debug)]
+struct AllParamsConfigInput {
+    configs: Punctuated<SingleParamConfigInput, Token![,]>,
+}
+
+impl Parse for AllParamsConfigInput {
+    fn parse(input: ParseStream) -> ParseResult<Self> {
+        if input.is_empty() {
+            Ok(Self {
+                configs: Punctuated::new(),
+            })
+        } else {
+            let configs = input.parse_terminated(SingleParamConfigInput::parse, Token![,])?;
+            Ok(Self { configs })
+        }
+    }
+}
+
+/// The parsed output of the `#[tool]` macro containing the function and its parameter configs.
+pub struct MacroInput {
+    /// The function item the macro was applied to.
+    pub func: ItemFn,
+    /// Map of parameter name to its configuration (description, enum_values).
+    pub param_configs: HashMap<String, ParamConfig>,
+}
+
+/// Parses both the macro attribute and the function item.
+///
+/// This is the main entry point for parsing the `#[tool]` macro input.
+pub fn parse_input(attr_input: TokenStream, item: TokenStream) -> syn::Result<MacroInput> {
+    let all_params_config = syn::parse::<AllParamsConfigInput>(attr_input)?;
+    let func = syn::parse::<ItemFn>(item)?;
+
+    let mut param_configs = HashMap::new();
+    for config in all_params_config.configs {
+        let name = config.name.to_string();
+        let mut details = ParamConfig::default();
+
+        if let Some(desc_lit) = config.description {
+            details.description = Some(desc_lit.value());
+        }
+
+        if let Some(enums_array) = config.enum_values {
+            let mut enums = Vec::new();
+            for elem_expr in enums_array.elems {
+                if let Expr::Lit(ExprLit {
+                    lit: Lit::Str(s), ..
+                }) = elem_expr
+                {
+                    enums.push(serde_json::Value::String(s.value()));
+                } else {
+                    return Err(syn::Error::new_spanned(
+                        elem_expr,
+                        format!("Enum values for param '{name}' must be string literals."),
+                    ));
+                }
+            }
+            if !enums.is_empty() {
+                details.enum_values = Some(enums);
+            }
+        }
+
+        param_configs.insert(name, details);
+    }
+
+    Ok(MacroInput {
+        func,
+        param_configs,
+    })
+}
+
+/// Extracts `/// doc` comments from a function's attributes.
+///
+/// Doc comments are joined with newlines to form the function's description.
+pub fn extract_doc_comments(attrs: &[Attribute]) -> String {
+    attrs
+        .iter()
+        .filter_map(|attr| {
+            if attr.path().is_ident("doc")
+                && let Meta::NameValue(mnv) = &attr.meta
+                && let Expr::Lit(ExprLit {
+                    lit: Lit::Str(lit_str),
+                    ..
+                }) = &mnv.value
+            {
+                return Some(lit_str.value().trim().to_string());
+            }
+            None
+        })
+        .collect::<Vec<String>>()
+        .join("\n")
+}

--- a/rust-genai-macros/src/schema.rs
+++ b/rust-genai-macros/src/schema.rs
@@ -1,0 +1,98 @@
+//! OpenAPI schema generation for function parameters.
+//!
+//! Converts Rust types to OpenAPI/JSON Schema types for use in
+//! AI function calling declarations.
+
+use crate::parsing::ParamConfig;
+use quote::ToTokens;
+use syn::Type;
+use utoipa::openapi::{
+    RefOr,
+    schema::{ArrayBuilder, ObjectBuilder, Schema, Type as OpenApiType},
+};
+
+/// Analyzes a type to determine if it's an `Option<T>` wrapper.
+///
+/// Returns a tuple of:
+/// - `bool`: `true` if the type is `Option<T>`, `false` otherwise
+/// - `Type`: The inner type (unwrapped if `Option`, original otherwise)
+pub fn get_type_info(ty: &Type) -> (bool, Type) {
+    if let Type::Path(type_path) = ty
+        && type_path.path.segments.len() == 1
+        && type_path.path.segments[0].ident == "Option"
+        && let syn::PathArguments::AngleBracketed(args) = &type_path.path.segments[0].arguments
+        && let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first()
+    {
+        return (true, inner_ty.clone());
+    }
+    (false, ty.clone())
+}
+
+/// Maps a Rust type to its corresponding OpenAPI type.
+///
+/// Supported mappings:
+/// - `String` -> `String`
+/// - `i32`, `i64`, `isize`, `u32`, `u64`, `usize` -> `Integer`
+/// - `f32`, `f64` -> `Number`
+/// - `bool` -> `Boolean`
+/// - `Vec<T>` -> `Array`
+/// - `serde_json::Value` -> `Object`
+/// - Other types default to `Object`
+fn map_rust_type_to_openapi_type(rust_type_path: &Type) -> OpenApiType {
+    let type_str = rust_type_path
+        .to_token_stream()
+        .to_string()
+        .replace(' ', "");
+    match type_str.as_str() {
+        "String" => OpenApiType::String,
+        "i32" | "i64" | "isize" | "u32" | "u64" | "usize" => OpenApiType::Integer,
+        "f32" | "f64" => OpenApiType::Number,
+        "bool" => OpenApiType::Boolean,
+        s if s.starts_with("Vec<") && s.ends_with('>') => OpenApiType::Array,
+        s if s == "Value" || s == "serde_json::Value" => OpenApiType::Object,
+        _ => OpenApiType::Object,
+    }
+}
+
+/// Builds an OpenAPI schema for a function parameter.
+///
+/// Uses the Rust type to determine the schema type, and applies any
+/// configuration (description, enum_values) from the macro attribute.
+pub fn build_param_schema(pat_type: &syn::PatType, config: Option<&ParamConfig>) -> RefOr<Schema> {
+    let (_, inner_type) = get_type_info(&pat_type.ty);
+    let api_type = map_rust_type_to_openapi_type(&inner_type);
+
+    if api_type == OpenApiType::Array {
+        let mut array_builder = ArrayBuilder::new();
+
+        if let Type::Path(type_path) = &inner_type
+            && let Some(segment) = type_path.path.segments.first()
+            && segment.ident == "Vec"
+            && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+            && let Some(syn::GenericArgument::Type(inner_ty_of_vec)) = args.args.first()
+        {
+            let inner_api_type = map_rust_type_to_openapi_type(inner_ty_of_vec);
+            let items_schema = ObjectBuilder::new().schema_type(inner_api_type).build();
+            array_builder = array_builder.items(RefOr::T(Schema::Object(items_schema)));
+        }
+
+        RefOr::T(Schema::Array(array_builder.build()))
+    } else {
+        let mut individual_schema_builder = ObjectBuilder::new().schema_type(api_type);
+
+        if let Some(config) = config {
+            if let Some(desc_val) = &config.description
+                && !desc_val.is_empty()
+            {
+                individual_schema_builder =
+                    individual_schema_builder.description(Some(desc_val.clone()));
+            }
+            if let Some(enums) = &config.enum_values {
+                individual_schema_builder =
+                    individual_schema_builder.enum_values(Some(enums.clone()));
+            }
+        }
+
+        RefOr::T(Schema::Object(individual_schema_builder.build()))
+    }
+}

--- a/tests/advanced_function_calling_tests.rs
+++ b/tests/advanced_function_calling_tests.rs
@@ -15,7 +15,7 @@ mod common;
 
 use common::{consume_auto_function_stream, consume_stream, get_client};
 use rust_genai::{CallableFunction, FunctionDeclaration, function_result_content};
-use rust_genai_macros::generate_function_declaration;
+use rust_genai_macros::tool;
 use serde_json::json;
 
 // =============================================================================
@@ -23,7 +23,7 @@ use serde_json::json;
 // =============================================================================
 //
 // NOTE: These functions are marked #[allow(dead_code)] because they're registered
-// with the inventory crate via #[generate_function_declaration]. The macro creates
+// with the inventory crate via #[tool]. The macro creates
 // `Callable*` structs that are collected at runtime for automatic function calling.
 //
 // While not all functions are explicitly called in tests, they serve these purposes:
@@ -34,7 +34,7 @@ use serde_json::json;
 
 /// Gets the current weather for a city
 #[allow(dead_code)]
-#[generate_function_declaration(city(description = "The city to get weather for"))]
+#[tool(city(description = "The city to get weather for"))]
 fn get_weather_test(city: String) -> String {
     format!(
         r#"{{"city": "{}", "temperature": "22°C", "conditions": "sunny"}}"#,
@@ -44,14 +44,14 @@ fn get_weather_test(city: String) -> String {
 
 /// Gets the current time in a timezone
 #[allow(dead_code)]
-#[generate_function_declaration(timezone(description = "The timezone like UTC, PST, JST"))]
+#[tool(timezone(description = "The timezone like UTC, PST, JST"))]
 fn get_time_test(timezone: String) -> String {
     format!(r#"{{"timezone": "{}", "time": "14:30:00"}}"#, timezone)
 }
 
 /// Converts temperature between units
 #[allow(dead_code)]
-#[generate_function_declaration(
+#[tool(
     value(description = "The temperature value"),
     from_unit(description = "Source unit: celsius or fahrenheit"),
     to_unit(description = "Target unit: celsius or fahrenheit")
@@ -70,21 +70,22 @@ fn convert_temperature(value: f64, from_unit: String, to_unit: String) -> String
 
 /// A function that always fails (for testing error handling)
 #[allow(dead_code)]
-#[generate_function_declaration(input(description = "Any input"))]
-fn always_fails(_input: String) -> String {
+#[allow(unused_variables)]
+#[tool(input(description = "Any input"))]
+fn always_fails(input: String) -> String {
     panic!("This function always fails!")
 }
 
 /// A function with no parameters
 #[allow(dead_code)]
-#[generate_function_declaration]
+#[tool]
 fn get_server_status() -> String {
     r#"{"status": "online", "uptime": "99.9%"}"#.to_string()
 }
 
 /// A function with complex nested arguments
 #[allow(dead_code)]
-#[generate_function_declaration(
+#[tool(
     user_id(description = "The user ID"),
     filters(description = "Optional filter criteria")
 )]

--- a/tests/interactions_api_tests.rs
+++ b/tests/interactions_api_tests.rs
@@ -37,7 +37,7 @@ use rust_genai::{
     CallableFunction, Client, CreateInteractionRequest, FunctionDeclaration, GenerationConfig,
     InteractionInput, InteractionStatus, function_result_content, image_uri_content, text_content,
 };
-use rust_genai_macros::generate_function_declaration;
+use rust_genai_macros::tool;
 use serde_json::json;
 use std::env;
 
@@ -55,7 +55,7 @@ fn get_client() -> Option<Client> {
 // The macro generates a callable wrapper, so the function itself appears unused.
 /// Gets a mock weather report for a city
 #[allow(dead_code)]
-#[generate_function_declaration(city(description = "The city to get weather for"))]
+#[tool(city(description = "The city to get weather for"))]
 fn get_mock_weather(city: String) -> String {
     format!("Weather in {}: Sunny, 75°F", city)
 }

--- a/tests/macro_tests.rs
+++ b/tests/macro_tests.rs
@@ -3,11 +3,11 @@
 #![allow(clippy::uninlined_format_args)] // Not important in tests
 
 use rust_genai::CallableFunction;
-use rust_genai_macros::generate_function_declaration;
+use rust_genai_macros::tool;
 
 #[test]
 fn test_basic_function_declaration() {
-    #[generate_function_declaration]
+    #[tool]
     fn test_basic(name: String) -> String {
         name
     }
@@ -22,7 +22,7 @@ fn test_basic_function_declaration() {
 #[test]
 fn test_function_with_doc_comment() {
     /// This is a test function that does something
-    #[generate_function_declaration]
+    #[tool]
     fn test_with_docs(name: String) -> String {
         name
     }
@@ -39,7 +39,7 @@ fn test_function_with_doc_comment() {
 #[test]
 fn test_with_param_metadata() {
     /// Function to greet someone
-    #[generate_function_declaration(
+    #[tool(
         name(description = "The person's name"),
         age(description = "The person's age")
     )]
@@ -61,7 +61,7 @@ fn test_with_param_metadata() {
 
 #[test]
 fn test_optional_parameters() {
-    #[generate_function_declaration(
+    #[tool(
         name(description = "Required name"),
         nickname(description = "Optional nickname")
     )]
@@ -76,7 +76,7 @@ fn test_optional_parameters() {
 
 #[test]
 fn test_enum_values() {
-    #[generate_function_declaration(
+    #[tool(
         unit(enum_values = ["celsius", "fahrenheit", "kelvin"])
     )]
     #[allow(unused_variables)]
@@ -95,7 +95,7 @@ fn test_enum_values() {
 
 #[test]
 fn test_various_types() {
-    #[generate_function_declaration]
+    #[tool]
     fn test_types(
         text: String,
         count: i32,
@@ -130,7 +130,7 @@ fn test_multiline_doc_comment() {
     /// does multiple things:
     /// - First thing
     /// - Second thing
-    #[generate_function_declaration]
+    #[tool]
     fn test_multiline(x: String) -> String {
         x
     }
@@ -148,7 +148,7 @@ fn test_multiline_doc_comment() {
 // that this comment in the code is accurate
 #[test]
 fn test_param_without_metadata_no_description() {
-    #[generate_function_declaration]
+    #[tool]
     fn test_no_param_desc(
         // Regular comment - not a doc comment
         name: String,
@@ -169,7 +169,7 @@ fn test_param_without_metadata_no_description() {
 fn test_param_docs_not_allowed() {
     // The following would NOT compile if uncommented:
     /*
-    #[generate_function_declaration]
+    #[tool]
     fn test_param_doc(
         /// This doc comment would cause a compile error
         name: String
@@ -179,9 +179,7 @@ fn test_param_docs_not_allowed() {
     */
 
     // Instead, descriptions must be provided via the macro attribute:
-    #[generate_function_declaration(name(
-        description = "This is the correct way to add param descriptions"
-    ))]
+    #[tool(name(description = "This is the correct way to add param descriptions"))]
     fn test_correct_param_desc(name: String) -> String {
         name
     }

--- a/tests/ui/fail_invalid_attr.rs
+++ b/tests/ui/fail_invalid_attr.rs
@@ -1,0 +1,10 @@
+use rust_genai_macros::tool;
+
+// This should fail because "invalid_key" is not a recognized attribute.
+// Valid attributes are: description, enum_values
+#[tool(name(invalid_key = "value"))]
+fn test_invalid_attr(name: String) -> String {
+    name
+}
+
+fn main() {}

--- a/tests/ui/fail_invalid_attr.stderr
+++ b/tests/ui/fail_invalid_attr.stderr
@@ -1,0 +1,5 @@
+error: Unknown attribute 'invalid_key'. Valid attributes are: description, enum_values
+ --> tests/ui/fail_invalid_attr.rs:5:13
+  |
+5 | #[tool(name(invalid_key = "value"))]
+  |             ^^^^^^^^^^^

--- a/tests/ui/fail_invalid_enum.rs
+++ b/tests/ui/fail_invalid_enum.rs
@@ -1,0 +1,10 @@
+use rust_genai_macros::tool;
+
+#[tool(
+    unit(enum_values = [1, 2, 3])
+)]
+fn test_invalid_enum(unit: String) -> String {
+    unit
+}
+
+fn main() {}

--- a/tests/ui/fail_invalid_enum.stderr
+++ b/tests/ui/fail_invalid_enum.stderr
@@ -1,0 +1,5 @@
+error: Enum values for param 'unit' must be string literals.
+ --> tests/ui/fail_invalid_enum.rs:4:25
+  |
+4 |     unit(enum_values = [1, 2, 3])
+  |                         ^

--- a/tests/ui/fail_nonexistent_param.rs
+++ b/tests/ui/fail_nonexistent_param.rs
@@ -1,0 +1,9 @@
+use rust_genai_macros::tool;
+
+// This should fail because "nonexistent" is not a parameter of the function.
+#[tool(nonexistent(description = "This param does not exist"))]
+fn test_nonexistent_param(name: String) -> String {
+    name
+}
+
+fn main() {}

--- a/tests/ui/fail_nonexistent_param.stderr
+++ b/tests/ui/fail_nonexistent_param.stderr
@@ -1,0 +1,5 @@
+error: Parameter 'nonexistent' referenced in #[tool] attribute does not exist in function 'test_nonexistent_param'. Available parameters: ["name"]
+ --> tests/ui/fail_nonexistent_param.rs:5:4
+  |
+5 | fn test_nonexistent_param(name: String) -> String {
+  |    ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui_tests.rs
+++ b/tests/ui_tests.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/fail_*.rs");
+}


### PR DESCRIPTION
## Summary

Closes #145

- Rename `#[generate_function_declaration]` to `#[tool]` for brevity and better ergonomics
- Split macro implementation into separate modules: `parsing.rs`, `schema.rs`, `codegen.rs`
- Add `trybuild` for compile-time UI tests
- Update all examples and tests to use new `#[tool]` attribute

## Code Quality Improvements

- Replace `expect()` with proper compile errors for schema serialization
- Handle empty properties case explicitly instead of silent fallback
- Fix u64 number handling at compile time (no runtime unwrap)
- Add validation for unknown attribute keys (typo detection)
- Add validation for non-existent parameter references
- Fix clippy lint: use let-chains for collapsible if statements
- Add module-level and function-level documentation
- Update CLAUDE.md and README.md with new macro name

## New Validation

The macro now provides better error messages:

```rust
// Typo in attribute key - now caught!
#[tool(name(desc = "..."))]  // Error: Unknown attribute 'desc'. Valid: description, enum_values

// Reference to non-existent parameter - now caught!
#[tool(typo_name(description = "..."))]  // Error: Parameter 'typo_name' does not exist
```

## Test Plan

- [x] All existing macro tests pass
- [x] New UI tests verify compile-time error messages
- [x] Clippy passes with no warnings
- [x] Documentation builds without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)