### PR TITLE
fix: Make is_unknown() const in Role, ThinkingLevel, and ThinkingSummaries

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -47,7 +47,7 @@ pub enum Role {
 impl Role {
     /// Returns true if this is an unknown role.
     #[must_use]
-    pub fn is_unknown(&self) -> bool {
+    pub const fn is_unknown(&self) -> bool {
         matches!(self, Self::Unknown { .. })
     }
 
@@ -359,7 +359,7 @@ pub enum ThinkingLevel {
 impl ThinkingLevel {
     /// Returns true if this is an unknown thinking level.
     #[must_use]
-    pub fn is_unknown(&self) -> bool {
+    pub const fn is_unknown(&self) -> bool {
         matches!(self, Self::Unknown { .. })
     }
 
@@ -682,7 +682,7 @@ pub enum ThinkingSummaries {
 impl ThinkingSummaries {
     /// Returns true if this is an unknown thinking summaries value.
     #[must_use]
-    pub fn is_unknown(&self) -> bool {
+    pub const fn is_unknown(&self) -> bool {
         matches!(self, Self::Unknown { .. })
     }
 


### PR DESCRIPTION
## Summary
- Adds the `const` qualifier to three `is_unknown()` methods in `src/request.rs`
- Ensures consistency with all other `is_unknown()` implementations across the codebase

## Test plan
- [x] `cargo test --lib` passes (534 tests)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes

Fixes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)