### PR TITLE
ci: Consolidate CI/CD workflows and extend integration test coverage (closes #315)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Check workspace
         run: cargo check --workspace --all-targets --all-features
-      - name: Run tests
+      - name: Run unit tests
         run: cargo test --workspace --verbose
+      - name: Run integration tests
+        run: cargo test --workspace --verbose -- --include-ignored
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Run clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,6 +58,8 @@ jobs:
             tests: "advanced_function_calling_tests thinking_function_tests multiturn_function_tests"
           - group: multimodal
             tests: "multimodal_tests api_canary_tests temp_file_tests"
+          - group: files-and-wire
+            tests: "api_wire_format_live_tests files_api_tests"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -109,18 +111,6 @@ jobs:
         run: cargo doc --workspace --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: -D warnings
-
-  security:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
-      - name: Run security audit
-        run: cargo audit
 
   msrv:
     name: MSRV Check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ See `docs/TESTING.md` for the full decision flowchart and examples.
 
 ## CI/CD
 
-GitHub Actions runs: check, test, test-strict-unknown, test-integration (4 matrix groups), fmt, clippy, doc, security, msrv, cross-platform, coverage, build-metrics. Integration tests require same-repo origin (protects API key).
+GitHub Actions runs: check, test, test-strict-unknown, test-integration (5 matrix groups), fmt, clippy, doc, msrv, cross-platform, coverage, build-metrics. Security audits run in separate `audit.yml` workflow (on Cargo.toml/lock changes + weekly). Integration tests require same-repo origin (protects API key). Release validation includes full integration test suite.
 
 ## Project Conventions
 


### PR DESCRIPTION
## Summary

- Remove duplicate `security` job from `rust.yml` (keep `audit.yml` as single source)
- Add `files-and-wire` matrix group for 25 previously-missed integration tests
- Add integration test step to `release.yml` validate job

## Test plan

- [ ] Verify CI passes with new `files-and-wire` matrix group
- [ ] Verify security audits still run via `audit.yml` workflow
- [ ] Confirm release validation would include integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)