### PR TITLE
docs: Add comprehensive documentation for multimodal and streaming APIs

### DIFF
--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -420,6 +420,25 @@ mod duration_millis {
 /// This type provides visibility into which functions were called during
 /// automatic function execution, useful for debugging, logging, and evaluation.
 ///
+/// # Memory Considerations
+///
+/// The `executions` vector accumulates all [`FunctionExecutionResult`] records
+/// from each iteration of the auto-function loop. For typical use cases (1-5
+/// iterations with 1-3 functions each), this is negligible.
+///
+/// For edge cases with many function calls or large result payloads, consider:
+///
+/// - **Limit iterations**: Use [`crate::InteractionBuilder::with_max_function_call_loops()`]
+///   to cap the maximum number of iterations (default: 5)
+/// - **Extract and drop**: Extract only the data you need, then drop the result
+/// - **Manual control**: For fine-grained memory management, implement function
+///   calling manually using [`crate::InteractionBuilder::with_functions()`] and
+///   [`crate::InteractionBuilder::create()`] instead of the auto-function helpers
+///
+/// Each `FunctionExecutionResult` contains the function name, call ID, result
+/// value (as `serde_json::Value`), and execution duration. Memory usage scales
+/// primarily with the size of function result payloads.
+///
 /// # Example
 ///
 /// ```no_run


### PR DESCRIPTION
## Summary

- Add file size recommendations to multimodal module (~20MB limit, 2.3× peak memory)
- Add format tables with extension → MIME type mappings to all `*_from_file()` functions
- Add detailed error documentation for each multimodal function
- Add memory considerations to `AutoFunctionResult` for long auto-function chains
- Fix HEIF MIME type mapping (`.heif` → `image/heif` per IANA standards)

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes with no warnings
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc` passes (all doc links resolve)
- [x] `cargo test --lib` passes (76 tests)

Closes #170, closes #174, closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)