### PR TITLE
chore: Bump version to 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-01-10
+
+### Fixed
+
+- Doctest compilation failures in `INTERACTIONS_API_FEEDBACK.md` (missing `ignore` annotation)
+- Updated `thought_content()` docstring to clarify it's for testing only (API rejects thought blocks in user input)
+
+### Changed
+
+- `INTERACTIONS_API_FEEDBACK.md`: Downgraded thought signature issue from P0 to P2, clarified that signatures ARE present on `Thought` outputs (not `FunctionCall`), and documented that API rejects thought blocks in user input
+
 ## [0.5.1] - 2026-01-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "genai-rs"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "genai-rs-macros"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 [package]
 name = "genai-rs"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"
@@ -35,7 +35,7 @@ keywords = ["gemini", "google", "ai", "llm", "genai"]
 categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
-genai-rs-macros = { version = "0.5.1", path = "./genai-rs-macros" }
+genai-rs-macros = { version = "0.5.2", path = "./genai-rs-macros" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/genai-rs-macros/Cargo.toml
+++ b/genai-rs-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genai-rs-macros"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/src/interactions_api.rs
+++ b/src/interactions_api.rs
@@ -70,18 +70,31 @@ pub fn text_content(text: impl Into<String>) -> InteractionContent {
     InteractionContent::new_text(text)
 }
 
-/// Creates thought content (internal reasoning visible in agent responses).
+/// Creates thought content (for testing and roundtrip verification only).
 ///
-/// **Prefer:** [`InteractionContent::new_thought()`] for new code.
+/// # ⚠️ API Limitation
 ///
-/// **Note:** Thought content contains a cryptographic signature, not text.
-/// The signature is used for verification of the model's reasoning process.
+/// **The Gemini API does NOT accept thought blocks in user input.**
+/// Attempting to send thoughts returns: `"User turns cannot contain thought blocks."`
+///
+/// For multi-turn conversations with thinking:
+/// - Use `with_previous_interaction(id)` — the server preserves thought context automatically
+/// - For stateless mode, only text content can be included in history
+///
+/// # Valid Uses
+///
+/// This helper exists for:
+/// - Roundtrip serialization testing
+/// - Representing API responses as structured data
+/// - Property-based testing (proptest)
 ///
 /// # Example
 /// ```
 /// use genai_rs::interactions_api::thought_content;
 ///
-/// let thought = thought_content("signature_value_here");
+/// // For testing serialization roundtrip
+/// let thought = thought_content("EosFCogFAXLI2...");
+/// assert!(thought.is_thought());
 /// ```
 pub fn thought_content(signature: impl Into<String>) -> InteractionContent {
     InteractionContent::new_thought(signature)


### PR DESCRIPTION
## Summary

- Fix doctest failures (INTERACTIONS_API_FEEDBACK.md missing `ignore` annotation)
- Update `thought_content()` docstring to clarify it's for testing only (API rejects thought blocks in user input)
- Downgrade thought signatures from P0 to P2 in feedback doc
- Clarify that signatures ARE present on `Thought` outputs, but API rejects thought blocks in user input

## Test plan

- [x] `cargo test --doc` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)