### PR TITLE
chore: Bump version to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-01-10
+
+### Fixed
+
+- Streaming tests no longer assert `event_id` presence (optional per API spec)
+- `test_get_interaction_stream` handles API not replaying completed interactions
+- Updated `STREAMING_API.md` with notes about optional `event_id` field
+
 ## [0.5.0] - 2026-01-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "genai-rs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "genai-rs-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 [package]
 name = "genai-rs"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"
@@ -35,7 +35,7 @@ keywords = ["gemini", "google", "ai", "llm", "genai"]
 categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
-genai-rs-macros = { version = "0.5.0", path = "./genai-rs-macros" }
+genai-rs-macros = { version = "0.5.1", path = "./genai-rs-macros" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/docs/INTERACTIONS_API_FEEDBACK.md
+++ b/docs/INTERACTIONS_API_FEEDBACK.md
@@ -3,7 +3,7 @@
 Feedback for the Google Gemini API team based on building and maintaining [genai-rs](https://github.com/evansenter/genai-rs), a Rust client library for the Interactions API.
 
 **Date**: 2026-01-10
-**Library Version**: 0.5.0
+****Library Version**: 0.5.1
 
 ---
 

--- a/genai-rs-macros/Cargo.toml
+++ b/genai-rs-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genai-rs-macros"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bump version to 0.5.1 for release.

Updates:
- Cargo.toml (main crate and macros dependency)
- genai-rs-macros/Cargo.toml
- docs/INTERACTIONS_API_FEEDBACK.md
- CHANGELOG.md (add 0.5.1 entry)

## Context

PR #340 fixed streaming tests but squash merge didn't include version bump commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)