### PR TITLE
test: Add streaming delta incrementality verification

### DIFF
--- a/tests/interactions_api_tests.rs
+++ b/tests/interactions_api_tests.rs
@@ -308,8 +308,9 @@ async fn test_streaming_deltas_are_incremental() {
         // Verify the content looks reasonable (should mention seasons)
         let lower = concatenated.to_lowercase();
         assert!(
-            lower.contains("spring") || lower.contains("summer")
-                || lower.contains("fall") || lower.contains("winter"),
+            ["spring", "summer", "fall", "winter"]
+                .iter()
+                .any(|season| lower.contains(season)),
             "Response should mention seasons. Got: {:?}",
             concatenated
         );


### PR DESCRIPTION
## Summary

Adds a test that validates streaming deltas from the Gemini Interactions API are truly incremental (each chunk contains only new content) rather than cumulative (each chunk containing the full response so far).

## Context

This was prompted by external feedback questioning whether the API's `content.delta` events return true deltas. The test proves they do:

```
Delta #2: "**Spring**\n..." (len=92)
Delta #3: "Summer**\n..." (len=100)
Delta #4: "**Fall**\n..." (len=89)
Delta #5: "**Winter**\n..." (len=88)

Sum of individual delta lengths: 369
Concatenated text length: 369
```

## Test Details

- Uses a prompt that generates enough output to be split across multiple chunks (4 haikus)
- Logs each delta's content and length for debugging
- Verifies `sum_of_lengths == concatenated_length` (proves no overlap)
- Requires at least 2 text deltas to be a valid incrementality test

## Test plan

- [x] `cargo test test_streaming_deltas_are_incremental -- --include-ignored`
- [x] `cargo clippy`
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)