### PR TITLE
feat: Add full Serialize/Deserialize for save/resume semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,10 +55,13 @@ for exec in &result.executions {
 
 ### Added
 
-- **`Serialize` support for response types** (#148):
+- **Full `Serialize`/`Deserialize` support for save/resume semantics** (#148, #151):
   - `InteractionResponse` now implements `Serialize` for logging, caching, and persistence
-  - `AutoFunctionResult` implements `Serialize` for full execution history serialization
-  - All nested types (`InteractionContent`, `Tool`, etc.) already support roundtrip serialization with `Unknown` variant preservation
+  - `AutoFunctionResult` implements `Serialize` and `Deserialize` for full execution history
+  - `FunctionExecutionResult` now implements `Deserialize` for roundtrip serialization
+  - `StreamChunk` and `AutoFunctionStreamChunk` implement both traits for streaming event replay
+  - New `AutoFunctionStreamChunk::Unknown` variant for forward-compatible deserialization
+  - Enables offline replay, testing/mocking, and state persistence for long-running agents
 
 - **New convenience helpers on `InteractionResponse`** (#131):
   - `google_search_call()` - returns first Google Search call (singular)

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -44,7 +44,7 @@
 //! ```
 
 use genai_client::models::interactions::{InteractionContent, InteractionResponse};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// A chunk from streaming with automatic function calling.
 ///
@@ -58,7 +58,13 @@ use serde::Serialize;
 /// This enum uses `#[non_exhaustive]` to allow adding new event types in future
 /// versions without breaking existing code. Always include a wildcard arm in
 /// match statements.
-#[derive(Clone, Debug)]
+///
+/// # Serialization
+///
+/// This enum implements `Serialize` and `Deserialize` for logging, persistence,
+/// and replay of streaming events. Unknown variants deserialize to `Unknown`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "chunk_type", content = "data", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum AutoFunctionStreamChunk {
     /// Incremental content from the model (text, thoughts, etc.)
@@ -86,6 +92,13 @@ pub enum AutoFunctionStreamChunk {
     /// This is the last event in the stream, yielded when the model returns
     /// a response that doesn't request any function calls.
     Complete(InteractionResponse),
+
+    /// Unknown event type (for forward compatibility).
+    ///
+    /// This variant captures any unrecognized event types that may be added
+    /// in future versions, allowing deserialization to succeed gracefully.
+    #[serde(other)]
+    Unknown,
 }
 
 /// Result of executing a function locally.
@@ -102,7 +115,7 @@ pub enum AutoFunctionStreamChunk {
 /// println!("Function {} returned: {}", result.name, result.result);
 /// println!("  For call ID: {}", result.call_id);
 /// ```
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct FunctionExecutionResult {
     /// Name of the function that was called
@@ -160,7 +173,7 @@ impl FunctionExecutionResult {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct AutoFunctionResult {
     /// The final response from the model (after all function calls completed)
@@ -221,12 +234,57 @@ mod tests {
         assert!(json_str.contains("call-456"), "Should contain call_id");
         assert!(json_str.contains("sunny"), "Should contain result data");
 
-        // Verify roundtrip works (FunctionExecutionResult would need Deserialize for full roundtrip,
-        // but we can at least verify it serializes to valid JSON)
-        let parsed: serde_json::Value =
-            serde_json::from_str(&json_str).expect("Should be valid JSON");
-        assert_eq!(parsed["name"], "get_weather");
-        assert_eq!(parsed["call_id"], "call-456");
-        assert_eq!(parsed["result"]["temp"], 22);
+        // Verify full roundtrip
+        let deserialized: FunctionExecutionResult =
+            serde_json::from_str(&json_str).expect("Deserialization should succeed");
+        assert_eq!(deserialized, result);
+    }
+
+    #[test]
+    fn test_auto_function_stream_chunk_serialization_roundtrip() {
+        // Test Delta variant roundtrip
+        let delta = AutoFunctionStreamChunk::Delta(InteractionContent::Text {
+            text: Some("Hello, world!".to_string()),
+        });
+
+        let json_str = serde_json::to_string(&delta).expect("Serialization should succeed");
+        assert!(json_str.contains("chunk_type"), "Should contain tag field");
+        assert!(json_str.contains("delta"), "Should contain variant name");
+        assert!(json_str.contains("Hello, world!"), "Should contain text");
+
+        let deserialized: AutoFunctionStreamChunk =
+            serde_json::from_str(&json_str).expect("Deserialization should succeed");
+
+        match deserialized {
+            AutoFunctionStreamChunk::Delta(content) => {
+                assert_eq!(content.text(), Some("Hello, world!"));
+            }
+            _ => panic!("Expected Delta variant"),
+        }
+
+        // Test FunctionResults variant roundtrip
+        let results = AutoFunctionStreamChunk::FunctionResults(vec![
+            FunctionExecutionResult::new("get_weather", "call-1", json!({"temp": 20})),
+            FunctionExecutionResult::new("get_time", "call-2", json!({"time": "14:30"})),
+        ]);
+
+        let json_str = serde_json::to_string(&results).expect("Serialization should succeed");
+        let deserialized: AutoFunctionStreamChunk =
+            serde_json::from_str(&json_str).expect("Deserialization should succeed");
+
+        match deserialized {
+            AutoFunctionStreamChunk::FunctionResults(execs) => {
+                assert_eq!(execs.len(), 2);
+                assert_eq!(execs[0].name, "get_weather");
+                assert_eq!(execs[1].name, "get_time");
+            }
+            _ => panic!("Expected FunctionResults variant"),
+        }
+
+        // Test Unknown variant handling (forward compatibility)
+        let unknown_json = r#"{"chunk_type": "future_event_type"}"#;
+        let deserialized: AutoFunctionStreamChunk =
+            serde_json::from_str(unknown_json).expect("Should deserialize unknown variant");
+        assert!(matches!(deserialized, AutoFunctionStreamChunk::Unknown));
     }
 }


### PR DESCRIPTION
## Summary

Enable complete save/resume semantics by adding `Serialize` and `Deserialize` to all streaming types.

Closes #151

**Depends on:** #150 (should be merged first)

## Changes

### Added Serialize + Deserialize
- `StreamChunk` (genai-client)
- `AutoFunctionStreamChunk` (rust-genai)

### Added Deserialize
- `AutoFunctionResult` (rust-genai)
- `FunctionExecutionResult` (rust-genai)

### New variant
- `AutoFunctionStreamChunk::Unknown` for forward-compatible deserialization

## Use Cases

- **Logging/debugging**: Persist streaming events for analysis
- **Offline replay**: Replay conversations without API calls
- **Testing/mocking**: Deserialize saved responses for unit tests
- **State persistence**: Save and resume long-running agent sessions

## Implementation Notes

Uses adjacently tagged serde representation (`tag = "chunk_type", content = "data"`) to avoid conflicts with `InteractionContent`'s internal `type` tag.

## Test plan

- [x] `FunctionExecutionResult` roundtrip test
- [x] `AutoFunctionStreamChunk` roundtrip test (Delta, FunctionResults, Unknown variants)
- [x] `StreamChunk` roundtrip test
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)