### PR TITLE
docs: Trim and consolidate documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | Function Calling Guide | https://ai.google.dev/gemini-api/docs/function-calling.md.txt |
 | Thought Signatures | https://ai.google.dev/gemini-api/docs/thought-signatures.md.txt |
 
-These are the canonical references for the Interactions API this library implements.
-
 ## Project Overview
 
 `rust-genai` is a Rust client library for Google's Generative AI (Gemini) API using the **Interactions API** for unified model/agent interactions.
@@ -33,9 +31,7 @@ These are the canonical references for the Interactions API this library impleme
 ```bash
 cargo test -- --include-ignored           # Full test suite (requires GEMINI_API_KEY)
 cargo test                                 # Unit tests only
-cargo test --test interactions_api_tests  # Specific test file
 cargo test test_name -- --include-ignored # Single test by name
-cargo test -- --nocapture                 # Show test output
 ```
 
 **Environment**: `GEMINI_API_KEY` required for integration tests. Tests take 2-5 minutes; some may flake due to LLM variability.
@@ -43,78 +39,39 @@ cargo test -- --nocapture                 # Show test output
 ### Quality Checks
 
 ```bash
-cargo fmt                                                            # Format
 cargo fmt -- --check                                                 # Check format
 cargo clippy --workspace --all-targets --all-features -- -D warnings # Lint
-RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items  # Build docs (warnings as errors, matches CI)
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items  # Docs
 ```
 
 ### Examples
 
-All require `GEMINI_API_KEY`:
+All require `GEMINI_API_KEY`. Key examples:
+- `cargo run --example simple_interaction` - Basic usage
+- `cargo run --example auto_function_calling` - Function calling
+- `cargo run --example streaming` - SSE streaming
 
-**Basic Examples:**
-```bash
-cargo run --example simple_interaction
-cargo run --example streaming
-cargo run --example system_instructions
-cargo run --example stateful_interaction
-```
-
-**Function Calling:**
-```bash
-cargo run --example auto_function_calling
-cargo run --example parallel_and_compositional_functions
-cargo run --example streaming_auto_functions
-cargo run --example manual_function_calling
-cargo run --example tool_service
-```
-
-**Advanced Features:**
-```bash
-cargo run --example structured_output
-cargo run --example google_search
-cargo run --example code_execution
-cargo run --example url_context
-cargo run --example thinking
-cargo run --example deep_research
-cargo run --example thought_echo
-cargo run --example files_api
-cargo run --example cancel_interaction
-```
-
-**Multimodal:**
-```bash
-cargo run --example multimodal_image
-cargo run --example audio_input
-cargo run --example video_input
-cargo run --example pdf_input
-cargo run --example text_input
-cargo run --example image_generation
-```
+See `examples/` for full list (multimodal, thinking, files API, image generation, etc.)
 
 ## Architecture
 
 ### Layered Design
 
-1. **Public API** (`src/lib.rs`, `src/client.rs`, `src/request_builder.rs`): User-facing `Client`, `InteractionBuilder`, error conversion
-2. **Internal Logic** (`src/function_calling.rs`, `src/interactions_api.rs`, `src/multimodal.rs`): Function registry, content builders, file loading helpers
-3. **HTTP Client** (`genai-client/`): Raw API requests, JSON models (`models/interactions/`, `models/shared.rs`), SSE streaming
+1. **Public API** (`src/lib.rs`, `src/client.rs`, `src/request_builder.rs`): User-facing `Client`, `InteractionBuilder`
+2. **Internal Logic** (`src/function_calling.rs`, `src/interactions_api.rs`, `src/multimodal.rs`): Function registry, content builders
+3. **HTTP Client** (`genai-client/`): Raw API requests, JSON models, SSE streaming
 4. **Macros** (`rust-genai-macros/`): `#[tool]` macro with `inventory` registration
 
 ### Key Patterns
 
-**Builder API**: Fluent builders throughout (`Client::builder()`, `client.interaction().with_*()`, `FunctionDeclaration::builder()`)
+**Builder API**: Fluent builders throughout (`Client::builder()`, `client.interaction().with_*()`)
 
-**Function Calling - Two Categories**:
+**Function Calling** - Two categories:
 
-*Client-Side Tools* (YOUR code executes):
-- `#[tool]` macro: Compile-time registration, stateless, auto-discovered
-- `ToolService`: Runtime registration, stateful (DB, APIs, config), dependency injection
-- Manual: Full control via `create()` + `function_result_content()` loop
-
-*Server-Side Tools* (API executes):
-- Google Search, Code Execution, URL Context - enabled via `with_tool()`
+| Category | Tools | Who Executes |
+|----------|-------|--------------|
+| Client-Side | `#[tool]` macro, `ToolService`, Manual | YOUR code |
+| Server-Side | Google Search, Code Execution, URL Context | API |
 
 **Choosing Client-Side Approach**:
 | Approach | Registration | State | Best For |
@@ -124,391 +81,109 @@ cargo run --example image_generation
 | Manual handling | N/A | Flexible | Custom execution logic, rate limiting |
 
 **Function Calling Modes**:
-| Mode | Behavior | Guarantees |
-|------|----------|------------|
-| Auto (default) | Model decides whether to call functions | None |
-| Any | Model must call a function | Schema adherence for calls |
-| None | Function calling disabled | No function calls |
-| Validated | Either calls OR natural language | Schema adherence for both |
+| Mode | Behavior |
+|------|----------|
+| Auto (default) | Model decides whether to call functions |
+| Any | Model must call a function |
+| None | Function calling disabled |
+| Validated | Schema adherence for both calls and natural language |
 
-Use `with_function_calling_mode()` to set the mode:
-```rust
-client.interaction()
-    .with_function_calling_mode(FunctionCallingMode::Validated)
-    .with_functions(vec![my_function])
-    // ...
-```
-
-**When You're Blocked - Use ToolService Instead of #[tool]**:
-- **Need database access**: `#[tool]` functions can't access connection pools → Use `ToolService` with `Arc<Pool<...>>`
-- **Need API client**: `#[tool]` functions can't share HTTP clients → Use `ToolService` with `Arc<reqwest::Client>`
-- **Need configuration**: `#[tool]` functions can't read runtime config → Use `ToolService` with `Arc<RwLock<Config>>`
-- **Need mutable state**: `#[tool]` functions are stateless → Use `ToolService` with `Arc<RwLock<T>>`
-- **Need per-request context**: `#[tool]` functions are global → Use `ToolService` to inject request-specific tools
-
-**ToolService Pattern**: Use `Arc<RwLock<T>>` for interior mutability. Same service instance reused across requests via `service.clone()` (clones the Arc, not the service). See `examples/tool_service.rs`.
-
-**Multi-Turn Inheritance Rules** (with `previousInteractionId`):
+**Multi-Turn Inheritance Rules** (critical gotcha):
 | Field | Inherited? | Notes |
 |-------|------------|-------|
 | `systemInstruction` | ✅ Yes | Only send on first turn |
 | `tools` | ❌ No | Must resend on every new user message turn |
 | Conversation history | ✅ Yes | Automatically included |
 
-**Function Result Returns**: When returning function results to the model (after executing a tool), you do NOT need to resend `tools`. The model remembers available tools from the interaction that triggered the function call. Only new user message turns require tools to be included.
+**Debugging**: Use `LOUD_WIRE=1` to see wire-level request/response details.
 
-**Debugging Multi-Turn**: Use `LOUD_WIRE=1` to see exactly what's being sent on each request. This shows tools, systemInstruction, and previousInteractionId for each turn, making it easy to verify correct behavior.
-
-**For comprehensive multi-turn and function calling patterns**: See `docs/MULTI_TURN_FUNCTION_CALLING.md` - covers stateful vs stateless, auto vs manual execution, thought signatures, and design patterns.
-
-**Streaming**: Uses `async-stream` generators and `futures-util::Stream`
+**Comprehensive Guides** (see `docs/`):
+- `docs/MULTI_TURN_FUNCTION_CALLING.md` - Stateful/stateless, auto/manual execution, thought signatures
+- `docs/STREAMING_API.md` - Stream types, resume capability, auto-function streaming
+- `docs/LOGGING_STRATEGY.md` - Log levels, sensitive data handling
 
 ### Error Types
 
-- `GenaiError`: API/network errors (thiserror-based), defined in `genai-client/src/errors.rs`, re-exported from `rust-genai`
+- `GenaiError`: API/network errors (thiserror-based), defined in `genai-client/src/errors.rs`
 - `FunctionError`: Function execution errors
 
-### Multimodal Input
+## Core Design Philosophy: Evergreen Soft-Typing
 
