### PR TITLE
ci: Add security audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,28 @@
+name: Security Audit
+
+on:
+  push:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sundays
+
+permissions:
+  contents: read
+  checks: write  # Required for rustsec/audit-check to post results
+
+jobs:
+  security:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Security Audit
+        uses: rustsec/audit-check@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a security audit workflow using `rustsec/audit-check` to scan for known vulnerabilities in dependencies.

## Details

- Triggers on Cargo.toml/Cargo.lock changes and weekly (Sundays)
- Includes `checks: write` permission (required for posting results)
- Uses same setup as gemicro's audit workflow (PR #212)

## Testing

Will run automatically on this PR to verify the workflow works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)