### PR TITLE
ci: Rebalance integration test matrix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,9 +55,9 @@ jobs:
           - group: tools
             tests: "tools_and_config_tests tools_multiturn_tests"
           - group: functions
-            tests: "advanced_function_calling_tests thinking_function_tests"
+            tests: "advanced_function_calling_tests thinking_function_tests agents_tests"
           - group: multimodal
-            tests: "multimodal_tests agents_tests api_canary_tests temp_file_tests"
+            tests: "multimodal_tests api_canary_tests temp_file_tests"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

Move `agents_tests` from multimodal to functions group to reduce CI time imbalance.

## Changes

| Group | Before | After |
|-------|--------|-------|
| functions | 2 test files | 3 test files (+agents_tests) |
| multimodal | 4 test files (~2m) | 3 test files (~1.5m) |

## Rationale

- `agents_tests` uses function calling, so it fits conceptually with the functions group
- Reduces multimodal group runtime by ~25%
- Simple 2-line YAML change

Fixes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)