### PR TITLE
Investigate and explain GitHub issue 47

### DIFF
--- a/genai-client/src/models/interactions/content.rs
+++ b/genai-client/src/models/interactions/content.rs
@@ -362,6 +362,21 @@ pub enum InteractionContent {
     /// // Serializes to: {"type": "array_type", "data": [1, 2, 3]}
     /// ```
     ///
+    /// # Field Ordering
+    ///
+    /// **Note:** Field ordering is not preserved during round-trip serialization.
+    /// When serializing an `Unknown` variant, the `"type"` field is always written
+    /// first, followed by the remaining fields from `data`. This means the output
+    /// field order may differ from the original API response.
+    ///
+    /// This has **no practical impact** on API compatibility because JSON objects
+    /// are inherently unordered per RFC 8259. The Gemini API does not depend on
+    /// field ordering.
+    ///
+    /// If you need to preserve the exact original field ordering (e.g., for logging
+    /// or debugging purposes), access the raw `data` field directly via
+    /// [`unknown_data()`](Self::unknown_data) instead of re-serializing the variant.
+    ///
     /// # Manual Construction
     ///
     /// While Unknown variants are typically created by deserialization, you can

--- a/genai-client/src/models/interactions/content.rs
+++ b/genai-client/src/models/interactions/content.rs
@@ -364,10 +364,11 @@ pub enum InteractionContent {
     ///
     /// # Field Ordering
     ///
-    /// **Note:** Field ordering is not preserved during round-trip serialization.
-    /// When serializing an `Unknown` variant, the `"type"` field is always written
-    /// first, followed by the remaining fields from `data`. This means the output
-    /// field order may differ from the original API response.
+    /// **Note:** Field ordering is not preserved during round-trip serialization,
+    /// but all field **values** are fully preserved. When serializing an `Unknown`
+    /// variant, the `"type"` field is always written first, followed by the remaining
+    /// fields from `data`. This means the output field order may differ from the
+    /// original API response.
     ///
     /// This has **no practical impact** on API compatibility because JSON objects
     /// are inherently unordered per RFC 8259. The Gemini API does not depend on


### PR DESCRIPTION
Add documentation clarifying that field ordering is not preserved during round-trip serialization of InteractionContent::Unknown. The "type" field is always written first, followed by flattened data fields.

This has no practical impact since JSON objects are unordered per RFC 8259. Users needing exact field preservation can access the raw data via unknown_data() instead of re-serializing.

Closes #47