### PR TITLE
docs: Fix stale counts and references in documentation

### DIFF
--- a/.github/workflows/ci-flakiness-report.yml
+++ b/.github/workflows/ci-flakiness-report.yml
@@ -228,7 +228,7 @@ jobs:
 
           > **Note:** \`.contains()\` assertions on LLM output are brittle because model responses vary.
           > Consider using \`validate_response_semantically()\` for behavioral validation.
-          > See [#324](https://github.com/${{ github.repository }}/issues/324) for migration guidance.
+          > See [docs/TESTING.md](https://github.com/${{ github.repository }}/blob/main/docs/TESTING.md#assertion-strategies) for migration guidance.
           EOF
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ See `examples/` for full list (multimodal, thinking, files API, image generation
 - `docs/MULTI_TURN_FUNCTION_CALLING.md` - Stateful/stateless, auto/manual execution, thought signatures
 - `docs/STREAMING_API.md` - Stream types, resume capability, auto-function streaming
 - `docs/LOGGING_STRATEGY.md` - Log levels, sensitive data handling
-- `docs/ENUM_WIRE_FORMATS.md` - Wire formats + all 11 Unknown variant types
+- `docs/ENUM_WIRE_FORMATS.md` - Wire formats and Unknown variant catalog
 
 ### Error Types
 
@@ -169,7 +169,7 @@ See `docs/TESTING.md` for the full decision flowchart and examples.
 
 ## CI/CD
 
-GitHub Actions runs: check, test, test-strict-unknown, test-integration (5 matrix groups), fmt, clippy, doc, msrv, cross-platform, coverage, build-metrics. Security audits run in separate `audit.yml` workflow (on Cargo.toml/lock changes + weekly). Integration tests require same-repo origin (protects API key). Release validation includes full integration test suite.
+GitHub Actions runs: check, test, test-strict-unknown, test-integration (5 matrix groups), fmt, clippy, doc, msrv, cross-platform, coverage, build-metrics, ci-flakiness-report (daily). Security audits run in separate `audit.yml` workflow (on Cargo.toml/lock changes + weekly). Integration tests require same-repo origin (protects API key). Release validation includes full integration test suite.
 
 ## Project Conventions
 
@@ -190,6 +190,8 @@ Apply `#[must_use]` to getters, handles, and boolean checks where ignoring the r
 ## Versioning Philosophy
 
 Breaking changes are permitted and preferred when they simplify the API or align with Evergreen principles. Prefer clean breaks over backwards-compatibility shims.
+
+**CHANGELOG**: Update `CHANGELOG.md` for user-facing changes: new features, breaking changes, bug fixes, deprecations. Internal refactors and CI changes don't need entries.
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ futures-util = "0.3"     # For streaming
 
 ## Examples
 
-36 runnable examples covering all features (28 core + 8 real-world applications):
+Runnable examples covering all features:
 
 ```bash
 export GEMINI_API_KEY=your-key
@@ -165,7 +165,7 @@ for thought in response.thoughts() {
 
 | Guide | Description |
 |-------|-------------|
-| [Examples Index](docs/EXAMPLES_INDEX.md) | All 36 examples, categorized |
+| [Examples Index](docs/EXAMPLES_INDEX.md) | All examples, categorized |
 | [Function Calling](docs/FUNCTION_CALLING.md) | `#[tool]` macro, ToolService, manual execution |
 | [Multi-Turn Patterns](docs/MULTI_TURN_FUNCTION_CALLING.md) | Stateful/stateless, inheritance rules |
 | [Streaming API](docs/STREAMING_API.md) | Stream types, resume, auto-functions |
@@ -231,7 +231,7 @@ cargo test -- --include-ignored  # Full integration suite (requires GEMINI_API_K
 genai-rs/           # Main crate: Client, InteractionBuilder, types
 genai-rs-macros/    # Procedural macro for #[tool]
 docs/               # Comprehensive guides
-examples/           # 36 runnable examples
+examples/           # Runnable examples
 ```
 
 ## Contributing

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -13,7 +13,7 @@ This guide explains the testing infrastructure, philosophy, and how to write tes
 
 ## Test Categories
 
-### Unit Tests (~24k lines)
+### Unit Tests
 
 Inline tests in source files covering serialization, builders, and internal logic.
 
@@ -30,7 +30,7 @@ cargo test --workspace -- test_name       # Run specific test
 - Helper method behavior
 - Error type formatting
 
-### Integration Tests (25 files)
+### Integration Tests
 
 End-to-end tests that call the real Gemini API. Require `GEMINI_API_KEY`.
 
@@ -47,7 +47,7 @@ cargo test --test interactions_api_tests -- --include-ignored  # Single file
 |------|----------|
 | `interactions_api_tests.rs` | Basic API interactions |
 | `multiturn_tests.rs` | Stateful conversations |
-| `streaming_tests.rs` | SSE streaming |
+| `streaming_multiturn_tests.rs` | SSE streaming |
 | `tools_and_config_tests.rs` | Built-in tools configuration |
 | `advanced_function_calling_tests.rs` | `#[tool]` macro, auto-execution |
 | `thinking_function_tests.rs` | Thinking mode + function calling |
@@ -164,7 +164,11 @@ The GitHub Actions workflow runs these jobs:
 | `clippy` | Lint check |
 | `doc` | Documentation build |
 | `security` | `cargo audit` |
+| `msrv` | Minimum supported Rust version check |
+| `cross-platform` | macOS and Windows builds |
+| `coverage` | Code coverage with `cargo llvm-cov` |
 | `build-metrics` | Clean build time measurement |
+| `ci-flakiness-report` | Daily flakiness analysis (creates `ci-health` issues) |
 
 ### Integration Test Matrix
 


### PR DESCRIPTION
## Summary
- Remove specific counts that become stale (example counts, test file counts, line counts)
- Fix workflow reference to closed issue #324
- Add missing CI jobs to documentation
- Add CHANGELOG guidance to CLAUDE.md

## Changes
- **CLAUDE.md**: Add CHANGELOG guidance, fix Unknown variant description, add ci-flakiness-report to CI list
- **README.md**: Remove specific example counts (36 → "Runnable examples")
- **docs/TESTING.md**: Fix streaming_tests.rs reference, add missing CI jobs, remove stale counts
- **ci-flakiness-report.yml**: Fix #324 reference → docs/TESTING.md#assertion-strategies

## Test plan
- [ ] Verify all links work
- [ ] Verify CI jobs listed match actual workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)