### PR TITLE
feat: Return partial AutoFunctionResult when max loops exceeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ for exec in &result.executions {
 
 ### Added
 
+- **Partial results when max_function_call_loops exceeded** (#172):
+  - `create_with_auto_functions()` now returns partial results instead of error when limit is hit
+  - New `reached_max_loops: bool` field on `AutoFunctionResult` indicates if limit was reached
+  - The `response` field contains the last API response (likely with pending function calls)
+  - The `executions` vector preserves all function calls that were executed before hitting the limit
+  - Enables debugging stuck function loops and accessing partial work
+  - New `AutoFunctionStreamChunk::MaxLoopsReached` variant for streaming (parallel change)
+  - `AutoFunctionResultAccumulator` now handles `MaxLoopsReached` and sets `reached_max_loops: true`
+  - Legacy JSON without `reached_max_loops` field deserializes with default `false`
+
 - **Function execution timing** (#148):
   - `FunctionExecutionResult.duration` tracks how long each function took to execute
   - Duration is serialized as milliseconds for JSON compatibility


### PR DESCRIPTION
## Summary

- Return partial results instead of error when `max_function_call_loops` is reached
- Preserve execution history and last response for debugging stuck function loops
- Add `reached_max_loops: bool` field to indicate when limit was hit

## Changes

- **`AutoFunctionResult`**: New `reached_max_loops: bool` field with `#[serde(default)]` for backwards compatibility
- **`AutoFunctionStreamChunk`**: New `MaxLoopsReached(InteractionResponse)` variant
- **`create_with_auto_functions()`**: Returns `Ok` with partial result instead of error
- **`create_stream_with_auto_functions()`**: Yields `MaxLoopsReached` instead of error
- **`AutoFunctionResultAccumulator`**: Handles `MaxLoopsReached` and sets `reached_max_loops: true`

## Before/After

**Before:** All execution history discarded on max loops
```rust
Err(GenaiError::Internal("Exceeded maximum function call loops..."))
```

**After:** Partial results preserved for debugging
```rust
Ok(AutoFunctionResult {
    response: last_response,  // Contains pending function calls
    executions: all_executions,  // All functions that ran
    reached_max_loops: true,
})
```

## Test plan

- [x] `cargo test --lib` passes (76 tests)
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt --check` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc` passes
- [x] New unit tests for `reached_max_loops` field
- [x] New unit tests for `MaxLoopsReached` variant serialization
- [x] New unit tests for `AutoFunctionResultAccumulator` handling
- [x] Backwards compatibility test for legacy JSON

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)