### PR TITLE
feat: Add thought() accessor to InteractionContent

### DIFF
--- a/examples/simple_interaction.rs
+++ b/examples/simple_interaction.rs
@@ -34,14 +34,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
             if !response.outputs.is_empty() {
                 println!("\nModel Output:");
                 for output in &response.outputs {
-                    match output {
-                        rust_genai::InteractionContent::Text { text: Some(t) } => {
-                            println!("{t}");
-                        }
-                        rust_genai::InteractionContent::Thought { text: Some(t) } => {
-                            println!("[Thought] {t}");
-                        }
-                        _ => {}
+                    if let Some(t) = output.text() {
+                        println!("{t}");
+                    } else if let Some(t) = output.thought() {
+                        println!("[Thought] {t}");
                     }
                 }
             }

--- a/examples/stateful_interaction.rs
+++ b/examples/stateful_interaction.rs
@@ -33,9 +33,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     if !first_response.outputs.is_empty() {
         println!("Assistant:");
         for output in &first_response.outputs {
-            if let rust_genai::InteractionContent::Text { text } = output
-                && let Some(t) = text
-            {
+            if let Some(t) = output.text() {
                 println!("{t}");
             }
         }
@@ -63,9 +61,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     if !second_response.outputs.is_empty() {
         println!("Assistant:");
         for output in &second_response.outputs {
-            if let rust_genai::InteractionContent::Text { text } = output
-                && let Some(t) = text
-            {
+            if let Some(t) = output.text() {
                 println!("{t}");
             }
         }
@@ -93,9 +89,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     if !third_response.outputs.is_empty() {
         println!("Assistant:");
         for output in &third_response.outputs {
-            if let rust_genai::InteractionContent::Text { text } = output
-                && let Some(t) = text
-            {
+            if let Some(t) = output.text() {
                 println!("{t}");
             }
         }

--- a/examples/streaming_auto_functions.rs
+++ b/examples/streaming_auto_functions.rs
@@ -20,7 +20,7 @@
 //! Set the `GEMINI_API_KEY` environment variable with your API key.
 
 use futures_util::StreamExt;
-use rust_genai::{AutoFunctionStreamChunk, CallableFunction, Client, InteractionContent};
+use rust_genai::{AutoFunctionStreamChunk, CallableFunction, Client};
 use rust_genai_macros::tool;
 use std::env;
 use std::io::{Write, stdout};
@@ -115,12 +115,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 AutoFunctionStreamChunk::Delta(content) => {
                     delta_count += 1;
                     // Print text content as it arrives
-                    if let InteractionContent::Text { text: Some(ref t) } = content {
+                    if let Some(t) = content.text() {
                         print!("{}", t);
                         stdout().flush()?;
                     }
                     // Show thoughts if present
-                    if let InteractionContent::Thought { text: Some(ref t) } = content {
+                    if let Some(t) = content.thought() {
                         print!("\n[Thinking: {}...]", &t[..t.len().min(50)]);
                         stdout().flush()?;
                     }

--- a/genai-client/src/models/interactions/content.rs
+++ b/genai-client/src/models/interactions/content.rs
@@ -597,6 +597,17 @@ impl InteractionContent {
         }
     }
 
+    /// Extract the thought content, if this is a Thought variant with non-empty text.
+    ///
+    /// Returns `Some` only for `Thought` variants with non-empty text.
+    /// Returns `None` for all other variants including `Text`.
+    pub fn thought(&self) -> Option<&str> {
+        match self {
+            Self::Thought { text: Some(t) } if !t.is_empty() => Some(t),
+            _ => None,
+        }
+    }
+
     /// Check if this is a Text content type.
     pub const fn is_text(&self) -> bool {
         matches!(self, Self::Text { .. })

--- a/genai-client/src/models/interactions/tests.rs
+++ b/genai-client/src/models/interactions/tests.rs
@@ -513,6 +513,31 @@ fn test_content_empty_text_returns_none() {
     assert_eq!(content_none.text(), None);
 }
 
+#[test]
+fn test_content_thought_accessor() {
+    // Non-empty thought returns Some
+    let content = InteractionContent::Thought {
+        text: Some("reasoning about the problem".to_string()),
+    };
+    assert_eq!(content.thought(), Some("reasoning about the problem"));
+
+    // Empty thought returns None
+    let empty = InteractionContent::Thought {
+        text: Some(String::new()),
+    };
+    assert_eq!(empty.thought(), None);
+
+    // None thought returns None
+    let none = InteractionContent::Thought { text: None };
+    assert_eq!(none.thought(), None);
+
+    // Text variant returns None for thought()
+    let text_content = InteractionContent::Text {
+        text: Some("hello".to_string()),
+    };
+    assert_eq!(text_content.thought(), None);
+}
+
 // --- Unknown Variant Tests ---
 
 #[test]

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -8,7 +8,7 @@
 //!
 //! ```no_run
 //! use futures_util::StreamExt;
-//! use rust_genai::{Client, AutoFunctionStreamChunk, InteractionContent};
+//! use rust_genai::{Client, AutoFunctionStreamChunk};
 //!
 //! # async fn example() -> Result<(), rust_genai::GenaiError> {
 //! let client = Client::new("your-api-key".to_string());
@@ -22,7 +22,7 @@
 //! while let Some(chunk) = stream.next().await {
 //!     match chunk? {
 //!         AutoFunctionStreamChunk::Delta(content) => {
-//!             if let InteractionContent::Text { text: Some(t) } = content {
+//!             if let Some(t) = content.text() {
 //!                 print!("{}", t);
 //!             }
 //!         }


### PR DESCRIPTION
## Summary

- Add `thought() -> Option<&str>` accessor to `InteractionContent` for symmetry with existing `text()` accessor
- Update 4 examples to use `text()` and `thought()` accessors instead of verbose pattern matching
- Update module docs in `streaming.rs` to use the cleaner accessor pattern
- Add unit test for the new `thought()` accessor

This provides a cleaner API for extracting thought content without verbose pattern matching:

```rust
// Before
if let InteractionContent::Thought { text: Some(t) } = content {
    println!("{}", t);
}

// After
if let Some(t) = content.thought() {
    println!("{}", t);
}
```

Closes #141

## Test plan

- [x] `cargo test` - all tests pass
- [x] `cargo clippy` - no warnings
- [x] `cargo fmt --check` - properly formatted
- [x] `cargo doc` - docs build without warnings
- [x] New unit test `test_content_thought_accessor` validates all edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)