### PR TITLE
fix: Add version to genai-rs-macros path dependency for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ keywords = ["gemini", "google", "ai", "llm", "genai"]
 categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
-genai-rs-macros = { path = "./genai-rs-macros" }
+genai-rs-macros = { version = "0.4.0", path = "./genai-rs-macros" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }


### PR DESCRIPTION
## Summary
- Adds version requirement to `genai-rs-macros` path dependency
- Required for `cargo publish` to work correctly

## Context
The initial publish of `genai-rs-macros` succeeded, but `genai-rs` failed because path dependencies need a version when publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)