### PR TITLE
docs: Update deprecated gemini-3-pro-preview model references

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -470,7 +470,7 @@ let mut stream = client.interaction().create_stream();
 
 3. **Use appropriate model:**
 ```rust,ignore
-// gemini-3-flash-preview is faster than gemini-3-pro-preview
+// gemini-3-flash-preview is faster than gemini-3.1-pro-preview
 ```
 
 ### High Token Usage

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -148,7 +148,7 @@ let config = GenerationConfig {
 | Model | Default Max | Absolute Max |
 |-------|-------------|--------------|
 | gemini-3-flash-preview | 8192 | 8192 |
-| gemini-3-pro-preview | 8192 | 8192 |
+| gemini-3.1-pro-preview | 8192 | 8192 |
 
 Note: Actual limits vary by model version. Check [Google's documentation](https://ai.google.dev/models/gemini) for current values.
 

--- a/docs/RELIABILITY_PATTERNS.md
+++ b/docs/RELIABILITY_PATTERNS.md
@@ -460,7 +460,7 @@ async fn with_model_fallback(
 ) -> Result<String, GenaiError> {
     let models = [
         "gemini-3-flash-preview",
-        "gemini-3-pro-preview",
+        "gemini-3.1-pro-preview",
     ];
 
     for model in models {


### PR DESCRIPTION
## Summary

- Replaces 3 references to `gemini-3-pro-preview` (shut down March 9, 2026) with `gemini-3.1-pro-preview`
- Files: `docs/RELIABILITY_PATTERNS.md`, `docs/CONFIGURATION.md`, `TROUBLESHOOTING.md`

Closes #381 (Phase 3 — final phase)

## Test plan

- [x] `grep -r gemini-3-pro-preview` returns zero results
- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)