### PR TITLE
docs: Fix doc gaps from RFC #381 audit

### DIFF
--- a/docs/BUILDER_API.md
+++ b/docs/BUILDER_API.md
@@ -66,6 +66,7 @@ Methods follow a consistent naming pattern based on their behavior:
 | ~~`with_file_search_config()`~~ | — | — | **Removed** — use `add_tool(FileSearchConfig::new(stores))` |
 | **Generation Config** |
 | `with_allowed_tools(Vec<String>)` | with | replaces | Restricts model to named tools |
+| `with_image_config(ImageConfig)` | with | replaces | Image generation aspect ratio and size |
 | `with_function_calling_mode()` | with | replaces | Auto/Any/None/Validated |
 | `with_thinking_level()` | with | replaces | Chain-of-thought reasoning level |
 | `with_seed()` | with | replaces | Deterministic output |

--- a/docs/ENUM_WIRE_FORMATS.md
+++ b/docs/ENUM_WIRE_FORMATS.md
@@ -25,6 +25,7 @@ All types below implement graceful handling of unrecognized values via an `Unkno
 | 13 | `UrlRetrievalStatus` | src/response.rs | `status_type` | URL fetch status |
 | 14 | `ImageAspectRatio` | src/request.rs | `ratio_type` | Image aspect ratios (14 values) |
 | 15 | `ImageSize` | src/request.rs | `size_type` | Image resolution (512/1K/2K/4K) |
+| 16 | `SearchType` | src/tools.rs | `search_type` | Google Search types (web_search/image_search) |
 
 ### Unknown Variant Pattern
 


### PR DESCRIPTION
## Summary

- Add `SearchType` to "Types with Unknown Variants" numbered table in ENUM_WIRE_FORMATS.md
- Add `with_image_config(ImageConfig)` to Generation Config method table in BUILDER_API.md

Found by post-merge compliance audit.

## Test plan

- [x] Docs-only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)