### PR TITLE
refactor: Deduplicate code and remove unused V1Alpha API version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ See `examples/` for full list (multimodal, thinking, files API, image generation
 **Multi-Turn Inheritance Rules** (critical gotcha):
 | Field | Inherited by API? | SDK Behavior |
 |-------|-------------------|--------------|
-| `systemInstruction` | ❌ No | Available on all states; set explicitly per-turn if needed |
+| `systemInstruction` | ❌ No | Available on all interactions; set explicitly per-turn if needed |
 | `tools` | ❌ No | Must resend on every new user message turn |
 | Conversation history | ✅ Yes | Automatically included |
 

--- a/src/http/common.rs
+++ b/src/http/common.rs
@@ -1,10 +1,6 @@
 /// Represents the API version to target.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApiVersion {
-    /// V1 Alpha API version (reserved for future use).
-    /// Kept for API completeness and tested in unit tests.
-    #[allow(dead_code)] // Used in tests, reserved for future API versions
-    V1Alpha,
     /// V1 Beta API version (current)
     V1Beta,
 }
@@ -12,7 +8,6 @@ pub enum ApiVersion {
 impl ApiVersion {
     const fn as_str(self) -> &'static str {
         match self {
-            Self::V1Alpha => "v1alpha",
             Self::V1Beta => "v1beta",
         }
     }
@@ -127,7 +122,6 @@ mod tests {
 
     #[test]
     fn test_api_version_as_str() {
-        assert_eq!(ApiVersion::V1Alpha.as_str(), "v1alpha");
         assert_eq!(ApiVersion::V1Beta.as_str(), "v1beta");
     }
 
@@ -292,14 +286,10 @@ mod tests {
     }
 
     #[test]
-    fn test_endpoint_to_path_with_different_versions() {
+    fn test_endpoint_to_path() {
         let endpoint = Endpoint::CreateInteraction { stream: false };
-
-        let path_v1alpha = endpoint.to_path(ApiVersion::V1Alpha);
-        assert_eq!(path_v1alpha, "/v1alpha/interactions");
-
-        let path_v1beta = endpoint.to_path(ApiVersion::V1Beta);
-        assert_eq!(path_v1beta, "/v1beta/interactions");
+        let path = endpoint.to_path(ApiVersion::V1Beta);
+        assert_eq!(path, "/v1beta/interactions");
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -980,3 +980,59 @@ pub async fn assert_response_semantic(
         validation_question, response_text
     );
 }
+
+// =============================================================================
+// Function Declaration Builders
+// =============================================================================
+
+/// Creates a standard "get_weather" function declaration for testing.
+///
+/// This is the canonical weather function used across function calling tests.
+/// Returns weather information for a given city.
+#[allow(dead_code)]
+pub fn get_weather_function() -> genai_rs::FunctionDeclaration {
+    use serde_json::json;
+    genai_rs::FunctionDeclaration::builder("get_weather")
+        .description("Get the current weather for a city")
+        .parameter(
+            "city",
+            json!({"type": "string", "description": "City name"}),
+        )
+        .required(vec!["city".to_string()])
+        .build()
+}
+
+/// Creates a standard "get_time" function declaration for testing.
+///
+/// This is the canonical time function used across function calling tests.
+/// Returns the current time in a given timezone.
+#[allow(dead_code)]
+pub fn get_time_function() -> genai_rs::FunctionDeclaration {
+    use serde_json::json;
+    genai_rs::FunctionDeclaration::builder("get_time")
+        .description("Get the current time in a timezone")
+        .parameter(
+            "timezone",
+            json!({"type": "string", "description": "Timezone like PST, EST, JST"}),
+        )
+        .required(vec!["timezone".to_string()])
+        .build()
+}
+
+// =============================================================================
+// Long Conversation Error Detection
+// =============================================================================
+
+/// Checks if an error is a known API limitation for long conversation chains.
+///
+/// Long multi-turn conversations can trigger backend issues including:
+/// - UTF-8 encoding errors
+/// - Spanner database timeouts
+/// - Content truncation errors
+///
+/// Use this to gracefully handle expected failures in long conversation tests.
+#[allow(dead_code)]
+pub fn is_long_conversation_api_error(error: &GenaiError) -> bool {
+    let error_str = format!("{:?}", error);
+    error_str.contains("UTF-8") || error_str.contains("spanner") || error_str.contains("truncated")
+}

--- a/tests/function_calling_tests.rs
+++ b/tests/function_calling_tests.rs
@@ -30,8 +30,9 @@ mod common;
 
 use common::{
     consume_auto_function_stream, consume_stream, extended_test_timeout, get_client,
-    interaction_builder, retry_on_any_error, stateful_builder, test_timeout,
-    validate_response_semantically, with_timeout,
+    get_time_function, get_weather_function, interaction_builder, is_long_conversation_api_error,
+    retry_on_any_error, stateful_builder, test_timeout, validate_response_semantically,
+    with_timeout,
 };
 use genai_rs::{
     CallableFunction, Content, FunctionDeclaration, FunctionExecutionResult, GenaiError,
@@ -137,36 +138,8 @@ fn get_time(timezone: String) -> String {
 }
 
 // =============================================================================
-// Helper Functions
+// Helper Constants
 // =============================================================================
-
-fn get_weather_function() -> FunctionDeclaration {
-    FunctionDeclaration::builder("get_weather")
-        .description("Get the current weather for a city")
-        .parameter(
-            "city",
-            json!({"type": "string", "description": "City name"}),
-        )
-        .required(vec!["city".to_string()])
-        .build()
-}
-
-fn get_time_function() -> FunctionDeclaration {
-    FunctionDeclaration::builder("get_time")
-        .description("Get the current time in a timezone")
-        .parameter(
-            "timezone",
-            json!({"type": "string", "description": "Timezone like PST, EST, JST"}),
-        )
-        .required(vec!["timezone".to_string()])
-        .build()
-}
-
-/// Checks if an error is a known API limitation for long conversation chains.
-fn is_long_conversation_api_error(error: &GenaiError) -> bool {
-    let error_str = format!("{:?}", error);
-    error_str.contains("UTF-8") || error_str.contains("spanner") || error_str.contains("truncated")
-}
 
 const SYSTEM_INSTRUCTION: &str = "You are a helpful assistant that uses available tools when appropriate. Always respond concisely.";
 

--- a/tests/multiturn_tests.rs
+++ b/tests/multiturn_tests.rs
@@ -13,7 +13,10 @@
 
 mod common;
 
-use common::{get_client, interaction_builder, stateful_builder, validate_response_semantically};
+use common::{
+    get_client, interaction_builder, is_long_conversation_api_error, stateful_builder,
+    validate_response_semantically,
+};
 use genai_rs::{Content, FunctionDeclaration, InteractionStatus};
 use serde_json::json;
 
@@ -27,18 +30,6 @@ const MIN_SUCCESSFUL_TURNS: usize = 3;
 
 /// Minimum facts the model should remember out of 10 in the recall test.
 const MIN_REMEMBERED_FACTS: usize = 5;
-
-// =============================================================================
-// Helper Functions
-// =============================================================================
-
-/// Checks if an error is a known API limitation for long conversation chains.
-/// These errors (UTF-8 encoding issues, spanner errors, truncation) can occur
-/// when the conversation context becomes too large.
-fn is_long_conversation_api_error(error: &genai_rs::GenaiError) -> bool {
-    let error_str = format!("{:?}", error);
-    error_str.contains("UTF-8") || error_str.contains("spanner") || error_str.contains("truncated")
-}
 
 // =============================================================================
 // Multi-turn: Very Long Conversations


### PR DESCRIPTION
## Summary

- Extract `write_to_map` helper on `StreamChunk` to eliminate ~60 lines of duplicated serialization logic between `StreamChunk` and `StreamEvent`
- Extract `auto_discover_tools` helper in `auto_functions.rs` to eliminate ~70 lines of duplicated function discovery logic
- Extract `extract_data_field` helper in `streaming.rs` deserializer
- Move shared test helpers (`get_weather_function`, `get_time_function`, `is_long_conversation_api_error`) to `tests/common/mod.rs`
- Remove unused `V1Alpha` variant from `ApiVersion` enum
- Fix minor CLAUDE.md wording (states → interactions)

**Net result:** -104 lines (216 added, 320 removed)

## Test plan

- [x] `make check` passes (fmt + clippy + 786 tests)
- [ ] Verify no behavioral changes via existing roundtrip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)