### PR TITLE
docs: Complete genai-rs rename and README overhaul

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ See `docs/LOGGING_STRATEGY.md`. Key points:
 
 ## Technical Notes
 
-- Rust edition 2024 (requires Rust 1.85+)
+- Rust edition 2024 (requires Rust 1.88+)
 - Uses `rustls-tls` (not native TLS)
 - Tokio async runtime
 - API version: Gemini V1Beta (configured in `src/http/common.rs`)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 rust-genai contributors
+Copyright (c) 2024 genai-rs contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,210 +1,146 @@
-# Rust GenAI
+# genai-rs
 
 [![Crates.io](https://img.shields.io/crates/v/genai-rs.svg)](https://crates.io/crates/genai-rs)
 [![Documentation](https://docs.rs/genai-rs/badge.svg)](https://docs.rs/genai-rs)
 [![CI](https://github.com/evansenter/genai-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/evansenter/genai-rs/actions/workflows/rust.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![MSRV](https://img.shields.io/badge/MSRV-1.88-blue.svg)](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0.html)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A Rust client library for interacting with Google's Generative AI (Gemini) API using the Interactions API.
+A Rust client library for Google's Generative AI (Gemini) API using the [Interactions API](https://ai.google.dev/static/api/interactions-api.md.txt).
 
-## Features
-
-- Simple, intuitive API for making requests to Google's Generative AI models
-- Support for both single-shot and streaming interactions
-- Stateful conversations with automatic context management via `previous_interaction_id`
-- Function calling with both manual and automatic execution
-- Automatic function discovery at compile time using procedural macros
-- Structured output with JSON schema enforcement via `with_response_format()`
-- Built-in tool support: Google Search grounding, URL context, and code execution
-- Comprehensive error handling with detailed error types
-- Async/await support with Tokio
-
-## External Documentation
-
-For authoritative Gemini API documentation, consult these sources:
-
-| Document | Description |
-|----------|-------------|
-| [Interactions API Reference](https://ai.google.dev/static/api/interactions.md.txt) | API specification and endpoint details |
-| [Interactions API Guide](https://ai.google.dev/static/api/interactions-api.md.txt) | Usage patterns and best practices |
-| [Function Calling Guide](https://ai.google.dev/gemini-api/docs/function-calling.md.txt) | Function declaration and execution |
-| [Thought Signatures](https://ai.google.dev/gemini-api/docs/thought-signatures.md.txt) | Reasoning and thought content |
-
-## Installation
-
-Add this to your `Cargo.toml`:
-
-```toml
-[dependencies]
-genai-rs = "0.4.0"
-genai-rs-macros = "0.4.0"  # Only if using the procedural macros
-tokio = { version = "1.0", features = ["full"] }
-serde_json = "1.0"
-futures-util = "0.3"  # Only if using streaming responses
-```
-
-### Prerequisites
-
-- Rust 1.88 or later (edition 2024)
-- A Google AI API key with access to Gemini models (get one from [Google AI Studio](https://ai.dev/))
-
-## Usage
-
-See `examples/` for complete, runnable examples covering all features.
-
-### Simple Interaction
+## Quick Start
 
 ```rust
 use genai_rs::Client;
-use std::env;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let api_key = env::var("GEMINI_API_KEY")?;
-    let client = Client::builder(api_key).build()?;
+async fn main() -> Result<(), genai_rs::GenaiError> {
+    let client = Client::new(std::env::var("GEMINI_API_KEY").unwrap());
 
     let response = client
         .interaction()
         .with_model("gemini-3-flash-preview")
-        .with_text("Write a short poem about Rust programming.")
+        .with_text("Explain Rust's ownership model in one sentence.")
         .create()
         .await?;
 
-    println!("{}", response.text().unwrap_or("No response"));
+    println!("{}", response.text().unwrap_or_default());
     Ok(())
 }
 ```
 
-### Streaming Responses
+## Features
+
+### Core Capabilities
+
+| Feature | Description |
+|---------|-------------|
+| **Streaming** | Real-time token streaming with resume capability |
+| **Stateful Conversations** | Multi-turn context via `previous_interaction_id` |
+| **Function Calling** | Auto-discovery with `#[tool]` macro or manual control |
+| **Structured Output** | JSON schema enforcement with `with_response_format()` |
+| **Thinking Mode** | Access model reasoning with configurable depth |
+
+### Built-in Tools
+
+| Tool | Method | Use Case |
+|------|--------|----------|
+| Google Search | `with_google_search()` | Real-time web grounding |
+| Code Execution | `with_code_execution()` | Python sandbox |
+| URL Context | `with_url_context()` | Web page analysis |
+
+### Multimodal I/O
+
+| Input | Output |
+|-------|--------|
+| Images, Audio, Video, PDFs | Text, Images, Audio (TTS) |
+
+## Installation
+
+```toml
+[dependencies]
+genai-rs = "0.4"
+tokio = { version = "1.0", features = ["full"] }
+
+# Optional
+genai-rs-macros = "0.4"  # For #[tool] macro
+futures-util = "0.3"     # For streaming
+```
+
+**Requirements:** Rust 1.88+ (edition 2024), [Gemini API key](https://ai.dev/)
+
+## Examples
+
+36 runnable examples covering all features (28 core + 8 real-world applications):
+
+```bash
+export GEMINI_API_KEY=your-key
+cargo run --example simple_interaction
+```
+
+**Quick Reference:**
+
+| I want to... | Example |
+|--------------|---------|
+| Make my first API call | `simple_interaction` |
+| Stream responses | `streaming` |
+| Use function calling | `auto_function_calling` |
+| Multi-turn conversations | `stateful_interaction` |
+| Generate images | `image_generation` |
+| Text to speech | `text_to_speech` |
+| Get structured JSON | `structured_output` |
+
+See [Examples Index](docs/EXAMPLES_INDEX.md) for the complete categorized list.
+
+## Usage Highlights
+
+### Streaming
 
 ```rust
-use genai_rs::Client;
 use futures_util::StreamExt;
 
-let stream = client
-    .interaction()
-    .with_model("gemini-3-flash-preview")
-    .with_text("Explain quantum computing.")
+let stream = client.interaction()
+    .with_text("Write a haiku about Rust.")
     .create_stream();
 
 futures_util::pin_mut!(stream);
-while let Some(result) = stream.next().await {
-    if let Ok(chunk) = result {
-        if let Some(text) = chunk.text() {
-            print!("{}", text);
-        }
+while let Some(Ok(chunk)) = stream.next().await {
+    if let Some(text) = chunk.text() {
+        print!("{}", text);
     }
 }
 ```
 
-See [`docs/STREAMING_API.md`](docs/STREAMING_API.md) for stream types, resume capability, and patterns.
-
-### Stateful Conversations
-
-```rust
-// First turn - set system instruction
-let response1 = client
-    .interaction()
-    .with_model("gemini-3-flash-preview")
-    .with_text("My name is Alice.")
-    .with_system_instruction("You are a helpful assistant.")
-    .with_store_enabled()
-    .create()
-    .await?;
-
-// Second turn - chain with previous
-let response2 = client
-    .interaction()
-    .with_model("gemini-3-flash-preview")
-    .with_previous_interaction(&response1.id)
-    .with_text("What is my name?")  // Model remembers: "Alice"
-    .create()
-    .await?;
-```
-
-**Key inheritance rules:**
-- `systemInstruction`: Inherited (only send on first turn)
-- `tools`: NOT inherited (must resend on each user message turn)
-
-See [`docs/MULTI_TURN_FUNCTION_CALLING.md`](docs/MULTI_TURN_FUNCTION_CALLING.md) for comprehensive patterns.
-
-### Function Calling
-
-Three approaches for client-side function calling:
-
-| Approach | State | Best For |
-|----------|-------|----------|
-| `#[tool]` macro | Stateless | Simple tools, quick prototyping |
-| `ToolService` | Stateful | DB connections, API clients, shared config |
-| Manual | Flexible | Custom execution logic, rate limiting |
-
-#### Automatic with `#[tool]` Macro
+### Function Calling with `#[tool]`
 
 ```rust
 use genai_rs_macros::tool;
 
-/// Get the weather in a location
-#[tool(location(description = "City and state, e.g. San Francisco, CA"))]
+#[tool(location(description = "City name, e.g. Tokyo"))]
 fn get_weather(location: String) -> String {
-    format!("Weather in {}: 72°F, sunny", location)
+    format!(r#"{{"temp": 72, "conditions": "sunny"}}"#)
 }
 
-let result = client
-    .interaction()
-    .with_model("gemini-3-flash-preview")
+let result = client.interaction()
     .with_text("What's the weather in Tokyo?")
     .with_function(GetWeatherCallable.declaration())
     .create_with_auto_functions()
     .await?;
-
-println!("{}", result.response.text().unwrap());
 ```
 
-#### Stateful with ToolService
-
-For tools that need shared state (database pools, API clients, configuration):
+### Stateful Conversations
 
 ```rust
-use genai_rs::{ToolService, CallableFunction};
-
-struct MyService {
-    db: Arc<DatabasePool>,
-}
-
-impl ToolService for MyService {
-    fn tools(&self) -> Vec<Arc<dyn CallableFunction>> {
-        vec![Arc::new(DbQueryTool { pool: self.db.clone() })]
-    }
-}
-
-let service = Arc::new(MyService { db });
-let result = client.interaction()
-    .with_tool_service(service)
-    .create_with_auto_functions()
-    .await?;
-```
-
-See `examples/tool_service.rs` for a complete example.
-
-### Built-in Tools
-
-```rust
-// Google Search grounding
-let response = client.interaction()
-    .with_google_search()
-    .with_text("What are today's top news stories?")
+// First turn
+let r1 = client.interaction()
+    .with_system_instruction("You are a helpful assistant.")
+    .with_text("My name is Alice.")
     .create().await?;
 
-// Code execution (Python sandbox)
-let response = client.interaction()
-    .with_code_execution()
-    .with_text("Calculate the first 10 Fibonacci numbers")
-    .create().await?;
-
-// URL context
-let response = client.interaction()
-    .with_url_context()
-    .with_text("Summarize https://example.com")
+// Continue conversation
+let r2 = client.interaction()
+    .with_previous_interaction(&r1.id)
+    .with_text("What's my name?")  // Remembers: Alice
     .create().await?;
 ```
 
@@ -214,88 +150,107 @@ let response = client.interaction()
 use genai_rs::ThinkingLevel;
 
 let response = client.interaction()
-    .with_thinking_level(ThinkingLevel::Medium)
-    .with_text("Solve step by step: If a train travels 120 km in 2 hours...")
+    .with_thinking_level(ThinkingLevel::High)
+    .with_text("What's 15% of 847?")
     .create().await?;
 
 for thought in response.thoughts() {
-    println!("Thinking: {}", thought);
+    println!("Reasoning: {}", thought);
 }
-println!("Answer: {}", response.text().unwrap());
 ```
 
-### Multimodal Input
+## Documentation
 
-```rust
-// Add images, audio, video, or documents
-let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
-    .with_text("What's in this image?")
-    .add_image_file("photo.jpg").await?
-    .create().await?;
-```
+### Guides
 
-All media types follow the same pattern: `add_*_file()`, `add_*_data()`, `add_*_uri()`.
+| Guide | Description |
+|-------|-------------|
+| [Examples Index](docs/EXAMPLES_INDEX.md) | All 36 examples, categorized |
+| [Function Calling](docs/FUNCTION_CALLING.md) | `#[tool]` macro, ToolService, manual execution |
+| [Multi-Turn Patterns](docs/MULTI_TURN_FUNCTION_CALLING.md) | Stateful/stateless, inheritance rules |
+| [Streaming API](docs/STREAMING_API.md) | Stream types, resume, auto-functions |
+| [Multimodal](docs/MULTIMODAL.md) | Images, audio, video, PDFs |
+| [Output Modalities](docs/OUTPUT_MODALITIES.md) | Image generation, text-to-speech |
+| [Thinking Mode](docs/THINKING_MODE.md) | Reasoning depth, thought signatures |
+| [Built-in Tools](docs/BUILT_IN_TOOLS.md) | Google Search, code execution, URL context |
+| [Configuration](docs/CONFIGURATION.md) | Client options, generation config |
+| [Conversation Patterns](docs/CONVERSATION_PATTERNS.md) | Multi-turn, context management |
 
-## Logging
+### Reference
 
-Enable debug logging:
+| Document | Description |
+|----------|-------------|
+| [Error Handling](docs/ERROR_HANDLING.md) | Error types, recovery patterns |
+| [Reliability Patterns](docs/RELIABILITY_PATTERNS.md) | Retries, timeouts, resilience |
+| [Logging Strategy](docs/LOGGING_STRATEGY.md) | Log levels, `LOUD_WIRE` debugging |
+| [Testing Guide](docs/TESTING.md) | Test strategies, assertions |
+| [Agents & Background](docs/AGENTS_AND_BACKGROUND.md) | Long-running tasks, polling |
+| [API Reference](https://docs.rs/genai-rs) | Generated API documentation |
+
+### External Resources
+
+| Resource | Description |
+|----------|-------------|
+| [Interactions API Reference](https://ai.google.dev/static/api/interactions.md.txt) | Official API specification |
+| [Interactions API Guide](https://ai.google.dev/static/api/interactions-api.md.txt) | Usage patterns |
+| [Function Calling Guide](https://ai.google.dev/gemini-api/docs/function-calling.md.txt) | Google's function calling docs |
+
+## Debugging
 
 ```bash
+# Wire-level request/response logging
+LOUD_WIRE=1 cargo run --example simple_interaction
+
+# Library debug logs
 RUST_LOG=genai_rs=debug cargo run --example simple_interaction
 ```
 
-For wire-level API debugging without configuring a logging backend:
-
-```bash
-LOUD_WIRE=1 cargo run --example simple_interaction
-```
-
-See [`docs/LOGGING_STRATEGY.md`](docs/LOGGING_STRATEGY.md) for details on log levels and `LOUD_WIRE` output.
-
-## Project Structure
-
-- **`genai-rs`** (root): Public API crate with `Client`, `InteractionBuilder`, HTTP layer (`src/http/`), and type modules
-- **`genai-rs-macros/`**: Procedural macro for `#[tool]`
+See [Logging Strategy](docs/LOGGING_STRATEGY.md) for details.
 
 ## Forward Compatibility
 
-This library follows the [Evergreen spec](https://github.com/google-deepmind/evergreen-spec) philosophy: unknown API types deserialize into `Unknown` variants instead of failing. Always include wildcard arms in match statements:
+This library follows the [Evergreen philosophy](https://github.com/google-deepmind/evergreen-spec): unknown API types deserialize into `Unknown` variants instead of failing. Always include wildcard arms:
 
 ```rust
-match output {
+match content {
     InteractionContent::Text { text } => println!("{}", text.unwrap_or_default()),
-    _ => {}  // Handle unknown future variants
+    _ => {}  // Handles future variants gracefully
 }
 ```
-
-## Error Handling
-
-Two main error types:
-
-- **`GenaiError`**: API/network errors (Http, Parse, Json, Utf8, Api, Internal, InvalidInput, MalformedResponse, Timeout, ClientBuild)
-- **`FunctionError`**: Function calling errors (ArgumentMismatch, ExecutionError)
-
-## Troubleshooting
-
-- **"API key not valid"**: Verify `GEMINI_API_KEY` is set correctly
-- **"Model not found"**: Use valid model name (e.g., `gemini-3-flash-preview`)
-- **Functions not executing**: Use `create_with_auto_functions()` for automatic execution
-- **Image URL blocked**: Use Google Cloud Storage URLs or base64-encoded images
 
 ## Testing
 
 ```bash
-cargo test -- --include-ignored  # Full test suite (requires GEMINI_API_KEY)
-cargo test                       # Unit tests only
+cargo test                       # Unit tests
+cargo test -- --include-ignored  # Full integration suite (requires GEMINI_API_KEY)
 ```
 
-See [CLAUDE.md](CLAUDE.md) for test assertion strategies and development guidelines.
+## Project Structure
 
-## License
-
-MIT License - see [LICENSE](LICENSE) for details.
+```
+genai-rs/           # Main crate: Client, InteractionBuilder, types
+genai-rs-macros/    # Procedural macro for #[tool]
+docs/               # Comprehensive guides
+examples/           # 36 runnable examples
+```
 
 ## Contributing
 
-Contributions welcome! See [CLAUDE.md](CLAUDE.md) for development guidelines.
+Contributions welcome! Please read:
+
+- [CLAUDE.md](CLAUDE.md) - Development guidelines and architecture
+- [CHANGELOG.md](CHANGELOG.md) - Version history and migration guides
+- [SECURITY.md](SECURITY.md) - Security policy and reporting
+
+## Troubleshooting
+
+Common issues and solutions are documented in [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+
+**Quick fixes:**
+- **"API key not valid"** - Check `GEMINI_API_KEY` is set
+- **"Model not found"** - Use `gemini-3-flash-preview`
+- **Functions not executing** - Use `create_with_auto_functions()`
+
+## License
+
+[MIT](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-If you discover a security vulnerability in rust-genai, please report it privately using one of these methods:
+If you discover a security vulnerability in genai-rs, please report it privately using one of these methods:
 
 1. **GitHub Private Vulnerability Reporting**: Use the "Report a vulnerability" button in the Security tab
 2. **Email**: Contact the maintainers directly

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # Troubleshooting Guide
 
-This guide covers common issues, debugging techniques, and solutions when working with `rust-genai`.
+This guide covers common issues, debugging techniques, and solutions when working with `genai-rs`.
 
 ## Table of Contents
 
@@ -45,7 +45,7 @@ Output shows:
 For internal library behavior:
 
 ```bash
-RUST_LOG=rust_genai=debug cargo run --example simple_interaction
+RUST_LOG=genai_rs=debug cargo run --example simple_interaction
 ```
 
 Log levels:
@@ -57,7 +57,7 @@ Log levels:
 ### Combined Debugging
 
 ```bash
-LOUD_WIRE=1 RUST_LOG=rust_genai=debug cargo run --example auto_function_calling
+LOUD_WIRE=1 RUST_LOG=genai_rs=debug cargo run --example auto_function_calling
 ```
 
 ## Common Errors
@@ -224,7 +224,7 @@ let prompt = "Use the get_weather function to check Tokyo's weather";
 
 4. **Force function calling:**
 ```rust,ignore
-use rust_genai::FunctionCallingMode;
+use genai_rs::FunctionCallingMode;
 
 let result = client
     .interaction()
@@ -526,7 +526,7 @@ The model may call functions in parallel or sequentially. This is normal behavio
 
 ### Can I use this library synchronously?
 
-No, `rust-genai` is async-only. Use a runtime like Tokio:
+No, `genai-rs` is async-only. Use a runtime like Tokio:
 ```rust,ignore
 #[tokio::main]
 async fn main() {
@@ -549,11 +549,11 @@ The Evergreen pattern logs when the API returns values not yet in the library's 
 1. Enable `LOUD_WIRE=1` and capture output
 2. Include Rust version: `rustc --version`
 3. Include library version from `Cargo.toml`
-4. Open issue at [GitHub](https://github.com/evansenter/rust-genai/issues)
+4. Open issue at [GitHub](https://github.com/evansenter/genai-rs/issues)
 
 ## Getting Help
 
 1. **Check examples:** `cargo run --example <name>`
 2. **Read docs:** See `docs/` directory
-3. **Enable debugging:** `LOUD_WIRE=1 RUST_LOG=rust_genai=debug`
+3. **Enable debugging:** `LOUD_WIRE=1 RUST_LOG=genai_rs=debug`
 4. **Open issue:** Include debug output and reproduction steps

--- a/examples/real_world/README.md
+++ b/examples/real_world/README.md
@@ -1,6 +1,6 @@
 # Real-World Example Applications
 
-This directory contains comprehensive example applications demonstrating practical use cases for the `rust-genai` library. Each example showcases production patterns, error handling, and best practices.
+This directory contains comprehensive example applications demonstrating practical use cases for the `genai-rs` library. Each example showcases production patterns, error handling, and best practices.
 
 ## Examples Overview
 


### PR DESCRIPTION
## Summary

- Replace all remaining `rust-genai`/`rust_genai` references with `genai-rs`/`genai_rs`
- Restructure README for better discoverability and user experience
- Fix documentation accuracy issues found by audit

## Changes

### Rename cleanup
- `LICENSE` - copyright notice
- `SECURITY.md` - security reporting instructions
- `TROUBLESHOOTING.md` - library references, RUST_LOG examples, GitHub URL, imports
- `examples/real_world/README.md` - library reference

### README overhaul
- Move Quick Start to top (was buried after Features/External Docs/Installation)
- Replace bullet walls with scannable tables for Features, Built-in Tools, Multimodal
- Add Examples section with quick reference table
- Link all 17 docs (was only 3 linked inline)
- Add MSRV badge
- Streamline code examples in Usage Highlights
- Add links to TROUBLESHOOTING.md, CHANGELOG.md, SECURITY.md

### Audit fixes
- Fix example count: 36 total (28 core + 8 real-world), was incorrectly "28"
- Fix MSRV in CLAUDE.md: 1.88+ (was incorrectly 1.85+)

## Test plan

- [x] All referenced doc paths exist
- [x] Example counts verified (28 in examples/*.rs, 8 in examples/real_world/*/main.rs)
- [x] MSRV matches Cargo.toml rust-version

🤖 Generated with [Claude Code](https://claude.ai/code)