### PR TITLE
fix: Install mold linker in release publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install mold linker
+        run: sudo apt-get update && sudo apt-get install -y mold
 
       - name: Verify tag matches Cargo.toml version
         run: |


### PR DESCRIPTION
## Summary

The v0.6.0 release failed because the publish job doesn't install mold linker, but `.cargo/config.toml` requires it for `cargo publish --verify`.

- Validate job installs mold ✅
- Publish job was missing mold ❌

## Fix

Add `Install mold linker` step to the publish job.

## Test plan

- [ ] Merge this PR
- [ ] Delete and recreate v0.6.0 tag, OR bump to v0.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)