### PR TITLE
docs: Use gemini-2.5-pro-preview-tts for TTS model convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ GitHub Actions runs: check, test, test-strict-unknown, test-integration (4 matri
 
 ## Project Conventions
 
-- **Model name**: Always use `gemini-3-flash-preview` (exception: `gemini-3-pro-image-preview` for image generation)
+- **Model name**: Always use `gemini-3-flash-preview` (exceptions: `gemini-3-pro-image-preview` for image generation, `gemini-2.5-pro-preview-tts` for text-to-speech)
 
 ### Naming Conventions
 

--- a/docs/ENUM_WIRE_FORMATS.md
+++ b/docs/ENUM_WIRE_FORMATS.md
@@ -219,7 +219,7 @@ Used in `generationConfig.speechConfig` for text-to-speech audio output.
 
 ```json
 {
-  "model": "gemini-2.5-flash-preview-tts",
+  "model": "gemini-2.5-pro-preview-tts",
   "input": "Hello, world!",
   "generationConfig": {
     "responseModalities": ["AUDIO"],

--- a/examples/text_to_speech.rs
+++ b/examples/text_to_speech.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let client = Client::builder(api_key).build()?;
 
     // TTS model - use the appropriate model for text-to-speech
-    let model_name = "gemini-2.5-flash-preview-tts";
+    let model_name = "gemini-2.5-pro-preview-tts";
 
     // =========================================================================
     // Example 1: Basic Text-to-Speech
@@ -133,7 +133,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         r#"
    let response = client
        .interaction()
-       .with_model("gemini-2.5-flash-preview-tts")
+       .with_model("gemini-2.5-pro-preview-tts")
        .with_text("Your text here")
        .with_audio_output()
        .with_voice("Kore")
@@ -157,7 +157,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
    let response = client
        .interaction()
-       .with_model("gemini-2.5-flash-preview-tts")
+       .with_model("gemini-2.5-pro-preview-tts")
        .with_text("Your text here")
        .with_audio_output()
        .with_speech_config(config)
@@ -188,7 +188,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("  [RES#1] completed: audio content with base64 data\n");
 
     println!("--- Production Considerations ---");
-    println!("  - Use appropriate TTS model (gemini-2.5-flash-preview-tts)");
+    println!("  - Use appropriate TTS model (gemini-2.5-pro-preview-tts)");
     println!("  - Voice selection affects tone and style");
     println!("  - Language setting should match content language");
     println!("  - Audio is returned as base64-encoded data");

--- a/src/request_builder/mod.rs
+++ b/src/request_builder/mod.rs
@@ -1703,7 +1703,7 @@ impl<'a, State: Send + 'a> InteractionBuilder<'a, State> {
     /// ```
     ///
     /// Use this when you want the model to generate speech audio. Requires a model
-    /// that supports text-to-speech (e.g., `gemini-2.5-flash-preview-tts`).
+    /// that supports text-to-speech (e.g., `gemini-2.5-pro-preview-tts`).
     ///
     /// For voice customization, chain with [`with_speech_config`](Self::with_speech_config)
     /// or [`with_voice`](Self::with_voice).
@@ -1719,7 +1719,7 @@ impl<'a, State: Send + 'a> InteractionBuilder<'a, State> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-2.5-flash-preview-tts")
+    ///     .with_model("gemini-2.5-pro-preview-tts")
     ///     .with_text("Hello, world! Welcome to text-to-speech.")
     ///     .with_audio_output()
     ///     .with_voice("Kore")
@@ -1761,7 +1761,7 @@ impl<'a, State: Send + 'a> InteractionBuilder<'a, State> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-2.5-flash-preview-tts")
+    ///     .with_model("gemini-2.5-pro-preview-tts")
     ///     .with_text("Hello from Puck!")
     ///     .with_audio_output()
     ///     .with_speech_config(config)
@@ -1798,7 +1798,7 @@ impl<'a, State: Send + 'a> InteractionBuilder<'a, State> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-2.5-flash-preview-tts")
+    ///     .with_model("gemini-2.5-pro-preview-tts")
     ///     .with_text("Hello, world!")
     ///     .with_audio_output()
     ///     .with_voice("Kore")

--- a/src/response.rs
+++ b/src/response.rs
@@ -581,7 +581,7 @@ impl ImageInfo<'_> {
 ///
 /// let response = client
 ///     .interaction()
-///     .with_model("gemini-2.5-flash-preview-tts")
+///     .with_model("gemini-2.5-pro-preview-tts")
 ///     .with_text("Hello, world!")
 ///     .with_audio_output()
 ///     .with_voice("Kore")
@@ -1186,7 +1186,7 @@ impl InteractionResponse {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-2.5-flash-preview-tts")
+    ///     .with_model("gemini-2.5-pro-preview-tts")
     ///     .with_text("Hello, world!")
     ///     .with_audio_output()
     ///     .with_voice("Kore")
@@ -1221,7 +1221,7 @@ impl InteractionResponse {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-2.5-flash-preview-tts")
+    ///     .with_model("gemini-2.5-pro-preview-tts")
     ///     .with_text("Generate multiple audio segments")
     ///     .with_audio_output()
     ///     .create()
@@ -1263,7 +1263,7 @@ impl InteractionResponse {
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("api-key".to_string());
-    /// # let response = client.interaction().with_model("gemini-2.5-flash-preview-tts")
+    /// # let response = client.interaction().with_model("gemini-2.5-pro-preview-tts")
     /// #     .with_text("Hello").with_audio_output().create().await?;
     /// if response.has_audio() {
     ///     for audio in response.audios() {

--- a/src/response_tests.rs
+++ b/src/response_tests.rs
@@ -2825,7 +2825,7 @@ fn test_images_iterator_empty_outputs() {
 fn test_audios_iterator_returns_only_audios_with_data() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-2.5-flash-preview-tts".to_string()),
+        model: Some("gemini-2.5-pro-preview-tts".to_string()),
         agent: None,
         input: vec![],
         outputs: vec![
@@ -2909,7 +2909,7 @@ fn test_audios_iterator_empty_when_no_audios() {
 fn test_audios_iterator_empty_outputs() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-2.5-flash-preview-tts".to_string()),
+        model: Some("gemini-2.5-pro-preview-tts".to_string()),
         agent: None,
         input: vec![],
         outputs: vec![],
@@ -2931,7 +2931,7 @@ fn test_audios_iterator_empty_outputs() {
 fn test_first_audio() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-2.5-flash-preview-tts".to_string()),
+        model: Some("gemini-2.5-pro-preview-tts".to_string()),
         agent: None,
         input: vec![],
         outputs: vec![
@@ -2995,7 +2995,7 @@ fn test_first_audio_none_when_empty() {
 fn test_has_audio_true() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-2.5-flash-preview-tts".to_string()),
+        model: Some("gemini-2.5-pro-preview-tts".to_string()),
         agent: None,
         input: vec![],
         outputs: vec![InteractionContent::Audio {
@@ -3046,7 +3046,7 @@ fn test_has_audio_false_when_uri_only() {
     // since the audios() iterator only includes data-based audio
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-2.5-flash-preview-tts".to_string()),
+        model: Some("gemini-2.5-pro-preview-tts".to_string()),
         agent: None,
         input: vec![],
         outputs: vec![InteractionContent::Audio {

--- a/tests/multimodal_tests.rs
+++ b/tests/multimodal_tests.rs
@@ -1131,7 +1131,7 @@ async fn test_text_to_speech_basic() {
     };
 
     // TTS requires a specific model
-    let tts_model = "gemini-2.5-flash-preview-tts";
+    let tts_model = "gemini-2.5-pro-preview-tts";
 
     // TTS can be slow - use extended timeout
     with_timeout(EXTENDED_TEST_TIMEOUT, async {
@@ -1177,7 +1177,7 @@ async fn test_text_to_speech_with_speech_config() {
         return;
     };
 
-    let tts_model = "gemini-2.5-flash-preview-tts";
+    let tts_model = "gemini-2.5-pro-preview-tts";
 
     // TTS can be slow - use extended timeout
     with_timeout(EXTENDED_TEST_TIMEOUT, async {


### PR DESCRIPTION
## Summary
- Update TTS model convention to use `gemini-2.5-pro-preview-tts` (pro variant)
- Update all code references from flash to pro TTS model

## Changes
- `CLAUDE.md`: Add TTS model exception to model naming convention
- `docs/ENUM_WIRE_FORMATS.md`: Update wire format example
- `examples/text_to_speech.rs`: Update example to use pro model
- `src/request_builder/mod.rs`: Update doc comments
- `src/response.rs`: Update doc comments
- `src/response_tests.rs`: Update test fixtures
- `tests/multimodal_tests.rs`: Update integration tests

## Rationale
Google's documentation recommends the pro variant for text-to-speech.

🤖 Generated with [Claude Code](https://claude.com/claude-code)