### PR TITLE
refactor: Use RES# prefix for responses in LOUD_WIRE output

### DIFF
--- a/docs/LOGGING_STRATEGY.md
+++ b/docs/LOGGING_STRATEGY.md
@@ -331,8 +331,8 @@ LOUD_WIRE=1 cargo run --example simple_interaction
   "input": "Hello",
   ...
 }
-[LOUD_WIRE] 2026-01-02T10:30:46Z [REQ#1] <<< 200 OK
-[LOUD_WIRE] 2026-01-02T10:30:46Z [REQ#1] SSE:
+[LOUD_WIRE] 2026-01-02T10:30:46Z [RES#1] <<< 200 OK
+[LOUD_WIRE] 2026-01-02T10:30:46Z [RES#1] SSE:
 {
   "delta": {
     "text": "Hello"
@@ -340,6 +340,6 @@ LOUD_WIRE=1 cargo run --example simple_interaction
 }
 ```
 
-- Request IDs (`[REQ#N]`) correlate requests with their responses and SSE chunks
+- Request IDs (`[REQ#N]`) and response IDs (`[RES#N]`) correlate requests with their responses
 - Base64 `"data"` fields are truncated: `"data": "AAAA..."`
 - File uploads show progress: `>>> UPLOAD "video.mp4" (video/mp4, 150.25 MB)`


### PR DESCRIPTION
## Summary

- Differentiate request and response prefixes in LOUD_WIRE output
- Requests now show `[REQ#N]`, responses show `[RES#N]`
- Makes it easier to visually distinguish outgoing vs incoming traffic

## Changes

- Split `prefix()` into `request_prefix()` and `response_prefix()` functions
- Updated all logging functions to use the appropriate prefix
- Updated documentation to reflect the new format

## Before

```
[LOUD_WIRE] 2026-01-02T10:30:45Z [REQ#1] >>> POST https://...
[LOUD_WIRE] 2026-01-02T10:30:46Z [REQ#1] <<< 200 OK
```

## After

```
[LOUD_WIRE] 2026-01-02T10:30:45Z [REQ#1] >>> POST https://...
[LOUD_WIRE] 2026-01-02T10:30:46Z [RES#1] <<< 200 OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)