### PR TITLE
chore: Bump version to 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.2] - 2026-01-17
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "genai-rs"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "genai-rs-macros"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 [package]
 name = "genai-rs"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"
@@ -35,7 +35,7 @@ keywords = ["gemini", "google", "ai", "llm", "genai"]
 categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
-genai-rs-macros = { version = "0.7.1", path = "./genai-rs-macros" }
+genai-rs-macros = { version = "0.7.2", path = "./genai-rs-macros" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/genai-rs-macros/Cargo.toml
+++ b/genai-rs-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genai-rs-macros"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bumps version from 0.7.1 to 0.7.2 across all packages
- Updates CHANGELOG with release date

## Release Contents

This release includes:

### Breaking Changes
- `AutoFunctionStreamChunk::ExecutingFunctions` changed from tuple variant to struct variant with `pending_calls` field

### Added
- `PendingFunctionCall` type for accessing function calls in streaming mode

### Fixed
- `ExecutingFunctions` chunk now provides function call information via `pending_calls` field (previously `response.function_calls()` was often empty in streaming mode)

## Checklist

- [x] `Cargo.toml` version updated
- [x] `genai-rs-macros/Cargo.toml` version updated
- [x] Dependency version updated
- [x] CHANGELOG updated with release date
- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)