### PR TITLE
feat: Add runtime warning for large file uploads

### DIFF
--- a/src/multimodal.rs
+++ b/src/multimodal.rs
@@ -160,8 +160,27 @@ pub fn detect_mime_type(path: &Path) -> Option<&'static str> {
 }
 
 /// Internal helper to load and encode a file.
+///
+/// Warns if file size exceeds 20MB (the recommended threshold for inline data).
+/// For large files, consider using URI-based content or the Files API.
 async fn load_and_encode_file(path: impl AsRef<Path>) -> Result<String, GenaiError> {
+    const LARGE_FILE_THRESHOLD: u64 = 20 * 1024 * 1024; // 20MB
+
     let path = path.as_ref();
+
+    // Check file size and warn if large (don't fail - let users proceed if they want)
+    if let Ok(metadata) = tokio::fs::metadata(path).await {
+        if metadata.len() > LARGE_FILE_THRESHOLD {
+            log::warn!(
+                "File '{}' is {:.1}MB which exceeds the recommended 20MB limit for inline data. \
+                 Consider using URI-based content (e.g., gs:// URLs) or the Files API for large files \
+                 to reduce memory usage. See: https://ai.google.dev/gemini-api/docs/files",
+                path.display(),
+                metadata.len() as f64 / (1024.0 * 1024.0)
+            );
+        }
+    }
+
     let bytes = tokio::fs::read(path).await.map_err(|e| {
         let suggestion = match e.kind() {
             std::io::ErrorKind::NotFound => " Check that the file path is correct.",


### PR DESCRIPTION
## Summary

- Adds runtime warning when loading files >20MB via `*_from_file()` functions
- Warning suggests using URI-based content or the Files API to reduce memory usage
- Graceful: warns but doesn't block - users can proceed if they know what they're doing

## Changes

Added file size check in `load_and_encode_file()`:

```rust
const LARGE_FILE_THRESHOLD: u64 = 20 * 1024 * 1024; // 20MB

if let Ok(metadata) = tokio::fs::metadata(path).await {
    if metadata.len() > LARGE_FILE_THRESHOLD {
        log::warn!(
            "File '{}' is {:.1}MB which exceeds the recommended 20MB limit...",
            path.display(),
            metadata.len() as f64 / (1024.0 * 1024.0)
        );
    }
}
```

## Design Decisions

- **Warning, not error** - Users can proceed if they know what they're doing
- **Graceful fallback** - If metadata check fails, we don't block the load
- **Actionable message** - Points to URI-based content and Files API as alternatives

## Related

- Closes #158
- References #93 (Files API support - the proper long-term solution for large files)

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes
- [x] `cargo test --lib` passes (76 tests)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)