### PR TITLE
feat: Improve CI flakiness report with categorization and trends

### DIFF
--- a/.github/scripts/categorize_failures.sh
+++ b/.github/scripts/categorize_failures.sh
@@ -59,7 +59,9 @@ PANIC_TESTS=$(echo "$LOGS" | grep -oE "---- [a-zA-Z0-9_:]+ stdout ----" | sed 's
 ALL_TESTS=$(echo -e "$FAILED_TESTS\n$PANIC_TESTS" | sort -u | grep -v '^$' || true)
 
 # Categorize each test based on surrounding log context
-for test_name in $ALL_TESTS; do
+while IFS= read -r test_name; do
+  [ -z "$test_name" ] && continue
+
   # Extract context around the test failure (100 lines before/after)
   CONTEXT=$(echo "$LOGS" | grep -A 100 -B 20 "$test_name" 2>/dev/null || echo "")
 
@@ -75,7 +77,7 @@ for test_name in $ALL_TESTS; do
   else
     UNKNOWN+=("$test_name")
   fi
-done
+done <<< "$ALL_TESTS"
 
 # Helper to convert bash array to JSON array
 to_json_array() {

--- a/.github/scripts/generate_flakiness_report.sh
+++ b/.github/scripts/generate_flakiness_report.sh
@@ -59,6 +59,7 @@ API_ERRORS=$(echo "$TRENDS" | jq -r '.current.api_errors')
 RATE_LIMIT=$(echo "$TRENDS" | jq -r '.current.rate_limit')
 ASSERTION_FAILURES=$(echo "$TRENDS" | jq -r '.current.assertion_failures')
 PANIC=$(echo "$TRENDS" | jq -r '.current.panic')
+UNKNOWN=$(echo "$TRENDS" | jq -r '.current.unknown')
 
 # Calculate failure rate
 if [ "$TOTAL_RUNS" -gt 0 ]; then
@@ -136,7 +137,7 @@ cat <<EOF
 EOF
 
 # Add failure breakdown section (only if there are failures)
-TOTAL_CATEGORIZED=$((API_ERRORS + RATE_LIMIT + ASSERTION_FAILURES + PANIC))
+TOTAL_CATEGORIZED=$((API_ERRORS + RATE_LIMIT + ASSERTION_FAILURES + PANIC + UNKNOWN))
 if [ "$TOTAL_CATEGORIZED" -gt 0 ]; then
   cat <<EOF
 
@@ -183,6 +184,7 @@ EOF
   format_category_row "Rate limit (429)" "$RATE_LIMIT" "rate_limit"
   format_category_row "Assertion failures" "$ASSERTION_FAILURES" "assertion_failures"
   format_category_row "Panics" "$PANIC" "panic"
+  format_category_row "Unknown" "$UNKNOWN" "unknown"
 fi
 
 # Add top flaky tests section

--- a/.github/workflows/ci-flakiness-report.yml
+++ b/.github/workflows/ci-flakiness-report.yml
@@ -137,6 +137,7 @@ jobs:
             --argjson rate_limit "$RATE_LIMIT" \
             --argjson assertion_failures "$ASSERTION_FAILURES" \
             --argjson panic "$PANIC" \
+            --argjson unknown "$UNKNOWN" \
             --arg date "$END_DATE" \
             '{
               total_runs: $total_runs,
@@ -146,6 +147,7 @@ jobs:
               rate_limit: $rate_limit,
               assertion_failures: $assertion_failures,
               panic: $panic,
+              unknown: $unknown,
               date: $date
             }' > summary.json
 


### PR DESCRIPTION
## Summary

- Add error categorization: API errors (503/timeout), rate limits (429), assertion failures, panics
- Add dual-period trend tracking: 24-hour day-over-day AND 7-day week-over-week comparison
- Remove brittle pattern section that was generating false positives
- Make recommendations conditional based on actual failure data

## Implementation

Modularized into three scripts in `.github/scripts/`:
- `categorize_failures.sh` - Parses failed job logs and categorizes by error type
- `compare_trends.sh` - Downloads previous artifacts and calculates trend indicators
- `generate_flakiness_report.sh` - Generates markdown report with conditional sections

Artifacts stored with 14-day retention for trend analysis.

## Test plan

- [ ] Manually trigger workflow: `gh workflow run ci-flakiness-report.yml`
- [ ] Verify report generates with categorized failures
- [ ] After 24 hours: verify 24hr trends appear
- [ ] After 7 days: verify 7-day trends appear

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)