### PR TITLE
docs: Fix path and test file references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ See `examples/` for full list (multimodal, thinking, files API, image generation
 
 ### Layered Design
 
-1. **Public API** (`src/lib.rs`, `src/client.rs`, `src/request_builder.rs`): User-facing `Client`, `InteractionBuilder`
+1. **Public API** (`src/lib.rs`, `src/client.rs`, `src/request_builder/`): User-facing `Client`, `InteractionBuilder`
 2. **Internal Logic** (`src/function_calling.rs`, `src/interactions_api.rs`, `src/multimodal.rs`): Function registry, content builders
 3. **HTTP Client** (`genai-client/`): Raw API requests, JSON models, SSE streaming
 4. **Macros** (`rust-genai-macros/`): `#[tool]` macro with `inventory` registration

--- a/docs/MULTI_TURN_FUNCTION_CALLING.md
+++ b/docs/MULTI_TURN_FUNCTION_CALLING.md
@@ -470,10 +470,10 @@ Thought signatures are cryptographic proofs that the model's thinking wasn't mod
 
 **For standard function calling, you can ignore thought signatures entirely.** They're just metadata on the response - you don't need to capture, store, or return them.
 
-> **Verified behavior**: See `tests/thinking_function_tests.rs` for comprehensive tests covering:
-> - `test_thought_signature_parallel_only_first` - Only first parallel call has signature
-> - `test_thought_signature_sequential_each_step` - Each sequential call has its own signature
-> - `test_function_calling_without_thinking` - No signatures without thinking mode
+> **Verified behavior**: See tests covering thought signatures:
+> - `test_thought_signature_parallel_only_first` in `tests/advanced_function_calling_tests.rs` - Only first parallel call has signature
+> - `test_thought_signature_sequential_each_step` in `tests/advanced_function_calling_tests.rs` - Each sequential call has its own signature
+> - `test_function_calling_without_thinking` in `tests/thinking_function_tests.rs` - No signatures without thinking mode
 > - `test_thought_echo_manual_history` in `tests/interactions_api_tests.rs` - Echoing thoughts
 
 ## Design Patterns


### PR DESCRIPTION
## Summary
- Fix `CLAUDE.md`: `src/request_builder.rs` → `src/request_builder/` (it's a directory)
- Fix `docs/MULTI_TURN_FUNCTION_CALLING.md`: Correct test file locations for thought signature tests

Found via `audit-docs` agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)