### PR TITLE
ci: Parallelize integration tests into 4 matrix jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,6 +65,7 @@ jobs:
           shared-key: integration-${{ matrix.group }}
       - name: Run integration tests (${{ matrix.group }})
         run: |
+          set -e
           for test in ${{ matrix.tests }}; do
             echo "::group::Running $test"
             cargo test --test $test --verbose -- --include-ignored

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,7 +237,7 @@ This requires a custom `Deserialize` implementation. See `InteractionContent` in
 
 ## CI/CD
 
-GitHub Actions (`.github/workflows/rust.yml`) runs 6 parallel jobs: check, test, test-integration, fmt, clippy, doc. Integration tests require same-repo origin (protects API key). CI runs on all PRs regardless of file type.
+GitHub Actions (`.github/workflows/rust.yml`) runs 9 parallel jobs: check, test, test-strict-unknown, 4× test-integration (core, tools, functions, multimodal), fmt, clippy, doc, security. Integration tests are split into 4 matrix jobs for faster execution (~2.5 min vs ~4 min). Integration tests require same-repo origin (protects API key). CI runs on all PRs regardless of file type.
 
 ## Project Conventions
 


### PR DESCRIPTION
## Summary

- Split integration tests into 4 parallel CI jobs using matrix strategy
- Expected improvement: ~4 min → ~1.5 min (60-70% faster)

## Test Groups

| Group | Test Files | Est. Tests |
|-------|-----------|------------|
| core | interactions_api, multiturn, streaming_multiturn | 33 |
| tools | tools_and_config, tools_multiturn | 23 |
| functions | advanced_function_calling, thinking_function | 23 |
| multimodal | multimodal, agents, api_canary | 23 |

## Changes

- Matrix strategy with `fail-fast: false` (all jobs complete even if one fails)
- Grouped cache keys for better cache efficiency
- Collapsible output sections with `::group::`

## Monitoring

After merge, watch for:
- API rate limiting errors from Gemini
- Increased flakiness
- Actual speedup achieved

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)