### PR TITLE
chore: Add MSRV and #[non_exhaustive] to API enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ utoipa = "5.4"
 name = "rust-genai"
 version = "0.2.0"
 edition = "2024"
+rust-version = "1.85"
 license = "MIT"
 
 [dependencies]

--- a/examples/url_context.rs
+++ b/examples/url_context.rs
@@ -54,6 +54,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         UrlRetrievalStatus::UrlRetrievalStatusUnsafe => "Unsafe (blocked)",
                         UrlRetrievalStatus::UrlRetrievalStatusError => "Error",
                         UrlRetrievalStatus::UrlRetrievalStatusUnspecified => "Unspecified",
+                        _ => "Unknown", // Handle future status values
                     };
                     println!("  {} - {}", entry.retrieved_url, status_str);
                 }

--- a/genai-client/src/models/interactions/metadata.rs
+++ b/genai-client/src/models/interactions/metadata.rs
@@ -83,8 +83,12 @@ pub struct UrlMetadataEntry {
 }
 
 /// Status of a URL retrieval attempt.
+///
+/// This enum is marked `#[non_exhaustive]` for forward compatibility.
+/// New status values may be added by the API in future versions.
 #[derive(Clone, Deserialize, Serialize, Debug, Default, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[non_exhaustive]
 pub enum UrlRetrievalStatus {
     /// Status not specified
     #[default]
@@ -95,4 +99,9 @@ pub enum UrlRetrievalStatus {
     UrlRetrievalStatusUnsafe,
     /// URL retrieval failed for other reasons
     UrlRetrievalStatusError,
+    /// Unknown status (for forward compatibility).
+    ///
+    /// This variant captures any unrecognized status values from the API.
+    #[serde(other, rename = "URL_RETRIEVAL_STATUS_UNKNOWN")]
+    Unknown,
 }

--- a/genai-client/src/models/interactions/request.rs
+++ b/genai-client/src/models/interactions/request.rs
@@ -19,8 +19,12 @@ pub enum InteractionInput {
 ///
 /// Controls the depth of reasoning the model performs before generating a response.
 /// Higher levels produce more detailed reasoning but consume more tokens.
+///
+/// This enum is marked `#[non_exhaustive]` for forward compatibility.
+/// New thinking levels may be added in future versions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ThinkingLevel {
     /// Minimal reasoning, fastest responses
     Minimal,

--- a/genai-client/src/models/interactions/response.rs
+++ b/genai-client/src/models/interactions/response.rs
@@ -11,15 +11,25 @@ use super::content::{CodeExecutionLanguage, CodeExecutionOutcome, InteractionCon
 use super::metadata::{GroundingMetadata, UrlContextMetadata};
 use crate::models::shared::Tool;
 
-/// Status of an interaction
+/// Status of an interaction.
+///
+/// This enum is marked `#[non_exhaustive]` for forward compatibility.
+/// New status values may be added by the API in future versions.
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum InteractionStatus {
     Completed,
     InProgress,
     RequiresAction,
     Failed,
     Cancelled,
+    /// Unknown status (for forward compatibility).
+    ///
+    /// This variant captures any unrecognized status values from the API,
+    /// allowing the library to handle new statuses gracefully.
+    #[serde(other, rename = "unknown")]
+    Unknown,
 }
 
 /// Token usage information from the Interactions API

--- a/genai-client/src/models/shared.rs
+++ b/genai-client/src/models/shared.rs
@@ -378,8 +378,12 @@ pub struct FunctionCallingConfig {
 }
 
 /// Modes for function calling behavior.
+///
+/// This enum is marked `#[non_exhaustive]` for forward compatibility.
+/// New modes may be added in future versions.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[non_exhaustive]
 pub enum FunctionCallingMode {
     Auto,
     Any,


### PR DESCRIPTION
## Summary

- Set `rust-version = "1.85"` in Cargo.toml (documents MSRV for Rust 2024 edition)
- Add `#[non_exhaustive]` and `Unknown` variants to API response enums
- Add `#[non_exhaustive]` to user input enums

## Changes

### MSRV
Added `rust-version = "1.85"` to root Cargo.toml. This is the minimum Rust version required for the 2024 edition.

### API Response Enums (with Unknown variant)
These enums come from the API and could receive new values:
- `InteractionStatus` - Added `Unknown` variant with `#[serde(other)]`
- `UrlRetrievalStatus` - Added `Unknown` variant with `#[serde(other)]`

### User Input Enums (no Unknown needed)
These enums are constructed by users, not received from API:
- `ThinkingLevel` - Added `#[non_exhaustive]` only
- `FunctionCallingMode` - Added `#[non_exhaustive]` only

### Example Updates
- Added wildcard arm to `url_context.rs` match statement

## Rationale

This follows the Evergreen spec philosophy documented in CLAUDE.md:
- API response types should gracefully handle unknown values
- User input types just need `#[non_exhaustive]` for future extensibility
- Both ensure minor version updates won't break user code

## Testing

- All existing tests pass
- No new tests needed (existing coverage is sufficient)