### PR TITLE
test: Add comprehensive roundtrip serialization tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,10 +184,30 @@ let content: InteractionContent = serde_json::from_str(json)?;
 // If json has type "future_feature", this should NOT error
 ```
 
+### Standard Unknown Variant Pattern
+
+All enums with `Unknown` variants should use the **data-preserving pattern**:
+
+```rust
+Unknown {
+    /// The unrecognized type name from the API (field name varies by context)
+    type_name: String,  // or tool_type, chunk_type, etc.
+    /// The full JSON data, preserved for debugging and roundtrip serialization
+    data: serde_json::Value,
+}
+```
+
+This requires a custom `Deserialize` implementation. See `InteractionContent` in `content.rs` for the reference implementation.
+
+**Why not `#[serde(other)] Unknown`?** The unit variant pattern loses all data - you can't inspect what the API sent or roundtrip serialize it. Always prefer the data-preserving pattern.
+
 ### Implementation Locations
 
-- `InteractionContent` (content.rs): Has `Unknown` variant, custom deserializer
-- `Tool` (shared.rs): Has `Unknown` variant with `#[non_exhaustive]`
+- `InteractionContent` (content.rs): Has `Unknown` variant, custom deserializer ✅
+- `Tool` (shared.rs): Has `Unknown` variant, custom deserializer ✅
+- `InteractionStatus` (response.rs): Unit variant ⚠️ (see issue #181)
+- `StreamChunk` (streaming.rs): Unit variant ⚠️ (see issue #181)
+- `AutoFunctionStreamChunk` (streaming.rs): Unit variant ⚠️ (see issue #181)
 - `strict-unknown` feature flag: Optional strict mode for development/testing
 
 ## Test Organization


### PR DESCRIPTION
## Summary

- Add comprehensive roundtrip serialization tests for `AutoFunctionResult` and `InteractionResponse`
- Document the standard Unknown variant pattern in CLAUDE.md and README.md
- Fix incorrect field name in README example (`content_type` → `type_name`)

## Tests Added

### `test_auto_function_result_roundtrip` (src/streaming.rs)
Tests `AutoFunctionResult` with:
- Full `InteractionResponse` with all fields
- Multiple `FunctionExecutionResult` entries
- Usage metadata
- Previous interaction ID

### `test_interaction_response_complex_roundtrip` (genai-client)
Tests `InteractionResponse` with all 11 content types:
- ✅ Text, Image, Thought, ThoughtSignature
- ✅ FunctionCall, FunctionResult
- ✅ CodeExecutionCall, CodeExecutionResult
- ✅ GoogleSearchCall, GoogleSearchResult
- ✅ UrlContextCall, UrlContextResult

Plus metadata:
- ✅ Usage (all 6 token count fields)
- ✅ Grounding metadata with WebSource
- ✅ URL context metadata
- ✅ Tools array

## Documentation Updates

### CLAUDE.md
- Added "Standard Unknown Variant Pattern" section
- Explains data-preserving pattern vs unit variant
- Updated Implementation Locations with status indicators (✅/⚠️)
- Links to issue #181 for types that need updating

### README.md
- Fixed example field name (`content_type` → `type_name`)
- Added note about data preservation
- Added design principle callout

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy` passes
- [x] `cargo fmt --check` passes

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)