### PR TITLE
docs: Update file paths after interactions module split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ cargo run --example image_generation
 
 1. **Public API** (`src/lib.rs`, `src/client.rs`, `src/request_builder.rs`): User-facing `Client`, `InteractionBuilder`, error conversion
 2. **Internal Logic** (`src/function_calling.rs`, `src/interactions_api.rs`, `src/multimodal.rs`): Function registry, content builders, file loading helpers
-3. **HTTP Client** (`genai-client/`): Raw API requests, JSON models (`models/interactions.rs`, `models/shared.rs`), SSE streaming
+3. **HTTP Client** (`genai-client/`): Raw API requests, JSON models (`models/interactions/`, `models/shared.rs`), SSE streaming
 4. **Macros** (`rust-genai-macros/`): `#[tool]` macro with `inventory` registration
 
 ### Key Patterns

--- a/tests/api_canary_tests.rs
+++ b/tests/api_canary_tests.rs
@@ -42,7 +42,7 @@ fn assert_no_unknown_content(response: &rust_genai::InteractionResponse, context
              Unknown types: {:?}\n\
              Full summary: {summary}\n\n\
              Action required: Add support for these content types in \
-             genai-client/src/models/interactions.rs",
+             genai-client/src/models/interactions/",
             summary.unknown_types
         );
     }
@@ -110,7 +110,7 @@ async fn canary_streaming_interaction() {
             "API returned unknown content types in streaming deltas!\n\
              Unknown types: {:?}\n\n\
              Action required: Add support for these content types in \
-             genai-client/src/models/interactions.rs",
+             genai-client/src/models/interactions/",
             unknown_types_found
         );
     }


### PR DESCRIPTION
## Summary
- Update CLAUDE.md architecture section: `models/interactions.rs` → `models/interactions/`
- Update api_canary_tests.rs error messages to point to the module directory

Follows up on PR #248 which split the tests file into focused modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)