### PR TITLE
ci: Add 5th integration test group for agents

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,9 @@ jobs:
           - group: tools
             tests: "tools_and_config_tests tools_multiturn_tests"
           - group: functions
-            tests: "advanced_function_calling_tests thinking_function_tests agents_tests"
+            tests: "advanced_function_calling_tests thinking_function_tests"
+          - group: agents
+            tests: "agents_tests"
           - group: multimodal
             tests: "multimodal_tests api_canary_tests temp_file_tests"
     steps:


### PR DESCRIPTION
## Summary

Add dedicated `agents` group to better parallelize integration tests.

## Changes

| Group | Before | After |
|-------|--------|-------|
| functions | advanced_function_calling, thinking_function, agents (~2m) | advanced_function_calling, thinking_function (~1m) |
| agents | — | agents_tests (~1m) |

## Expected Impact

- Reduces slowest group from ~2m to ~1m
- All 5 groups now run in ~1-1.5m each
- Total wall-clock time drops by ~1 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)