-**Fluent Builder Pattern** (recommended for inline content):
-```rust
-// Images, audio, video, documents - all use the same pattern
-client.interaction()
-    .with_model("gemini-3-flash-preview")
-    .with_text("Analyze this image")
-    .add_image_file("photo.jpg").await?        // From file (auto MIME detection)
-    .add_image_data(base64_data, "image/png")  // From base64
-    .add_image_uri("gs://bucket/img.jpg", "image/jpeg")  // From URI
-    .create().await?
-```
-
-**Content Vector** (for programmatic/dynamic content):
-```rust
-use rust_genai::{text_content, image_from_file};
-
-let contents = vec![
-    text_content("Analyze this image"),
-    image_from_file("photo.jpg").await?,
-];
-client.interaction()
-    .with_content(contents)
-    .create().await?
-```
-
-**File Loading Helpers** (in `multimodal` module):
-- `image_from_file()`, `audio_from_file()`, `video_from_file()`, `document_from_file()`
-- Auto-detect MIME type from extension, load file, base64 encode
-- `*_from_file_with_mime()` variants for explicit MIME override
-
-### Multimodal Output (Image Generation)
-
-**Generate images** by setting response modalities:
-```rust
-let response = client.interaction()
-    .with_model("gemini-3-pro-image-preview")
-    .with_text("Generate an image of a sunset over mountains")
-    .with_response_modalities(vec!["IMAGE".to_string()])
-    .create().await?;
-
-// Extract and save generated images
-for output in &response.outputs {
-    if let InteractionContent::Image {
-        data: Some(base64_data),
-        mime_type,
-        ..
-    } = output {
-        // Decode base64 image data
-        use base64::Engine;
-        let bytes = base64::engine::general_purpose::STANDARD.decode(base64_data)?;
-
-        // Save to file (mime_type typically "image/png" or "image/jpeg")
-        std::fs::write("generated.png", bytes)?;
-    }
-}
-```
-
-**Response Modalities**:
-- `"TEXT"` - Text generation (default)
-- `"IMAGE"` - Image generation
-- Can specify both: `vec!["TEXT".to_string(), "IMAGE".to_string()]`
-
-See `examples/image_generation.rs` for complete example.
-
-### Content Export Strategy
-
-**Re-exported** (user-constructed): `image_data_content`, `audio_uri_content`, `function_result_content`, `function_call_content`, `image_from_file`, `audio_from_file`, `video_from_file`, `document_from_file`, `detect_mime_type`
-
-**Not re-exported** (model-generated): Built-in tool outputs accessed via response methods like `response.google_search_results()`, `response.code_execution_results()`
-
-### Files API
-
-The Files API allows uploading large files (up to 2GB) that can be referenced across multiple interactions. Files are stored for 48 hours.
-
-**Standard upload** (loads entire file into memory):
-```rust
-let file = client.upload_file("video.mp4").await?;
-// Use in interaction
-client.interaction().with_file(&file).with_text("Describe this").create().await?;
-// Clean up
-client.delete_file(&file.name).await?;
-```
-
-**Chunked upload** (memory-efficient for large files 500MB-2GB):
-```rust
-// Uses ~8MB memory regardless of file size
-let (file, resumable) = client.upload_file_chunked("large_video.mp4").await?;
-
-// With custom chunk size
-let (file, resumable) = client.upload_file_chunked_with_options(
-    "large_video.mp4",
-    "video/mp4",
-    16 * 1024 * 1024  // 16MB chunks
-).await?;
-```
-
-**When to use chunked:**
-- Large files (500MB-2GB) to avoid memory pressure
-- Memory-constrained environments (containers, edge devices)
-- Batch processing multiple large files
-
-**Memory characteristics:**
-- Standard: Requires `file_size` bytes of RAM
-- Chunked: Uses fixed ~`chunk_size` bytes (default 8MB)
-
-**ResumableUpload handle** returned from chunked methods:
-- `file_size()`: Total file size
-- `mime_type()`: File MIME type
-- `upload_url()`: Resumable upload URL
-- `query_offset()`: Query server for bytes uploaded (for resume logic)
-- `resume()`: Resume upload from offset with a reader
-
-## Core Design Philosophy: Evergreen-Inspired Soft-Typing
-
-This library follows the [Evergreen spec](https://github.com/google-deepmind/evergreen-spec) philosophy for graceful API evolution. The core principle: **unknown data should be preserved, not rejected**.
+This library follows the [Evergreen spec](https://github.com/google-deepmind/evergreen-spec) philosophy: **unknown data should be preserved, not rejected**.
 
 ### Key Principles
 
-1. **Graceful Unknown Handling**: Unrecognized API types deserialize into `Unknown` variants instead of failing
-2. **Non-Exhaustive Enums**: Use `#[non_exhaustive]` on enums that may grow (e.g., `InteractionContent`, `Tool`)
-3. **Soft-Typed Where Appropriate**: Use `serde_json::Value` for evolving structures (e.g., function args)
-4. **Preserve Data Roundtrip**: `Unknown` variants serialize back with their original data intact
-5. **Continue on Unknown Status**: When polling for interaction completion, continue polling on unrecognized status variants rather than failing immediately. This ensures forward compatibility when the API adds new transient states. Use timeouts to protect against infinite loops (see `examples/deep_research.rs`).
-
-### DO:
-```rust
-// Use non_exhaustive for API-driven enums
-#[non_exhaustive]
-pub enum Tool {
-    GoogleSearch,
-    CodeExecution,
-    Unknown { tool_type: String, data: serde_json::Value },
-}
-
-// Handle unknown variants in match
-match tool {
-    Tool::GoogleSearch => ...,
-    Tool::CodeExecution => ...,
-    _ => log::warn!("Unknown tool type, ignoring"),
-}
-
-// Use serde_json::Value for flexible/evolving fields
-pub struct FunctionCall {
-    pub name: String,
-    pub args: serde_json::Value,  // Schema may change
-}
-
-// Continue polling on unknown status variants
-match response.status {
-    InteractionStatus::Completed => return Ok(response),
-    InteractionStatus::Failed => return Err(...),
-    InteractionStatus::InProgress => { /* continue */ }
-    other => {
-        // Don't fail - continue polling with timeout protection
-        eprintln!("Unhandled status {:?}, continuing...", other);
-    }
-}
-```
-
-### DON'T:
-```rust
-// Don't use exhaustive enums for API types - breaks when API adds variants
-pub enum Tool {
-    GoogleSearch,
-    CodeExecution,
-    // API adds "NewTool" -> all client code breaks!
-}
-
-// Don't fail on unknown data
-let content: InteractionContent = serde_json::from_str(json)?;
-// If json has type "future_feature", this should NOT error
-```
+1. **Graceful Unknown Handling**: Unrecognized API types deserialize into `Unknown` variants
+2. **Non-Exhaustive Enums**: Use `#[non_exhaustive]` on enums that may grow
+3. **Preserve Data Roundtrip**: `Unknown` variants serialize back with original data intact
+4. **Continue on Unknown Status**: When polling, continue on unrecognized status (use timeouts)
 
 ### Standard Unknown Variant Pattern
 
-All enums with `Unknown` variants use the **data-preserving pattern** with consistent naming:
-
-**Field names** follow `<context>_type`:
-- `InteractionContent`: `content_type`
-- `Tool`: `tool_type`
-- `InteractionStatus`: `status_type`
-- `StreamChunk` / `AutoFunctionStreamChunk`: `chunk_type`
-
-**Helper methods** are consistent across all types:
-- `is_unknown()` - Check if this is an Unknown variant
-- `unknown_<context>_type()` - Get the unrecognized type name
-- `unknown_data()` - Get the preserved JSON data
+All enums use consistent naming - field names follow `<context>_type` (e.g., `content_type`, `tool_type`, `status_type`):
 
 ```rust
 Unknown {
-    /// The unrecognized type from the API
-    <context>_type: String,
-    /// The full JSON data, preserved for debugging and roundtrip serialization
-    data: serde_json::Value,
+    <context>_type: String,      // The unrecognized type from API
+    data: serde_json::Value,     // Full JSON preserved for roundtrip
 }
 ```
 
-This requires a custom `Deserialize` implementation. See `InteractionContent` in `content.rs` for the reference implementation.
+Helper methods: `is_unknown()`, `unknown_<context>_type()`, `unknown_data()`
 
-**Why not `#[serde(other)] Unknown`?** The unit variant pattern loses all data - you can't inspect what the API sent or roundtrip serialize it. Always prefer the data-preserving pattern.
+See `InteractionContent` in `genai-client/src/models/interactions/content.rs` for reference implementation.
 
-### Implementation Locations
-
-- `InteractionContent` (content.rs): `content_type` field, `unknown_content_type()` helper ✅
-- `Tool` (shared.rs): `tool_type` field, `unknown_tool_type()` helper ✅
-- `InteractionStatus` (response.rs): `status_type` field, `unknown_status_type()` helper ✅
-- `StreamChunk` (streaming.rs): `chunk_type` field, `unknown_chunk_type()` helper ✅
-- `AutoFunctionStreamChunk` (streaming.rs): `chunk_type` field, `unknown_chunk_type()` helper ✅
-- `FunctionCallingMode` (shared.rs): `mode_type` field, `unknown_mode_type()` helper ✅
-- `strict-unknown` feature flag: Optional strict mode for development/testing
+**Implementation status** (all ✅): `InteractionContent`, `Tool`, `InteractionStatus`, `StreamChunk`, `AutoFunctionStreamChunk`, `FunctionCallingMode`
 
 ## Test Organization
 
 - **Unit tests**: Inline in source files
-- **Integration tests** (`tests/`):
-  - `function_declaration_builder_tests.rs`, `interaction_builder_tests.rs`, `macro_tests.rs`, `ui_tests.rs`: No API key needed
-  - `interactions_api_tests.rs`: Core CRUD, streaming
-  - `advanced_function_calling_tests.rs`: Complex function scenarios (parallel calls, auto-functions)
-  - `tool_service_tests.rs`: ToolService dependency injection patterns
-  - `agents_tests.rs`, `multiturn_tests.rs`, `streaming_multiturn_tests.rs`: Stateful conversations
-  - `thinking_function_tests.rs`, `tools_multiturn_tests.rs`: Thinking and tool multi-turn tests
-  - `multimodal_tests.rs`: Image/media handling
-  - `tools_and_config_tests.rs`: Built-in tools
-  - `api_canary_tests.rs`: API compatibility checks
-  - `common/`: Shared test utilities
+- **Integration tests** (`tests/`): Require `GEMINI_API_KEY` for most; see file names for categories
 - **Property-based tests** (proptest): Serialization roundtrip verification
-  - `genai-client/src/models/interactions/proptest_tests.rs`: Strategy generators and unit proptests
-  - `tests/proptest_roundtrip_tests.rs`: Integration proptests for public API types
-  - To add coverage for a new type: create an `arb_<type>()` strategy function, then add a `<type>_roundtrip` test
-  - Use `#[cfg(feature = "strict-unknown")]` variants for strategies that include `Unknown` variants
+  - `genai-client/src/models/interactions/proptest_tests.rs`: Strategy generators
+  - `tests/proptest_roundtrip_tests.rs`: Integration proptests
 
 ### Test Assertion Strategies
 
-Integration tests should use the appropriate assertion strategy based on what they're testing:
-
-**Structural Assertions** (default for most tests):
-- Verify API mechanics work (status codes, response structure, field presence)
-- Check non-empty responses, valid IDs, correct status
-- Fast execution, no extra API calls
-- Example: `assert!(!response.text().unwrap().is_empty())`
-
-**Semantic Validation** (for high-value behavioral tests):
-- Use `validate_response_semantically()` from `tests/common/mod.rs`
-- Validates responses are contextually appropriate using Gemini as a judge
-- Uses structured output for deterministic yes/no validation with explanation
-- Apply to critical tests where behavior matters: context preservation, function calling effectiveness, multi-turn coherence
-- Adds ~1-2 seconds per validation (extra API call)
-- Example:
-  ```rust
-  let is_valid = validate_response_semantically(
-      &client,
-      "User asked about weather in Tokyo",
-      response.text().unwrap(),
-      "Does this response provide weather information?"
-  ).await?;
-  assert!(is_valid, "Response should address weather question");
-  ```
-
-**DO NOT use brittle content assertions:**
-- ❌ Avoid `text.contains("specific word")` - LLM outputs vary
-- ❌ Avoid checking for exact phrases or specific numbers in generated text
-- ✅ Use structural checks for mechanics, semantic validation for behavior
-
-**When to use semantic validation:**
-- Multi-turn context preservation tests
-- Function calling integration tests where the function result should inform the response
-- Tests validating the model understood and addressed a complex question
-- Any test where "did it do the right thing?" matters more than "did it respond?"
-
-See `tests/thinking_function_tests.rs::test_thinking_with_function_calling_multi_turn` and `tests/interactions_api_tests.rs::test_stateful_conversation` for examples.
+- **Structural**: Verify API mechanics (status, field presence) - default for most tests
+- **Semantic**: Use `validate_response_semantically()` for behavioral tests (adds ~1-2s API call)
+- **Avoid**: Brittle `text.contains("word")` assertions - LLM outputs vary
 
 ## CI/CD
 
-GitHub Actions (`.github/workflows/rust.yml`) runs these jobs: check, test, test-strict-unknown, test-integration (4 matrix groups: core, tools, functions, multimodal), fmt, clippy, doc, security, build-metrics. Integration tests are split into 4 parallel matrix jobs for faster execution (~2.5 min vs ~4 min). Integration tests require same-repo origin (protects API key). Build-metrics runs only on PRs. CI runs on all PRs regardless of file type.
+GitHub Actions runs: check, test, test-strict-unknown, test-integration (4 matrix groups), fmt, clippy, doc, security, build-metrics. Integration tests require same-repo origin (protects API key).
 
 ## Project Conventions
 
-- **Model name**: Always use `gemini-3-flash-preview` throughout the project (tests, examples, documentation). Exception: Image generation requires `gemini-3-pro-image-preview` since it's the only model supporting image output.
+- **Model name**: Always use `gemini-3-flash-preview` (exception: `gemini-3-pro-image-preview` for image generation)
 
 ### Naming Conventions
 
-**Suffix patterns for method names:**
-
 | Suffix | Meaning | Example |
 |--------|---------|---------|
-| `*_stream()` | Returns a `Stream<Item>` for async iteration | `create_stream()` returns `Stream<StreamChunk>` |
-| `*_chunked()` | Uses chunked/streaming internally, returns single result | `upload_file_chunked()` returns `(FileMetadata, ResumableUpload)` |
+| `*_stream()` | Returns `Stream<Item>` for async iteration | `create_stream()` |
+| `*_chunked()` | Uses chunked I/O internally, returns single result | `upload_file_chunked()` |
 | `*_with_auto_functions()` | Automatically executes functions in a loop | `create_stream_with_auto_functions()` |
-
-The distinction matters: `*_stream()` methods return async iterators that yield multiple items, while `*_chunked()` methods use chunked I/O internally but return a single final result.
 
 ### #[must_use] Annotation
 
-Use `#[must_use]` liberally to prevent users from silently dropping values with side effects:
-
-```rust
-// Good - prevents ignoring important return values
-#[must_use]
-pub fn upload_url(&self) -> &str { ... }
-
-#[must_use]
-pub fn is_active(&self) -> bool { ... }
-```
-
-Apply `#[must_use]` to:
-- Getters that return important state
-- Methods returning handles needed for further operations (e.g., `ResumableUpload`)
-- Boolean status checks
-- Any function where ignoring the result is likely a bug
-
-The attribute generates a compiler warning if the return value is unused, catching bugs early.
+Apply `#[must_use]` to getters, handles, and boolean checks where ignoring the result is likely a bug.
 
 ## Versioning Philosophy
 
-Breaking changes are always permitted, and preferred when they:
-- Simplify the API surface
-- Remove unnecessary abstractions
-- Align with Evergreen principles
-
-Prefer clean breaks over backwards-compatibility shims. Don't add deprecation warnings or migration layers—just make the change.
+Breaking changes are permitted and preferred when they simplify the API or align with Evergreen principles. Prefer clean breaks over backwards-compatibility shims.
 
 ## Logging
 
-See `docs/LOGGING_STRATEGY.md` for the full logging strategy. Key points:
-
-- **Log levels**: `error` for unrecoverable failures, `warn` for recoverable issues (including Evergreen unknown variants), `debug` for API lifecycle events and request bodies
-- **Sensitive data**: API keys are redacted in `Debug` output. User prompts/media logged only at `debug` level (disabled by default)
-- **Evergreen logging**: All `Unknown` variants log at `warn` level to surface API evolution
-- **Maintenance**: When adding new logging, update the strategy doc to keep examples accurate
-
-Enable debug logging with:
-```bash
-RUST_LOG=rust_genai=debug cargo run --example simple_interaction
-```
+See `docs/LOGGING_STRATEGY.md`. Key points:
+- `error` for unrecoverable, `warn` for recoverable (including Evergreen unknowns), `debug` for API lifecycle
+- API keys redacted; user content only at `debug` level
+- Enable: `RUST_LOG=rust_genai=debug cargo run --example simple_interaction`
 
 ## Technical Notes
 
 - Rust edition 2024 (requires Rust 1.85+)
 - Uses `rustls-tls` (not native TLS)
 - Tokio async runtime
-- API version: Gemini V1Beta (configured in `genai-client/src/common.rs`, not user-configurable)
+- API version: Gemini V1Beta (configured in `genai-client/src/common.rs`)
 - See `CHANGELOG.md` for breaking changes and migration guides

--- a/README.md
+++ b/README.md
@@ -2,30 +2,6 @@
 
 A Rust client library for interacting with Google's Generative AI (Gemini) API using the Interactions API.
 
-## Table of Contents
-
-- [Features](#features)
-- [External Documentation](#external-documentation)
-- [Installation](#installation)
-- [Usage](#usage)
-  - [Simple Interaction](#simple-interaction)
-  - [Streaming Responses](#streaming-responses)
-  - [System Instructions](#system-instructions)
-  - [Stateful Conversations](#stateful-conversations)
-  - [Function Calling](#function-calling)
-  - [Automatic Function Calling](#automatic-function-calling)
-  - [Built-in Tools](#built-in-tools)
-  - [Thinking Mode](#thinking-mode)
-  - [Multimodal Input](#multimodal-input)
-- [API Reference](#api-reference)
-- [Project Structure](#project-structure)
-- [Error Handling](#error-handling)
-- [Logging](#logging)
-- [Troubleshooting](#troubleshooting)
-- [Testing](#testing)
-- [License](#license)
-- [Contributing](#contributing)
-
 ## Features
 
 - Simple, intuitive API for making requests to Google's Generative AI models
@@ -35,11 +11,8 @@ A Rust client library for interacting with Google's Generative AI (Gemini) API u
 - Automatic function discovery at compile time using procedural macros
 - Structured output with JSON schema enforcement via `with_response_format()`
 - Built-in tool support: Google Search grounding, URL context, and code execution
-- Helper functions for building multi-turn conversations
 - Comprehensive error handling with detailed error types
 - Async/await support with Tokio
-- Type-safe function argument handling with serde
-- Support for both synchronous and asynchronous functions
 
 ## External Documentation
 
@@ -61,11 +34,9 @@ Add this to your `Cargo.toml`:
 rust-genai = "0.3.0"
 rust-genai-macros = "0.3.0"  # Only if using the procedural macros
 tokio = { version = "1.0", features = ["full"] }
-serde_json = "1.0"  # For JSON values in function calls
+serde_json = "1.0"
 futures-util = "0.3"  # Only if using streaming responses
 ```
-
-Note: `async-trait` and `inventory` are already included as dependencies of `rust-genai`, so you don't need to add them unless you're implementing custom `CallableFunction` traits.
 
 ### Prerequisites
 
@@ -74,32 +45,7 @@ Note: `async-trait` and `inventory` are already included as dependencies of `rus
 
 ## Usage
 
-> **Note**: For complete, runnable examples, check out the `examples/` directory:
-> - `simple_interaction.rs` - Basic text generation
-> - `streaming.rs` - Real-time streaming responses
-> - `system_instructions.rs` - Custom system prompts
-> - `stateful_interaction.rs` - Multi-turn conversations
-> - `auto_function_calling.rs` - Automatic function execution
-> - `parallel_and_compositional_functions.rs` - Parallel and chained function execution
-> - `structured_output.rs` - JSON schema enforcement
-> - `google_search.rs` - Web search grounding
-> - `code_execution.rs` - Python code execution
-> - `url_context.rs` - URL content fetching
-> - `thinking.rs` - Reasoning with thought content
-> - `multimodal_image.rs` - Image input handling
-> - `audio_input.rs` - Audio input handling
-> - `video_input.rs` - Video input handling
-> - `pdf_input.rs` - PDF document processing
-> - `text_input.rs` - Text document input (TXT, Markdown, JSON, CSV)
-> - `files_api.rs` - File upload and management via Files API
-> - `image_generation.rs` - Image generation
-> - `deep_research.rs` - Long-running research tasks
-> - `thought_echo.rs` - Thought continuation across turns
-> - `streaming_auto_functions.rs` - Streaming with automatic function calling
-> - `tool_service.rs` - Dependency injection for function calling
-> - `manual_function_calling.rs` - Full control over function execution loop
-
-You'll need a Google API key from [Google AI Studio](https://ai.dev/).
+See `examples/` for complete, runnable examples covering all features.
 
 ### Simple Interaction
 
@@ -109,13 +55,9 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY")?;
+    let client = Client::builder(api_key).build()?;
 
-    // Create the client
-    let client = Client::builder(api_key).build();
-
-    // Send an interaction and get response
     let response = client
         .interaction()
         .with_model("gemini-3-flash-preview")
@@ -123,9 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .create()
         .await?;
 
-    // Print the generated text
     println!("{}", response.text().unwrap_or("No response"));
-
     Ok(())
 }
 ```
@@ -134,896 +74,224 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ```rust
 use rust_genai::Client;
-use futures_util::{pin_mut, StreamExt};
-use std::{env, io::{stdout, Write}};
+use futures_util::StreamExt;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let api_key = env::var("GEMINI_API_KEY")?;
-    let client = Client::builder(api_key).build();
+let stream = client
+    .interaction()
+    .with_model("gemini-3-flash-preview")
+    .with_text("Explain quantum computing.")
+    .create_stream();
 
-    // Get a stream of response chunks
-    let stream = client
-        .interaction()
-        .with_model("gemini-3-flash-preview")
-        .with_text("Explain quantum computing in simple terms.")
-        .create_stream();
-    pin_mut!(stream);
-
-    // Process each chunk as it arrives
-    while let Some(result) = stream.next().await {
-        match result {
-            Ok(chunk) => {
-                if let Some(text) = chunk.text() {
-                    print!("{}", text);
-                    stdout().flush()?;
-                }
-            }
-            Err(e) => {
-                eprintln!("\nError: {}", e);
-                break;
-            }
+futures_util::pin_mut!(stream);
+while let Some(result) = stream.next().await {
+    if let Ok(chunk) = result {
+        if let Some(text) = chunk.text() {
+            print!("{}", text);
         }
     }
-
-    println!("\n");
-    Ok(())
 }
 ```
 
-### System Instructions
-
-```rust
-use rust_genai::Client;
-use std::env;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let api_key = env::var("GEMINI_API_KEY")?;
-    let client = Client::builder(api_key).build();
-
-    // Send request with system instruction
-    let response = client
-        .interaction()
-        .with_model("gemini-3-flash-preview")
-        .with_system_instruction("You are a helpful geography expert.")
-        .with_text("What is the capital of France?")
-        .create()
-        .await?;
-
-    println!("{}", response.text().unwrap_or("No response"));
-    Ok(())
-}
-```
+See [`docs/STREAMING_API.md`](docs/STREAMING_API.md) for stream types, resume capability, and patterns.
 
 ### Stateful Conversations
 
-The Interactions API supports stateful conversations using `previous_interaction_id`. The server automatically maintains context:
-
 ```rust
-use rust_genai::Client;
-use std::env;
+// First turn - set system instruction
+let response1 = client
+    .interaction()
+    .with_model("gemini-3-flash-preview")
+    .with_text("My name is Alice.")
+    .with_system_instruction("You are a helpful assistant.")
+    .with_store_enabled()
+    .create()
+    .await?;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let api_key = env::var("GEMINI_API_KEY")?;
-    let client = Client::builder(api_key).build();
-
-    // First interaction - establish context
-    let response1 = client
-        .interaction()
-        .with_model("gemini-3-flash-preview")
-        .with_text("My name is Alice and I live in New York.")
-        .with_store_enabled()  // Store for later reference
-        .create()
-        .await?;
-
-    println!("Response 1: {}", response1.text().unwrap_or(""));
-
-    // Second interaction - reference the first
-    let response2 = client
-        .interaction()
-        .with_model("gemini-3-flash-preview")
-        .with_previous_interaction(&response1.id)  // Link to previous
-        .with_text("What is my name and where do I live?")
-        .create()
-        .await?;
-
-    // Model remembers: "Your name is Alice and you live in New York."
-    println!("Response 2: {}", response2.text().unwrap_or(""));
-
-    Ok(())
-}
+// Second turn - chain with previous
+let response2 = client
+    .interaction()
+    .with_model("gemini-3-flash-preview")
+    .with_previous_interaction(&response1.id)
+    .with_text("What is my name?")  // Model remembers: "Alice"
+    .create()
+    .await?;
 ```
 
-#### Multi-Turn Inheritance Rules
+**Key inheritance rules:**
+- `systemInstruction`: Inherited (only send on first turn)
+- `tools`: NOT inherited (must resend on each user message turn)
 
-When using `previous_interaction_id`, different fields have different inheritance behavior:
-
-| Field | Inherited? | Notes |
-|-------|------------|-------|
-| `systemInstruction` | ✅ Yes | Only send on first turn |
-| `tools` | ❌ No | Must resend on every new user message turn |
-| Conversation history | ✅ Yes | Automatically included via the chain |
-
-**Important**: Function result returns do NOT need to resend `tools`. When returning results after executing a tool, the model already knows about available tools from the interaction that triggered the function call. Only new user message turns require tools to be included.
-
-**Debugging tip**: Use `LOUD_WIRE=1` to see exactly what's being sent on each request. This shows tools, systemInstruction, and previousInteractionId for each turn, making it easy to verify correct behavior.
-
-See `examples/real_world/multi_turn_agent_manual/main.rs` for detailed comments on this pattern.
-
-**For comprehensive multi-turn and function calling patterns**: See [`docs/MULTI_TURN_FUNCTION_CALLING.md`](docs/MULTI_TURN_FUNCTION_CALLING.md) - covers stateful vs stateless, auto vs manual execution, parallel function calls, thought signatures, and design patterns.
+See [`docs/MULTI_TURN_FUNCTION_CALLING.md`](docs/MULTI_TURN_FUNCTION_CALLING.md) for comprehensive patterns.
 
 ### Function Calling
 
-There are two categories of tools in this library:
+Three approaches for client-side function calling:
 
-**Client-Side Tools** - Functions YOUR code executes:
-- The model requests a function → Your code runs it → Results sent back to model
-- Use `#[tool]` macro, `ToolService`, or manual handling
+| Approach | State | Best For |
+|----------|-------|----------|
+| `#[tool]` macro | Stateless | Simple tools, quick prototyping |
+| `ToolService` | Stateful | DB connections, API clients, shared config |
+| Manual | Flexible | Custom execution logic, rate limiting |
 
-**Server-Side Tools** - Built-in tools the API executes:
-- The model uses the tool → API runs it → Results in response
-- Google Search, Code Execution, URL Context (see [Built-in Tools](#built-in-tools))
-
-#### Quick Decision Guide for Client-Side Tools
-
-| Need | Approach | Example |
-|------|----------|---------|
-| Simplest stateless tools | `#[tool]` macro | `auto_function_calling.rs` |
-| Stateful tools (DB, APIs, config) | `ToolService` trait | `tool_service.rs` |
-| Full execution control | Manual with `create()` | `manual_function_calling.rs` |
-
-All approaches support both streaming and non-streaming execution:
-- **Non-streaming**: `create_with_auto_functions()` or `create()`
-- **Streaming**: `create_stream_with_auto_functions()` or `create_stream()`
-
-See `streaming_auto_functions.rs` for a streaming example.
-
-#### Manual Function Calling
-
-For full control over the execution loop:
+#### Automatic with `#[tool]` Macro
 
 ```rust
-use rust_genai::{Client, FunctionDeclaration, function_result_content, WithFunctionCalling};
-use serde_json::json;
-use std::env;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let api_key = env::var("GEMINI_API_KEY")?;
-    let client = Client::builder(api_key).build();
-
-    // Define a function using the builder
-    let weather_function = FunctionDeclaration::builder("get_weather")
-        .description("Get the current weather in a given location")
-        .parameter("location", json!({
-            "type": "string",
-            "description": "The city and state, e.g. San Francisco, CA"
-        }))
-        .required(vec!["location".to_string()])
-        .build();
-
-    // First request with function declaration
-    let response = client
-        .interaction()
-        .with_model("gemini-3-flash-preview")
-        .with_text("What's the weather like in London?")
-        .with_function(weather_function.clone())
-        .create()
-        .await?;
-
-    // Check if model wants to call a function
-    let function_calls = response.function_calls();
-    if !function_calls.is_empty() {
-        let call = &function_calls[0];
-        println!("Function call: {} with args: {}", call.name, call.args);
-
-        // Execute your function logic here...
-        let weather_result = json!({"temperature": "72°F", "conditions": "sunny"});
-
-        // Send the result back using function_result_content
-        let call_id = call.id.expect("call_id required");
-        let function_result = function_result_content(call.name, call_id, weather_result);
-
-        let final_response = client
-            .interaction()
-            .with_model("gemini-3-flash-preview")
-            .with_previous_interaction(&response.id)
-            .with_content(vec![function_result])
-            .with_function(weather_function)
-            .create()
-            .await?;
-
-        println!("{}", final_response.text().unwrap_or("No response"));
-    }
-
-    Ok(())
-}
-```
-
-### Automatic Function Calling
-
-The library supports automatic function discovery and execution. Functions decorated with `#[tool]` are automatically discovered and executed when the model requests them:
-
-```rust
-use rust_genai::{Client, CallableFunction, WithFunctionCalling};
 use rust_genai_macros::tool;
-use std::env;
 
-/// Get the current weather in a location
-#[tool(
-    location(description = "The city and state, e.g. San Francisco, CA"),
-    unit(description = "The temperature unit", enum_values = ["celsius", "fahrenheit"])
-)]
-fn get_weather(location: String, unit: Option<String>) -> String {
-    format!("The weather in {} is 22 degrees {}",
-        location,
-        unit.as_deref().unwrap_or("celsius"))
+/// Get the weather in a location
+#[tool(location(description = "City and state, e.g. San Francisco, CA"))]
+fn get_weather(location: String) -> String {
+    format!("Weather in {}: 72°F, sunny", location)
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let api_key = env::var("GEMINI_API_KEY")?;
-    let client = Client::builder(api_key).build();
+let result = client
+    .interaction()
+    .with_model("gemini-3-flash-preview")
+    .with_text("What's the weather in Tokyo?")
+    .with_function(GetWeatherCallable.declaration())
+    .create_with_auto_functions()
+    .await?;
 
-    // Get the function declaration from the generated callable
-    let weather_func = GetWeatherCallable.declaration();
-
-    // Use create_with_auto_functions() to automatically handle function calls
-    let result = client
-        .interaction()
-        .with_model("gemini-3-flash-preview")
-        .with_text("What's the weather in Tokyo?")
-        .with_function(weather_func)
-        .create_with_auto_functions()
-        .await?;
-
-    // The library automatically:
-    // 1. Sends the function declaration to the model
-    // 2. Executes the function when the model calls it
-    // 3. Sends results back to the model
-    // 4. Continues until the model provides a final response
-
-    // Access the final response and execution history
-    println!("{}", result.response.text().unwrap_or("No response"));
-
-    // You can also inspect which functions were called
-    for exec in &result.executions {
-        println!("Called {} -> {}", exec.name, exec.result);
-    }
-    Ok(())
-}
+println!("{}", result.response.text().unwrap());
 ```
 
-Key features of automatic function calling:
-- Functions are discovered at compile time using the `inventory` crate
-- Both sync and async functions are supported
-- The conversation loop handles multiple function calls automatically
-- Error handling is built-in - function errors are reported back to the model
-- Maximum of 5 conversation turns to prevent infinite loops
+#### Stateful with ToolService
 
-### Dependency Injection with ToolService
-
-For functions that need access to shared state (database connections, API clients, configuration), use the `ToolService` trait:
+For tools that need shared state (database pools, API clients, configuration):
 
 ```rust
-use rust_genai::{Client, CallableFunction, FunctionDeclaration, FunctionError, ToolService};
-use async_trait::async_trait;
-use serde_json::{json, Value};
-use std::sync::{Arc, RwLock};
+use rust_genai::{ToolService, CallableFunction};
 
-// A tool that reads from shared mutable state
-struct CalculatorTool {
-    precision: Arc<RwLock<u32>>,  // Shared config, can change at runtime
+struct MyService {
+    db: Arc<DatabasePool>,
 }
 
-#[async_trait]
-impl CallableFunction for CalculatorTool {
-    fn declaration(&self) -> FunctionDeclaration {
-        FunctionDeclaration::builder("calculate")
-            .description("Performs arithmetic calculations")
-            .parameter("expression", json!({"type": "string"}))
-            .required(vec!["expression".to_string()])
-            .build()
-    }
-
-    async fn call(&self, args: Value) -> Result<Value, FunctionError> {
-        let precision = *self.precision.read().unwrap();
-        Ok(json!({ "result": "42", "precision": precision }))
-    }
-}
-
-// Service that provides tools with shared dependencies
-struct MathService {
-    precision: Arc<RwLock<u32>>,
-}
-
-impl MathService {
-    fn new(precision: u32) -> Self {
-        Self { precision: Arc::new(RwLock::new(precision)) }
-    }
-
-    fn set_precision(&self, precision: u32) {
-        *self.precision.write().unwrap() = precision;
-    }
-}
-
-impl ToolService for MathService {
-    fn tools(&self) -> Vec<Arc<dyn CallableFunction>> {
-        vec![Arc::new(CalculatorTool { precision: self.precision.clone() })]
-    }
-}
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = Client::builder(std::env::var("GEMINI_API_KEY")?).build();
-
-    // Create a single service instance
-    let service = Arc::new(MathService::new(2));
-
-    // First request uses precision=2
-    let result1 = client.interaction()
-        .with_model("gemini-3-flash-preview")
-        .with_text("Calculate 2 + 2")
-        .with_tool_service(service.clone())  // Clone the Arc
-        .create_with_auto_functions()
-        .await?;
-
-    // Change precision on the SAME service instance
-    service.set_precision(8);
-
-    // Second request uses precision=8
-    let result2 = client.interaction()
-        .with_model("gemini-3-flash-preview")
-        .with_text("Calculate 3 * 3")
-        .with_tool_service(service.clone())  // Same service
-        .create_with_auto_functions()
-        .await?;
-
-    Ok(())
-}
-```
-
-#### Choosing Your Approach
-
-| Approach | Registration | Execution | State | Best For |
-|----------|-------------|-----------|-------|----------|
-| `#[tool]` macro | Compile-time (global) | Auto | Stateless | Simple tools, clean code |
-| `ToolService` | Runtime (per-request) | Auto | Stateful | DB connections, API clients |
-| `FunctionDeclaration::builder()` | Manual | Manual | Flexible | Dynamic schemas, full control |
-
-**Use `#[tool]` macro** when you have simple, stateless functions:
-```rust
-#[tool]
-fn get_weather(city: String) -> String {
-    format!("Weather in {}", city)  // No external dependencies
-}
-```
-
-**Use `ToolService`** when you need shared state or dependency injection:
-```rust
 impl ToolService for MyService {
     fn tools(&self) -> Vec<Arc<dyn CallableFunction>> {
-        vec![Arc::new(DbQueryTool { pool: self.db_pool.clone() })]
+        vec![Arc::new(DbQueryTool { pool: self.db.clone() })]
     }
 }
+
+let service = Arc::new(MyService { db });
+let result = client.interaction()
+    .with_tool_service(service)
+    .create_with_auto_functions()
+    .await?;
 ```
 
-**Use manual handling** when you need full control over execution:
-- Custom rate limiting, caching, or circuit breakers
-- Complex error recovery logic
-- Integration with external systems requiring special handling
-- Logging, metrics, or tracing around each function call
-
-Key benefits of `ToolService`:
-- **Shared mutable state**: Use `Arc<RwLock<T>>` for config that changes at runtime
-- **Dependency injection**: Tools access databases, API clients, feature flags
-- **Same instance across requests**: Reuse connections, share caches
-- **Override global functions**: Service functions shadow same-named `#[tool]` functions
-- **Works with streaming**: Compatible with `create_stream_with_auto_functions()`
-
-### Using the Procedural Macro
-
-The `#[tool]` macro provides an ergonomic way to create function declarations:
-
-```rust
-use rust_genai_macros::tool;
-
-/// Function to get the weather in a given location
-#[tool(
-    location(description = "The city and state, e.g. San Francisco, CA"),
-    unit(description = "The temperature unit to use", enum_values = ["celsius", "fahrenheit"])
-)]
-fn get_weather(location: String, unit: Option<String>) -> String {
-    format!("Weather for {}", location)
-}
-
-// The macro generates:
-// - A `get_weather_declaration()` function returning FunctionDeclaration
-// - A `GetWeatherCallable` struct implementing CallableFunction
-// - Automatic registration in the global function registry
-```
-
-The macro supports:
-- Automatic extraction of function doc comments as descriptions
-- Parameter descriptions via the macro attribute
-- Enum constraints for parameters with fixed values
-- Proper handling of optional parameters (Option<T>)
-- Type mapping for common Rust types (String, i32, i64, f32, f64, bool, Vec<T>, serde_json::Value)
+See `examples/tool_service.rs` for a complete example.
 
 ### Built-in Tools
 
-The library supports Gemini's built-in tools for enhanced capabilities:
-
 ```rust
-// Google Search grounding - real-time web search
-let response = client
-    .interaction()
-    .with_model("gemini-3-flash-preview")
+// Google Search grounding
+let response = client.interaction()
     .with_google_search()
     .with_text("What are today's top news stories?")
-    .create()
-    .await?;
+    .create().await?;
 
-// Access grounding metadata
-if let Some(metadata) = response.google_search_metadata() {
-    for chunk in &metadata.grounding_chunks {
-        println!("Source: {:?}", chunk.web);
-    }
-}
-
-// Code execution - run Python in a sandbox
-let response = client
-    .interaction()
-    .with_model("gemini-3-flash-preview")
+// Code execution (Python sandbox)
+let response = client.interaction()
     .with_code_execution()
     .with_text("Calculate the first 10 Fibonacci numbers")
-    .create()
-    .await?;
+    .create().await?;
 
-// Get successful output
-if let Some(output) = response.successful_code_output() {
-    println!("Result: {}", output);
-}
-
-// URL context - fetch and analyze web content
-let response = client
-    .interaction()
-    .with_model("gemini-3-flash-preview")
+// URL context
+let response = client.interaction()
     .with_url_context()
     .with_text("Summarize https://example.com")
-    .create()
-    .await?;
+    .create().await?;
 ```
 
 ### Thinking Mode
 
-Enable reasoning/thinking for complex problem-solving:
-
 ```rust
 use rust_genai::ThinkingLevel;
 
-let response = client
-    .interaction()
-    .with_model("gemini-3-flash-preview")
+let response = client.interaction()
     .with_thinking_level(ThinkingLevel::Medium)
-    .with_text("Solve this step by step: If a train travels 120 km in 2 hours...")
-    .create()
-    .await?;
+    .with_text("Solve step by step: If a train travels 120 km in 2 hours...")
+    .create().await?;
 
-// Access the model's reasoning process
 for thought in response.thoughts() {
     println!("Thinking: {}", thought);
 }
-
-// Get the final answer
-println!("Answer: {}", response.text().unwrap_or(""));
+println!("Answer: {}", response.text().unwrap());
 ```
 
 ### Multimodal Input
 
-Send images, audio, video, and documents to the model for analysis:
-
 ```rust
-use rust_genai::Client;
-use std::env;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let api_key = env::var("GEMINI_API_KEY")?;
-    let client = Client::builder(api_key).build();
-
-    // Method 1: Fluent builder pattern (recommended)
-    let response = client
-        .interaction()
-        .with_model("gemini-3-flash-preview")
-        .with_text("What's in this image?")
-        .add_image_file("photo.jpg").await?  // Auto-detects MIME type
-        .create()
-        .await?;
-
-    println!("{}", response.text().unwrap_or("No response"));
-
-    // Add multiple media files
-    let response = client
-        .interaction()
-        .with_model("gemini-3-flash-preview")
-        .with_text("Compare these two images")
-        .add_image_file("photo1.jpg").await?
-        .add_image_file("photo2.png").await?
-        .create()
-        .await?;
-
-    // Use base64 data directly
-    let response = client
-        .interaction()
-        .with_model("gemini-3-flash-preview")
-        .with_text("Describe this image")
-        .add_image_data(base64_encoded_image, "image/jpeg")
-        .create()
-        .await?;
-
-    Ok(())
-}
-```
-
-All media types use the same pattern:
-- **Images**: `add_image_file()`, `add_image_data()`, `add_image_uri()`
-- **Audio**: `add_audio_file()`, `add_audio_data()`, `add_audio_uri()`
-- **Video**: `add_video_file()`, `add_video_data()`, `add_video_uri()`
-- **Documents**: `add_document_file()`, `add_document_data()`, `add_document_uri()`
-
-For programmatic content building, use the helper functions:
-
-```rust
-use rust_genai::{image_from_file, text_content};
-
-// Load files with automatic MIME detection
-let image = image_from_file("photo.jpg").await?;
-
-let contents = vec![
-    text_content("Analyze this image"),
-    image,
-];
-
-let response = client
-    .interaction()
+// Add images, audio, video, or documents
+let response = client.interaction()
     .with_model("gemini-3-flash-preview")
-    .with_content(contents)
-    .create()
-    .await?;
+    .with_text("What's in this image?")
+    .add_image_file("photo.jpg").await?
+    .create().await?;
 ```
 
-## API Reference
-
-### Client Builder
-
-```rust
-// Create a client with API key
-let client = Client::builder(api_key).build();
-```
-
-For debug logging, see the [Logging](#logging) section below.
-
-### InteractionBuilder Methods
-
-The `InteractionBuilder` provides a fluent API for constructing requests:
-
-```rust
-client
-    .interaction()                              // Start building an interaction
-    .with_model("model-name")                   // Set the model (required unless using agent)
-    .with_agent("agent-name")                   // Use an agent instead of model
-    .with_text("prompt")                        // Set input as simple text
-    .with_input(InteractionInput::...)          // Set complex input
-    .with_content(vec![...])                    // Set content array directly
-    .with_system_instruction("instruction")     // Set system instruction
-    .with_previous_interaction("id")            // Link to previous interaction
-    .with_function(func_decl)                   // Add a function declaration
-    .with_functions(vec![...])                  // Add multiple function declarations
-    .with_tool_service(service)                 // Inject dependency-providing service
-    .with_google_search()                       // Enable Google Search grounding
-    .with_code_execution()                      // Enable Python code execution
-    .with_url_context()                         // Enable URL content fetching
-    .with_thinking_level(ThinkingLevel::Medium) // Enable reasoning mode
-    .with_generation_config(config)             // Set generation parameters
-    .with_response_modalities(vec![...])        // Set response modalities
-    .with_response_format(schema)               // Set JSON schema for output
-    .with_store_enabled()                           // Whether to store the interaction
-    .with_background(false)                     // Run in background mode
-    // Multimodal content (accumulate, don't replace)
-    .add_image_file("path").await?              // Add image from file
-    .add_image_data(base64, "image/png")        // Add image from base64
-    .add_image_uri(uri, "image/jpeg")           // Add image from URI
-    .add_audio_file("path").await?              // Add audio from file
-    .add_video_file("path").await?              // Add video from file
-    .add_document_file("path").await?           // Add document from file
-    // Execute
-    .create()                                   // Execute and get response
-    .create_stream()                            // Get streaming response
-    .create_with_auto_functions()               // Execute with auto function calling
-```
-
-### Response Types
-
-```rust
-// InteractionResponse provides convenience methods
-impl InteractionResponse {
-    // Text content
-    fn text(&self) -> Option<&str>;             // Get first text output
-    fn all_text(&self) -> String;               // Concatenate all text outputs
-    fn has_text(&self) -> bool;
-
-    // Function calling
-    fn function_calls(&self) -> Vec<FunctionCallInfo>;
-    fn function_results(&self) -> Vec<FunctionResultInfo>;
-    fn has_function_calls(&self) -> bool;
-    fn has_function_results(&self) -> bool;
-
-    // Thinking/reasoning
-    fn thoughts(&self) -> impl Iterator<Item = &str>;
-    fn has_thoughts(&self) -> bool;
-
-    // Built-in tools
-    fn google_search_metadata(&self) -> Option<&GroundingMetadata>;
-    fn code_execution_results(&self) -> Vec<(CodeExecutionOutcome, &str)>;
-    fn url_context_metadata(&self) -> Option<&UrlContextMetadata>;
-}
-
-// Function call/result info structs with named fields
-pub struct FunctionCallInfo<'a> {
-    pub id: Option<&'a str>,                // Call ID for sending results back
-    pub name: &'a str,                      // Function name
-    pub args: &'a Value,                    // Function arguments
-    pub thought_signature: Option<&'a str>, // For reasoning continuity
-}
-
-pub struct FunctionResultInfo<'a> {
-    pub name: &'a str,                      // Function name
-    pub call_id: &'a str,                   // Matches the call's ID
-    pub result: &'a Value,                  // Function result
-}
-```
-
-### Advanced: Function Registry and CallableFunction Trait
-
-For advanced users who want to implement custom function handling:
-
-```rust
-use rust_genai::{CallableFunction, FunctionError, FunctionDeclaration};
-use async_trait::async_trait;
-
-pub struct MyFunction;
-
-#[async_trait]
-impl CallableFunction for MyFunction {
-    fn declaration(&self) -> FunctionDeclaration {
-        // Return function declaration
-    }
-
-    async fn call(&self, args: serde_json::Value) -> Result<serde_json::Value, FunctionError> {
-        // Implement function logic
-    }
-}
-
-// Functions marked with #[tool] are automatically registered in a global
-// registry and discovered by create_with_auto_functions()
-```
+All media types follow the same pattern: `add_*_file()`, `add_*_data()`, `add_*_uri()`.
 
 ## Logging
 
-The library uses the standard Rust `log` crate for structured logging. To see debug output, initialize a logging backend in your application:
-
-```toml
-# Add to your Cargo.toml
-[dependencies]
-env_logger = "0.11"  # or simplelog, tracing-subscriber, etc.
-```
-
-```rust
-// Initialize logging in your application
-fn main() {
-    env_logger::init();
-    // ... your code
-}
-```
-
-Control log levels via the `RUST_LOG` environment variable:
+Enable debug logging:
 
 ```bash
-# Show all debug logs from rust-genai
-RUST_LOG=rust_genai=debug cargo run
-
-# Show only warnings and errors
-RUST_LOG=rust_genai=warn cargo run
+RUST_LOG=rust_genai=debug cargo run --example simple_interaction
 ```
 
-The library logs request/response details, streaming events, and interaction lifecycle at the `debug` level.
-
-### Wire-Level Debugging
-
-For quick debugging of raw API traffic without configuring a logging backend, use the `LOUD_WIRE` environment variable:
+For wire-level API debugging without configuring a logging backend:
 
 ```bash
 LOUD_WIRE=1 cargo run --example simple_interaction
 ```
 
-This prints pretty-formatted JSON of all API requests and responses to stderr with:
-- Color-coded output (green for requests, red for responses, blue for SSE chunks)
-- Request IDs for correlating requests with responses
-- Automatic truncation of base64 data fields
-- Timestamps for timing analysis
-
-See [docs/LOGGING_STRATEGY.md](docs/LOGGING_STRATEGY.md) for a detailed comparison of `RUST_LOG` vs `LOUD_WIRE`.
+See [`docs/LOGGING_STRATEGY.md`](docs/LOGGING_STRATEGY.md) for details on log levels and `LOUD_WIRE` output.
 
 ## Project Structure
 
-The project consists of three main components:
-
-1. **Public API Crate (`rust-genai`)**:
-   - Provides a user-friendly interface in `src/lib.rs`
-   - Handles high-level error representation and client creation
-   - Contains the `InteractionBuilder` for fluent API construction
-
-2. **Internal Client (`genai-client/`)**:
-   - Contains the low-level implementation for API communication
-   - Defines the JSON serialization/deserialization models
-   - Handles the actual HTTP requests and response parsing
-
-3. **Macro Crate (`rust-genai-macros/`)**:
-   - Procedural macro for `#[tool]`
-   - Automatic function registration via `inventory` crate
-
-Users of the `rust-genai` crate typically do not need to interact with `genai-client` directly, as its functionalities are exposed through the main `rust-genai` API.
+- **`rust-genai`** (root): Public API crate with `Client` and `InteractionBuilder`
+- **`genai-client/`**: Internal HTTP client, JSON models, SSE streaming
+- **`rust-genai-macros/`**: Procedural macro for `#[tool]`
 
 ## Forward Compatibility
 
-This library follows the [Evergreen spec](https://github.com/google-deepmind/evergreen-spec) philosophy for graceful API evolution:
-
-- **Unknown types are preserved, not rejected**: When the API returns content types this library doesn't recognize yet, they're captured in `Unknown` variants rather than causing deserialization errors.
-- **Non-exhaustive enums**: Key types like `InteractionContent` and `Tool` use `#[non_exhaustive]`, so your match statements should include wildcard arms.
-- **Roundtrip preservation**: Unknown content can be serialized back without data loss - the `Unknown` variants store both the type name and full JSON data.
+This library follows the [Evergreen spec](https://github.com/google-deepmind/evergreen-spec) philosophy: unknown API types deserialize into `Unknown` variants instead of failing. Always include wildcard arms in match statements:
 
 ```rust
-// Handle unknown content gracefully
-for output in response.outputs {
-    match output {
-        InteractionContent::Text { text } => println!("{}", text.unwrap_or_default()),
-        InteractionContent::Unknown { content_type, data } => {
-            log::warn!("Unknown content type '{}': {:?}", content_type, data);
-        }
-        _ => {} // Future variants
-    }
+match output {
+    InteractionContent::Text { text } => println!("{}", text.unwrap_or_default()),
+    _ => {}  // Handle unknown future variants
 }
 ```
-
-**Design principle**: All `Unknown` variants use a data-preserving pattern with `<context>_type: String` and `data: serde_json::Value` fields. This ensures you can always inspect what the API sent and roundtrip serialize it. Helper methods like `is_unknown()`, `unknown_content_type()`, and `unknown_data()` provide convenient access. See [CLAUDE.md](CLAUDE.md) for implementation details.
-
-For strict validation during development, enable the `strict-unknown` feature flag - unknown types will error instead of being captured.
 
 ## Error Handling
 
-The library provides comprehensive error handling with two main error types:
+Two main error types:
 
-### GenaiError
-
-The main error type for API interactions:
-
-- `Http`: Network-related errors
-- `Parse`: Issues parsing the response
-- `Json`: JSON deserialization errors
-- `Utf8`: Text encoding errors
-- `Api`: Errors returned by the Google API
-- `Internal`: Other internal errors
-- `InvalidInput`: Validation errors (missing model, missing input, etc.)
-
-### FunctionError
-
-Specific to function calling:
-
-- `ArgumentMismatch`: When function arguments don't match the expected schema
-- `ExecutionError`: When a function fails during execution
-
-```rust
-use rust_genai::FunctionError;
-
-// Example of handling function errors
-match result {
-    Err(FunctionError::ArgumentMismatch(msg)) => {
-        eprintln!("Invalid arguments: {}", msg);
-    }
-    Err(FunctionError::ExecutionError(msg)) => {
-        eprintln!("Function failed: {}", msg);
-    }
-    Ok(value) => {
-        // Process result
-    }
-}
-```
+- **`GenaiError`**: API/network errors (Http, Parse, Json, Api, InvalidInput)
+- **`FunctionError`**: Function calling errors (ArgumentMismatch, ExecutionError)
 
 ## Troubleshooting
 
-### Common Issues
+- **"API key not valid"**: Verify `GEMINI_API_KEY` is set correctly
+- **"Model not found"**: Use valid model name (e.g., `gemini-3-flash-preview`)
+- **Functions not executing**: Use `create_with_auto_functions()` for automatic execution
+- **Image URL blocked**: Use Google Cloud Storage URLs or base64-encoded images
 
-**"API key not valid" error**
-- Ensure `GEMINI_API_KEY` environment variable is set correctly
-- Verify your API key has access to the Gemini models at [Google AI Studio](https://ai.dev/)
+## Testing
 
-**"Model not found" error**
-- Check that you're using a valid model name (e.g., `gemini-3-flash-preview`)
-- Some models may require specific API access or be in preview
+```bash
+cargo test -- --include-ignored  # Full test suite (requires GEMINI_API_KEY)
+cargo test                       # Unit tests only
+```
 
-**Function calls not being executed**
-- Ensure you're using `create_with_auto_functions()` for automatic execution
-- For manual execution, check that you're sending the `FunctionResult` back correctly
-- Verify your function is registered via `#[tool]`
-
-**Image URL not accessible**
-- The API blocks most public HTTP URLs for security
-- Use Google Cloud Storage URLs (`gs://...`) or base64-encoded images
-- See `image_data_content()` for base64 encoding
-
-**Rate limiting errors**
-- The free tier has request limits; wait and retry
-- Consider adding delays between requests in batch operations
+See [CLAUDE.md](CLAUDE.md) for test assertion strategies and development guidelines.
 
 ## License
 
 MIT License - see [LICENSE](LICENSE) for details.
 
-## Testing
-
-### Running Tests
-
-```bash
-# Run all tests (requires GEMINI_API_KEY)
-cargo test -- --include-ignored
-
-# Run specific test file
-cargo test --test interactions_api_tests -- --include-ignored
-
-# Run with output visible
-cargo test -- --include-ignored --nocapture
-```
-
-### Writing Integration Tests
-
-When writing integration tests for LLM interactions, use the appropriate assertion strategy:
-
-**Structural Assertions** (default):
-```rust
-// ✅ Good: Verify structure and mechanics
-assert!(response.has_text());
-assert!(!response.text().unwrap().is_empty());
-assert_eq!(response.status, InteractionStatus::Completed);
-```
-
-**Semantic Validation** (for behavioral tests):
-```rust
-// ✅ Good: Validate meaning using Gemini as a judge
-use common::validate_response_semantically;
-
-let is_valid = validate_response_semantically(
-    &client,
-    "User asked about weather in Tokyo",
-    response.text().unwrap(),
-    "Does this response provide weather information?"
-).await?;
-assert!(is_valid);
-```
-
-**Brittle Content Assertions** (avoid):
-```rust
-// ❌ Bad: LLM outputs vary, causes flaky tests
-assert!(text.contains("sunny"));  // Don't do this
-assert!(text.contains("umbrella") || text.contains("rain"));  // Still brittle
-```
-
-For more details, see the "Test Assertion Strategies" section in [CLAUDE.md](CLAUDE.md).
-
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-For development guidelines and testing patterns, see [CLAUDE.md](CLAUDE.md).
+Contributions welcome! See [CLAUDE.md](CLAUDE.md) for development guidelines.

--- a/examples/real_world/README.md
+++ b/examples/real_world/README.md
@@ -9,6 +9,7 @@ This directory contains comprehensive example applications demonstrating practic
 | [RAG System](./rag_system/) | Document Q&A with retrieval | Context injection, source attribution |
 | [Multi-Turn Agent (Auto)](./multi_turn_agent_auto/) | Customer support bot | `create_with_auto_functions()`, stateful conversations |
 | [Multi-Turn Agent (Manual)](./multi_turn_agent_manual/) | Customer support bot | Manual function loop, full control |
+| [Multi-Turn Agent (Stateless)](./multi_turn_agent_manual_stateless/) | Customer support bot | `store: false`, manual history |
 | [Code Assistant](./code_assistant/) | Code analysis tool | Structured output, multi-task analysis |
 | [Data Analysis](./data_analysis/) | CSV analysis with NL queries | Function calling, data operations |
 | [Web Scraper Agent](./web_scraper_agent/) | Web research assistant | Google Search grounding, streaming |
@@ -28,6 +29,7 @@ Run any example with:
 cargo run --example rag_system
 cargo run --example multi_turn_agent_auto
 cargo run --example multi_turn_agent_manual
+cargo run --example multi_turn_agent_manual_stateless
 cargo run --example code_assistant
 cargo run --example data_analysis
 cargo run --example web_scraper_agent
@@ -47,10 +49,10 @@ cargo run --example testing_assistant
 
 | Feature | Examples |
 |---------|----------|
-| Function Calling | Multi-Turn Agent, Data Analysis |
+| Function Calling | Multi-Turn Agent (all variants), Data Analysis |
 | Structured Output | Code Assistant, Testing Assistant |
 | Google Search Grounding | Web Scraper Agent |
-| Auto Function Execution | Multi-Turn Agent, Data Analysis |
+| Auto Function Execution | Multi-Turn Agent (Auto), Data Analysis |
 | System Instructions | All examples |
 
 ### Production Patterns
@@ -103,6 +105,18 @@ Same bot with manual control over function execution:
 let response = client.interaction()
     .with_previous_interaction(&last_id)
     .with_content(function_results)
+    .create().await?;
+```
+
+### Multi-Turn Agent (Stateless)
+
+Stateless conversations with client-side history management:
+
+```rust
+// No server state - maintain history locally
+let response = client.interaction()
+    .with_input(InteractionInput::Content(history.clone()))
+    .with_store_disabled()  // No previous_interaction_id
     .create().await?;
 ```
 

--- a/examples/real_world/multi_turn_agent_manual_stateless/README.md
+++ b/examples/real_world/multi_turn_agent_manual_stateless/README.md
@@ -1,0 +1,77 @@
+# Multi-Turn Agent (Manual + Stateless)
+
+Customer support agent demonstrating **stateless** multi-turn conversations with manual function calling.
+
+## Key Concept
+
+When `store: false`, the server keeps no conversation state. You must:
+- Manually build and maintain conversation history
+- Send full history with each request
+- Cannot use `previous_interaction_id`
+
+## Stateful vs Stateless
+
+| Aspect | Stateful (`store: true`) | Stateless (`store: false`) |
+|--------|--------------------------|----------------------------|
+| Server state | Yes | No |
+| `previous_interaction_id` | Available | Cannot use |
+| History management | Automatic | Manual |
+| Auto functions | Available | Blocked at compile time |
+
+## When to Use Stateless
+
+- **Privacy**: No server-side conversation storage
+- **Custom persistence**: Store conversations in your own database
+- **History modification**: Filter or transform history between turns
+- **Testing**: Full control for reproducible test scenarios
+
+## Running
+
+```bash
+export GEMINI_API_KEY=your_key
+cargo run --example multi_turn_agent_manual_stateless
+
+# With wire debugging
+LOUD_WIRE=1 cargo run --example multi_turn_agent_manual_stateless
+```
+
+## Core Pattern
+
+```rust
+struct StatelessSession {
+    client: Client,
+    conversation_history: Vec<InteractionContent>,  // Manual history
+}
+
+impl StatelessSession {
+    async fn process_message(&mut self, message: &str) -> Result<String> {
+        // Add user message to history
+        self.conversation_history.push(text_content(message));
+
+        // Send FULL history each time
+        let response = self.client.interaction()
+            .with_input(InteractionInput::Content(self.conversation_history.clone()))
+            .with_store_disabled()  // <-- Key difference
+            .create()
+            .await?;
+
+        // Manual function loop, add results to history...
+
+        // Add final response to history
+        self.conversation_history.push(text_content(response.text()));
+        Ok(response.text().to_string())
+    }
+}
+```
+
+## Comparison with Other Examples
+
+| Example | State | Functions | Best For |
+|---------|-------|-----------|----------|
+| `multi_turn_agent_auto` | Server | Automatic | Quick prototyping |
+| `multi_turn_agent_manual` | Server | Manual | Custom execution logic |
+| `multi_turn_agent_manual_stateless` | Client | Manual | Privacy, custom storage |
+
+## See Also
+
+- [Multi-Turn Function Calling Guide](../../../docs/MULTI_TURN_FUNCTION_CALLING.md)


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: 515 → 189 lines (63% reduction) - Remove verbose examples, consolidate patterns into tables, point to docs/
- **README.md**: 1029 → 297 lines (71% reduction) - Streamline to essential patterns, remove redundant API reference
- **examples/real_world/**: Add missing `multi_turn_agent_manual_stateless` documentation

## Test plan

- [ ] Verify documentation renders correctly on GitHub
- [ ] Verify all internal links work
- [ ] Verify examples still compile: `cargo check --examples`

🤖 Generated with [Claude Code](https://claude.com/claude-code)