### PR TITLE
fix: Exclude doctests from --include-ignored in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Run unit tests
         run: cargo test --workspace --verbose
       - name: Run integration tests
-        run: cargo test --workspace --verbose -- --include-ignored
+        # Use --tests to exclude doctests; --include-ignored would compile 'ignore' doctest snippets
+        run: cargo test --workspace --tests --verbose -- --include-ignored
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       - name: Check formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-01-10
+
+### Fixed
+
+- Release workflow: Use `--tests` to exclude doctests from `--include-ignored` run (v0.5.2 release workflow failed because `--include-ignored` compiles `ignore` doctest snippets)
+
 ## [0.5.2] - 2026-01-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "genai-rs"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "genai-rs-macros"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 [package]
 name = "genai-rs"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"
@@ -35,7 +35,7 @@ keywords = ["gemini", "google", "ai", "llm", "genai"]
 categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
-genai-rs-macros = { version = "0.5.2", path = "./genai-rs-macros" }
+genai-rs-macros = { version = "0.5.3", path = "./genai-rs-macros" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/docs/INTERACTIONS_API_FEEDBACK.md
+++ b/docs/INTERACTIONS_API_FEEDBACK.md
@@ -3,7 +3,7 @@
 Feedback for the Google Gemini API team based on building and maintaining [genai-rs](https://github.com/evansenter/genai-rs), a Rust client library for the Interactions API.
 
 **Date**: 2026-01-10
-**Library Version**: 0.5.2
+**Library Version**: 0.5.3
 
 ---
 

--- a/genai-rs-macros/Cargo.toml
+++ b/genai-rs-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genai-rs-macros"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Release workflow fix: `--include-ignored` compiles `ignore` doctests, causing failures
- Bumps version to 0.5.3 (v0.5.2 release failed)

## Changes
- `.github/workflows/release.yml`: Use `--tests` to exclude doctests from integration test step
- Version bump: 0.5.2 → 0.5.3

## Test plan
- [x] `cargo test --workspace --verbose` passes (doctests are ignored)
- [x] `cargo test --workspace --tests --verbose -- --include-ignored` runs without doctests

🤖 Generated with [Claude Code](https://claude.com/claude-code)