### PR TITLE
fix: Audit-driven quality fixes (error variant, tests, docs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,15 +70,6 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings # Lint
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items  # Docs
 ```
 
-### Examples
-
-All require `GEMINI_API_KEY`. Key examples:
-- `cargo run --example simple_interaction` - Basic usage
-- `cargo run --example auto_function_calling` - Function calling
-- `cargo run --example streaming` - SSE streaming
-
-See `examples/` for full list (multimodal, thinking, files API, image generation, etc.)
-
 ## Architecture
 
 ### Layered Design
@@ -98,7 +89,7 @@ See `examples/` for full list (multimodal, thinking, files API, image generation
 | Category | Tools | Who Executes |
 |----------|-------|--------------|
 | Client-Side | `#[tool]` macro, `ToolService`, Manual | YOUR code |
-| Server-Side | Google Search, Code Execution, URL Context | API |
+| Server-Side | Google Search, Code Execution, URL Context, Google Maps | API |
 
 **Choosing Client-Side Approach**:
 | Approach | Registration | State | Best For |
@@ -222,21 +213,7 @@ GitHub Actions runs: check, test, test-strict-unknown, test-integration (5 matri
 | `with_*` | **Configures** a setting (replaces if called twice) | `with_model()`, `with_text()` |
 | `add_*` | **Accumulates** items to a collection | `add_function()`, `add_tool()` |
 
-**Getter patterns**:
-
-| Pattern | Purpose | Example |
-|---------|---------|---------|
-| `as_*()` | Extract enum variant as borrowed reference | `as_text()`, `as_parts()` |
-| `into_*()` | Extract enum variant, consuming self | `into_text()` |
-| `is_*()` | Check if value matches a variant/condition | `is_unknown()`, `is_empty()` |
-
-**Method suffixes**:
-
-| Suffix | Meaning | Example |
-|--------|---------|---------|
-| `*_stream()` | Returns `Stream<Item>` for async iteration | `create_stream()` |
-| `*_chunked()` | Uses chunked I/O internally, returns single result | `upload_file_chunked()` |
-| `*_with_auto_functions()` | Automatically executes functions in a loop | `create_stream_with_auto_functions()` |
+**Method suffix**: `*_with_auto_functions()` automatically executes functions in a loop with timeout/storage semantics — see `docs/MULTI_TURN_FUNCTION_CALLING.md`.
 
 ### #[must_use] Annotation
 

--- a/src/proptest_tests.rs
+++ b/src/proptest_tests.rs
@@ -980,7 +980,7 @@ fn arb_known_tool() -> impl Strategy<Value = Tool> {
             }),
         // ComputerUse tool
         (
-            Just("browser".to_string()),
+            prop_oneof![Just("browser".to_string()), arb_identifier()],
             proptest::collection::vec(arb_identifier(), 0..3),
         )
             .prop_map(|(environment, excluded)| Tool::ComputerUse {

--- a/src/proptest_tests.rs
+++ b/src/proptest_tests.rs
@@ -978,6 +978,15 @@ fn arb_known_tool() -> impl Strategy<Value = Tool> {
                     metadata_filter,
                 }
             }),
+        // ComputerUse tool
+        (
+            Just("browser".to_string()),
+            proptest::collection::vec(arb_identifier(), 0..3),
+        )
+            .prop_map(|(environment, excluded)| Tool::ComputerUse {
+                environment,
+                excluded_predefined_functions: excluded,
+            }),
         // MCP Server (use BTreeMap for deterministic JSON key ordering in roundtrip tests)
         (
             arb_identifier(),

--- a/src/response.rs
+++ b/src/response.rs
@@ -1281,7 +1281,7 @@ impl InteractionResponse {
                 let bytes = base64::engine::general_purpose::STANDARD
                     .decode(base64_data)
                     .map_err(|e| {
-                        GenaiError::InvalidInput(format!("Invalid base64 image data: {}", e))
+                        GenaiError::MalformedResponse(format!("Invalid base64 image data: {}", e))
                     })?;
                 return Ok(Some(bytes));
             }

--- a/src/response_tests.rs
+++ b/src/response_tests.rs
@@ -704,6 +704,92 @@ fn test_interaction_response_url_context_helpers() {
     assert!(url_results[0].items[0].is_success());
 }
 
+#[test]
+fn test_interaction_response_google_maps_helpers() {
+    use super::content::{GoogleMapsResultItem, Place};
+
+    let response = InteractionResponse {
+        id: Some("test_id".to_string()),
+        model: Some("gemini-3-flash-preview".to_string()),
+        agent: None,
+        input: vec![],
+        outputs: vec![
+            Content::GoogleMapsResult {
+                call_id: "maps_123".to_string(),
+                signature: None,
+                result: vec![GoogleMapsResultItem {
+                    places: Some(vec![Place {
+                        name: Some("Eiffel Tower".to_string()),
+                        formatted_address: Some("Paris, France".to_string()),
+                        place_id: Some("ChIJLU7jZClu5kcR".to_string()),
+                        lat: Some(48.8584),
+                        lng: Some(2.2945),
+                        types: None,
+                        rating: None,
+                        user_ratings_total: None,
+                        website: None,
+                        phone_number: None,
+                        extra: serde_json::Map::new(),
+                    }]),
+                    widget_context_token: Some("token123".to_string()),
+                }],
+            },
+            Content::Text {
+                text: Some("Here are the maps results.".to_string()),
+                annotations: None,
+            },
+        ],
+        status: InteractionStatus::Completed,
+        usage: None,
+        tools: None,
+        previous_interaction_id: None,
+        grounding_metadata: None,
+        url_context_metadata: None,
+        created: None,
+        updated: None,
+    };
+
+    assert!(response.has_google_maps_results());
+
+    let maps_results = response.google_maps_results();
+    assert_eq!(maps_results.len(), 1);
+    assert_eq!(maps_results[0].call_id, "maps_123");
+    assert_eq!(maps_results[0].items.len(), 1);
+
+    let places = maps_results[0].items[0].places.as_ref().unwrap();
+    assert_eq!(places.len(), 1);
+    assert_eq!(places[0].name.as_deref(), Some("Eiffel Tower"));
+    assert_eq!(
+        places[0].formatted_address.as_deref(),
+        Some("Paris, France")
+    );
+}
+
+#[test]
+fn test_interaction_response_google_maps_helpers_empty() {
+    let response = InteractionResponse {
+        id: Some("test_id".to_string()),
+        model: Some("gemini-3-flash-preview".to_string()),
+        agent: None,
+        input: vec![],
+        outputs: vec![Content::Text {
+            text: Some("No maps here.".to_string()),
+            annotations: None,
+        }],
+        status: InteractionStatus::Completed,
+        usage: None,
+        tools: None,
+        previous_interaction_id: None,
+        grounding_metadata: None,
+        url_context_metadata: None,
+        created: None,
+        updated: None,
+    };
+
+    assert!(!response.has_google_maps_results());
+    assert!(response.google_maps_results().is_empty());
+}
+
 // --- URL Context Metadata Tests ---
 
 #[test]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -436,6 +436,7 @@ impl FunctionDeclaration {
     }
 
     /// Converts this FunctionDeclaration into a Tool for API requests
+    #[must_use]
     pub fn into_tool(self) -> Tool {
         Tool::Function {
             name: self.name,

--- a/tests/proptest_roundtrip_tests.rs
+++ b/tests/proptest_roundtrip_tests.rs
@@ -108,6 +108,7 @@ fn arb_interaction_status() -> impl Strategy<Value = InteractionStatus> {
         Just(InteractionStatus::RequiresAction),
         Just(InteractionStatus::Failed),
         Just(InteractionStatus::Cancelled),
+        Just(InteractionStatus::Incomplete),
     ]
 }
 
@@ -625,6 +626,7 @@ fn arb_interaction_status_with_unknown() -> impl Strategy<Value = InteractionSta
         Just(InteractionStatus::RequiresAction),
         Just(InteractionStatus::Failed),
         Just(InteractionStatus::Cancelled),
+        Just(InteractionStatus::Incomplete),
         // Unknown variant via JSON deserialization
         arb_unknown_type_string().prop_map(|type_str| {
             serde_json::from_value::<InteractionStatus>(serde_json::json!(type_str))

--- a/tests/tools_and_config_tests.rs
+++ b/tests/tools_and_config_tests.rs
@@ -1619,22 +1619,16 @@ mod config_fields {
         let text = response.as_text().expect("Should have text response");
         println!("Stop sequence response: {}", text);
 
-        // The response should NOT contain numbers after 5 since we stopped there
-        // It may or may not include 5 itself (stop sequences may or may not be included)
-        let has_six_or_higher = text.contains("6")
-            || text.contains("7")
-            || text.contains("8")
-            || text.contains("9")
-            || text.contains("10");
-
-        if !has_six_or_higher {
-            println!("✓ Stop sequence correctly halted generation before 6-10");
-        } else {
-            println!(
-                "Note: Stop sequence may not have halted as expected (API behavior may vary): {}",
-                text
-            );
-        }
+        // The response should be shorter than a full 1-10 count.
+        // Stop sequences halt generation, so we expect fewer numbers.
+        // We verify the response doesn't contain the later numbers (8, 9, 10)
+        // which would indicate the stop sequence had no effect at all.
+        let has_late_numbers = text.contains("8") || text.contains("9") || text.contains("10");
+        assert!(
+            !has_late_numbers,
+            "Stop sequence '5' should have halted generation before 8-10, got: {}",
+            text
+        );
     }
 
     /// Test response_mime_type with structured output.


### PR DESCRIPTION
## Summary

- Fix `first_image_bytes()` error variant: `InvalidInput` → `MalformedResponse` (base64 from API is not user input)
- Add `#[must_use]` to `FunctionDeclaration::into_tool()` (consumes self, dropping result is a bug)
- Fill proptest strategy gaps: `InteractionStatus::Incomplete`, `Tool::ComputerUse`
- Fix `test_generation_config_stop_sequences` — had zero real assertions
- Add GoogleMaps response helper unit tests (2 new tests)
- Update stale `add_mcp_server()` doc references → `add_tool()`
- Trim CLAUDE.md: remove discoverable getter patterns table and examples section, add Google Maps to server-side tools

Fixes #386

## Test plan

- [x] `make check` passes (fmt + clippy + 824 tests)
- [x] New GoogleMaps tests verify both populated and empty response cases
- [x] Stop sequences test now asserts instead of just printing
- [x] Proptest strategies cover Incomplete and ComputerUse variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)