### PR TITLE
fix: Use snake_case for response_format wire format

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -480,7 +480,6 @@ impl<'de> Visitor<'de> for ThinkingLevelVisitor {
 
 /// Generation configuration for model behavior
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
 pub struct GenerationConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
@@ -556,7 +555,6 @@ pub struct GenerationConfig {
 /// See [Google's TTS documentation](https://ai.google.dev/gemini-api/docs/text-generation)
 /// for the full list of available voices.
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
 pub struct SpeechConfig {
     /// The voice to use for speech synthesis.
     ///
@@ -614,7 +612,7 @@ impl SpeechConfig {
 /// };
 /// ```
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(default)]
 pub struct ImageConfig {
     /// The aspect ratio for generated images.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -952,7 +950,6 @@ impl<'de> Deserialize<'de> for ImageSize {
 /// # }
 /// ```
 #[derive(Clone, Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
 pub struct InteractionRequest {
     /// Model name (e.g., "gemini-3-flash-preview") - mutually exclusive with agent
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -982,7 +979,6 @@ pub struct InteractionRequest {
     pub response_modalities: Option<Vec<String>>,
 
     /// JSON schema for structured output
-    #[serde(rename = "response_format")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<serde_json::Value>,
 
@@ -1712,8 +1708,8 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(value["aspectRatio"], "1:1");
-        assert!(value.get("imageSize").is_none());
+        assert_eq!(value["aspect_ratio"], "1:1");
+        assert!(value.get("image_size").is_none());
     }
 
     #[test]
@@ -1736,8 +1732,8 @@ mod tests {
         let json = serde_json::to_string(&config).expect("Serialization failed");
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(value["imageConfig"]["aspectRatio"], "9:16");
-        assert_eq!(value["imageConfig"]["imageSize"], "4K");
+        assert_eq!(value["image_config"]["aspect_ratio"], "9:16");
+        assert_eq!(value["image_config"]["image_size"], "4K");
     }
 
     // =========================================================================
@@ -1754,7 +1750,7 @@ mod tests {
         let json = serde_json::to_string(&config).expect("Serialization failed");
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
-        let tools = value["allowedTools"].as_array().unwrap();
+        let tools = value["allowed_tools"].as_array().unwrap();
         assert_eq!(tools.len(), 2);
         assert_eq!(tools[0], "get_weather");
         assert_eq!(tools[1], "get_time");
@@ -1771,8 +1767,8 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
         assert!(
-            value.get("allowedTools").is_none(),
-            "allowedTools should be omitted when None"
+            value.get("allowed_tools").is_none(),
+            "allowed_tools should be omitted when None"
         );
     }
 }

--- a/src/request_tests.rs
+++ b/src/request_tests.rs
@@ -50,8 +50,8 @@ fn test_generation_config_serialization() {
     let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
     assert_eq!(value["temperature"], 0.7);
-    assert_eq!(value["maxOutputTokens"], 500);
-    assert_eq!(value["thinkingLevel"], "medium");
+    assert_eq!(value["max_output_tokens"], 500);
+    assert_eq!(value["thinking_level"], "medium");
 }
 
 #[test]
@@ -75,11 +75,10 @@ fn test_generation_config_new_fields_serialization() {
     let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
     assert_eq!(value["seed"], 42);
-    assert_eq!(value["stopSequences"][0], "END");
-    assert_eq!(value["stopSequences"][1], "---");
-    // GenerationConfig uses lowercase format for thinkingSummaries
-    assert_eq!(value["thinkingSummaries"], "auto");
-    assert_eq!(value["thinkingLevel"], "high");
+    assert_eq!(value["stop_sequences"][0], "END");
+    assert_eq!(value["stop_sequences"][1], "---");
+    assert_eq!(value["thinking_summaries"], "auto");
+    assert_eq!(value["thinking_level"], "high");
 }
 
 #[test]
@@ -267,9 +266,9 @@ fn test_generation_config_partial_fields() {
 
     // Only set fields should be present
     assert_eq!(value["seed"], 42);
-    assert_eq!(value["stopSequences"][0], "DONE");
+    assert_eq!(value["stop_sequences"][0], "DONE");
     assert!(value.get("temperature").is_none());
-    assert!(value.get("thinkingLevel").is_none());
+    assert!(value.get("thinking_level").is_none());
 }
 
 #[test]
@@ -462,8 +461,7 @@ fn test_create_interaction_request_with_agent_config() {
 /// - `thinking_summaries` key uses snake_case per API documentation
 /// - Values use SCREAMING_SNAKE_CASE: "THINKING_SUMMARIES_AUTO", "THINKING_SUMMARIES_NONE"
 ///
-/// Note: The Gemini Interactions API uses snake_case for field names, which differs from
-/// the camelCase used in GenerationConfig (which has `#[serde(rename_all = "camelCase")]`).
+/// Note: The Gemini Interactions API uses snake_case for field names.
 #[test]
 fn test_agent_config_field_naming_conventions() {
     // Verify the exact JSON structure matches API expectations
@@ -588,9 +586,7 @@ fn test_response_format_serializes_as_snake_case() {
     let json = serde_json::to_string(&request).expect("Serialization failed");
 
     // The Gemini Interactions API requires snake_case for response_format.
-    // The struct-level rename_all = "camelCase" would produce "responseFormat",
-    // which the API silently misinterprets. The field-level #[serde(rename)]
-    // override ensures we send the correct wire format.
+    // Verify the struct serializes field names as snake_case (matching Rust field names).
     assert!(
         json.contains("\"response_format\""),
         "Expected snake_case 'response_format' in JSON, got: {json}"
@@ -598,5 +594,15 @@ fn test_response_format_serializes_as_snake_case() {
     assert!(
         !json.contains("\"responseFormat\""),
         "Must NOT contain camelCase 'responseFormat' in JSON, got: {json}"
+    );
+
+    // Verify deserialization also uses snake_case key.
+    // This guards against regressions where removing the rename would cause
+    // incoming JSON with "response_format" to silently drop the field.
+    let roundtripped: InteractionRequest =
+        serde_json::from_str(&json).expect("Deserialization failed");
+    assert!(
+        roundtripped.response_format.is_some(),
+        "response_format should survive serialization roundtrip"
     );
 }

--- a/tests/multimodal_tests.rs
+++ b/tests/multimodal_tests.rs
@@ -1285,8 +1285,8 @@ mod text_to_speech {
         };
 
         let mut request_json = serde_json::to_value(&request).expect("Serialize request");
-        request_json["generationConfig"] = json!({
-            "speechConfig": nested_speech_config
+        request_json["generation_config"] = json!({
+            "speech_config": nested_speech_config
         });
 
         let nested_response = http_client

--- a/tests/tools_and_config_tests.rs
+++ b/tests/tools_and_config_tests.rs
@@ -1751,7 +1751,7 @@ mod function_calling_modes {
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(
-            json["toolChoice"],
+            json["tool_choice"],
             serde_json::Value::String("AUTO".to_string())
         );
 
@@ -1762,7 +1762,7 @@ mod function_calling_modes {
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(
-            json["toolChoice"],
+            json["tool_choice"],
             serde_json::Value::String("ANY".to_string())
         );
 
@@ -1773,7 +1773,7 @@ mod function_calling_modes {
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(
-            json["toolChoice"],
+            json["tool_choice"],
             serde_json::Value::String("NONE".to_string())
         );
 
@@ -1784,7 +1784,7 @@ mod function_calling_modes {
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(
-            json["toolChoice"],
+            json["tool_choice"],
             serde_json::Value::String("VALIDATED".to_string())
         );
 


### PR DESCRIPTION
## Summary

- Remove `rename_all = "camelCase"` from all request-side structs (`InteractionRequest`, `GenerationConfig`, `SpeechConfig`, `ImageConfig`) — Rust field names are already snake_case, so they now serialize correctly without any rename
- The Gemini Interactions API silently misinterprets `responseFormat` (camelCase) as a `genai.Value` instead of a JSON schema — only `response_format` (snake_case) works correctly
- All other fields accept both formats, but snake_case is the documented API convention and prevents this class of bug
- Add serialization + deserialization roundtrip test for `response_format`
- Fix flaky `test_generation_config_combined` — increase `max_output_tokens` from 200 to 2048 since thinking tokens now consume part of the budget

## Root cause

Verified with `LOUD_WIRE=1` and direct API calls:
- `responseFormat: {"type": "object", "properties": {...}}` → 400: "no such field: 'properties'"
- `response_format: {"type": "object", "properties": {...}}` → 200: works correctly
- All other multi-word fields accept both camelCase and snake_case

## Test plan

- [x] `make check` passes (823 tests, fmt, clippy)
- [x] `test_response_format_serializes_as_snake_case` verifies serialization + deserialization roundtrip
- [x] All unit test assertions updated from camelCase to snake_case keys
- [ ] Integration tests (CI) — this fix unblocks PR #387's integration test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)