### PR TITLE
refactor: Remove speculative HEIC/HEIF support from ImageInfo::extension()

### DIFF
--- a/src/response_ext.rs
+++ b/src/response_ext.rs
@@ -395,8 +395,6 @@ mod tests {
         check(Some("image/png"), "png");
         check(Some("image/webp"), "webp");
         check(Some("image/gif"), "gif");
-        check(Some("image/heic"), "png"); // Unknown format, defaults to png
-        check(Some("image/heif"), "png"); // Unknown format, defaults to png
         check(Some("image/unknown"), "png"); // default
         check(None, "png"); // default
     }


### PR DESCRIPTION
## Summary
- Remove explicit HEIC/HEIF MIME type handling from `ImageInfo::extension()`
- Let these formats fall through to the Unknown case (logs warning, defaults to png)
- Purer Evergreen approach: warning logs will surface when/if the API adds these formats

The original PR #215 added HEIC/HEIF support speculatively, but these formats aren't documented as API outputs. Per Evergreen philosophy, it's better to let unknown formats trigger the warning path so we know when to update the library.

Closes #219

## Test plan
- [x] `cargo test test_image_info_extension` - passes
- [x] `cargo fmt` - passes
- [x] `cargo clippy` - passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)