### PR TITLE
feat: Save generated images to disk in image_generation example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,7 @@ version = "0.2.0"
 dependencies = [
  "async-stream",
  "async-trait",
+ "base64",
  "futures-util",
  "genai-client",
  "inventory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,6 @@ inventory = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 trybuild = "1.0.114"
+base64 = "0.22"
 
 # Workspace-level metadata

--- a/examples/image_generation.rs
+++ b/examples/image_generation.rs
@@ -1,7 +1,7 @@
 //! Example: Image Generation
 //!
 //! This example demonstrates how to generate images using Gemini's
-//! image generation capabilities.
+//! image generation capabilities and saves them to disk.
 //!
 //! # Running
 //!
@@ -24,8 +24,34 @@
 //! a "model not found" error, your API key may not have access to the
 //! image generation model in your region.
 
+use base64::Engine;
 use rust_genai::{Client, GenaiError, InteractionContent, InteractionStatus};
 use std::env;
+use std::path::PathBuf;
+
+/// Save a base64-encoded image to a file and return the path
+fn save_image(
+    base64_data: &str,
+    mime_type: Option<&str>,
+    prefix: &str,
+    index: usize,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let extension = match mime_type {
+        Some("image/png") => "png",
+        Some("image/jpeg") | Some("image/jpg") => "jpg",
+        Some("image/webp") => "webp",
+        Some("image/gif") => "gif",
+        _ => "png", // Default to png
+    };
+
+    let filename = format!("{}_{}.{}", prefix, index, extension);
+    let path = std::env::temp_dir().join(filename);
+
+    let bytes = base64::engine::general_purpose::STANDARD.decode(base64_data)?;
+    std::fs::write(&path, bytes)?;
+
+    Ok(path)
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -39,11 +65,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ==========================================================================
     // Example 1: Basic Image Generation
     // ==========================================================================
-    println!("--- Example 1: Basic Image Generation ---\n");
+    println!("--- Example 1: Birman Cat ---\n");
 
-    // Use the image generation preview model
     let model = "gemini-3-pro-image-preview";
-    let prompt = "Generate a simple image of a red circle on a white background.";
+    let prompt = "A white and orange Birman cat sitting cozily on an electric blanket on a couch.";
 
     println!("Model: {}", model);
     println!("Prompt: {}\n", prompt);
@@ -62,67 +87,46 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Status: {:?}", response.status);
 
             if response.status == InteractionStatus::Completed {
-                // Look for image content in outputs
                 let mut image_count = 0;
 
-                for (i, output) in response.outputs.iter().enumerate() {
+                for output in response.outputs.iter() {
                     if let InteractionContent::Image {
-                        data,
+                        data: Some(base64_data),
                         mime_type,
-                        uri,
+                        ..
                     } = output
                     {
                         image_count += 1;
-                        println!("\nImage {} found:", i + 1);
-
-                        if let Some(mime) = mime_type {
-                            // Common MIME types: image/png, image/jpeg, image/webp
-                            println!("  MIME type: {}", mime);
-                        }
-
-                        if let Some(uri) = uri {
-                            println!("  URI: {}", uri);
-                        }
-
-                        // Show base64 image data info
-                        if let Some(base64_data) = data {
-                            println!("  Base64 data length: {} chars", base64_data.len());
-                            // Approximate decoded size (base64 is ~4/3 of original)
-                            let approx_bytes = base64_data.len() * 3 / 4;
-                            println!("  Approximate image size: {} bytes", approx_bytes);
-                            println!(
-                                "  First 50 chars: {}...",
-                                &base64_data[..50.min(base64_data.len())]
-                            );
-
-                            // To save the image, add the `base64` crate and use:
-                            // use base64::Engine;
-                            // let bytes = base64::engine::general_purpose::STANDARD.decode(base64_data)?;
-                            // std::fs::write("image.png", bytes)?;
+                        match save_image(
+                            base64_data,
+                            mime_type.as_deref(),
+                            "birman_cat",
+                            image_count,
+                        ) {
+                            Ok(path) => {
+                                println!("\n  Image {} saved!", image_count);
+                                println!("  Size: {} bytes", base64_data.len() * 3 / 4);
+                                println!("  Path: {}", path.display());
+                                println!("  Open: file://{}", path.display());
+                            }
+                            Err(e) => {
+                                eprintln!("\n  Failed to save image {}: {}", image_count, e);
+                            }
                         }
                     }
                 }
 
                 if image_count == 0 {
                     println!("\nNo image content in response.");
-                    println!("Outputs:");
-                    for output in &response.outputs {
-                        println!("  {:?}", output);
-                    }
-                } else {
-                    println!("\nGenerated {} image(s) successfully!", image_count);
                 }
             }
 
-            // Show token usage
             if let Some(usage) = &response.usage {
-                println!("\n--- Token Usage ---");
-                if let Some(input) = usage.total_input_tokens {
-                    println!("  Input tokens: {}", input);
-                }
-                if let Some(output) = usage.total_output_tokens {
-                    println!("  Output tokens: {}", output);
-                }
+                println!(
+                    "\n  Tokens: {} in / {} out",
+                    usage.total_input_tokens.unwrap_or(0),
+                    usage.total_output_tokens.unwrap_or(0)
+                );
             }
         }
         Err(e) => {
@@ -131,19 +135,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // ==========================================================================
-    // Example 2: More Detailed Image Prompt
+    // Example 2: Watercolor Birman with Motorcycle
     // ==========================================================================
-    println!("\n--- Example 2: Detailed Image Generation ---\n");
+    println!("\n--- Example 2: Watercolor Birman with Motorcycle ---\n");
 
-    let detailed_prompt = "Generate a watercolor painting of a sunset over calm ocean waves. \
-                           The sky should have warm orange and pink tones, reflecting on the water.";
+    let prompt = "A watercolor painting of a white and orange Birman cat standing by a Triumph cafe racer motorcycle on a scenic road.";
 
-    println!("Prompt: {}\n", detailed_prompt);
+    println!("Prompt: {}\n", prompt);
 
     let result = client
         .interaction()
         .with_model(model)
-        .with_text(detailed_prompt)
+        .with_text(prompt)
         .with_response_modalities(vec!["IMAGE".to_string()])
         .with_store(true)
         .create()
@@ -153,42 +156,53 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(response) => {
             println!("Status: {:?}", response.status);
 
-            // Count images with actual data (not just metadata)
-            let image_count = response
-                .outputs
-                .iter()
-                .filter(|o| matches!(o, InteractionContent::Image { data: Some(_), .. }))
-                .count();
+            if response.status == InteractionStatus::Completed {
+                let mut image_count = 0;
 
-            if image_count > 0 {
-                println!("Generated {} image(s)!", image_count);
-            } else {
-                println!("No images with data in response.");
+                for output in response.outputs.iter() {
+                    if let InteractionContent::Image {
+                        data: Some(base64_data),
+                        mime_type,
+                        ..
+                    } = output
+                    {
+                        image_count += 1;
+                        match save_image(
+                            base64_data,
+                            mime_type.as_deref(),
+                            "watercolor_birman_motorcycle",
+                            image_count,
+                        ) {
+                            Ok(path) => {
+                                println!("\n  Image {} saved!", image_count);
+                                println!("  Size: {} bytes", base64_data.len() * 3 / 4);
+                                println!("  Path: {}", path.display());
+                                println!("  Open: file://{}", path.display());
+                            }
+                            Err(e) => {
+                                eprintln!("\n  Failed to save image {}: {}", image_count, e);
+                            }
+                        }
+                    }
+                }
+
+                if image_count == 0 {
+                    println!("\nNo image content in response.");
+                }
+            }
+
+            if let Some(usage) = &response.usage {
+                println!(
+                    "\n  Tokens: {} in / {} out",
+                    usage.total_input_tokens.unwrap_or(0),
+                    usage.total_output_tokens.unwrap_or(0)
+                );
             }
         }
         Err(e) => {
             handle_image_generation_error(&e);
         }
     }
-
-    // ==========================================================================
-    // Usage Notes
-    // ==========================================================================
-    println!("\n--- Usage Notes ---\n");
-    println!("Image Generation Tips:");
-    println!("  1. Use 'gemini-3-pro-image-preview' or compatible model");
-    println!("  2. Set response_modalities to [\"IMAGE\"]");
-    println!("  3. Generated images are returned as base64-encoded data");
-    println!("  4. Check MIME type to determine image format (PNG, JPEG, WebP)");
-    println!("  5. Regional availability may affect access to image models");
-    println!("\nTo save generated images, add the `base64` crate and use:");
-    println!("  use base64::Engine;");
-    println!("  let bytes = base64::engine::general_purpose::STANDARD.decode(&base64_data)?;");
-    println!("  std::fs::write(\"image.png\", bytes)?;");
-    println!("\nCommon Errors:");
-    println!("  - 'model not found': Model not available in your region");
-    println!("  - 'not supported': Feature not enabled for your API key");
-    println!("  - Empty response: Try a different or simpler prompt");
 
     println!("\n=== END EXAMPLE ===");
 


### PR DESCRIPTION
## Summary
- Add `base64` dev-dependency for decoding image data
- Add `save_image()` helper to write images to temp directory
- Update prompts to showcase Birman cat and watercolor sunset
- Display file paths and clickable `file://` URLs for easy viewing
- Simplify output format with cleaner token usage display

## Test plan
- [x] Ran `cargo run --example image_generation` - images saved and viewable
- [x] Verified images open correctly with `open <path>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)