### PR TITLE
chore: Set up work/review cycle

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,4 +51,4 @@ jobs:
 
             Use the REPO and PR_NUMBER variables provided above.
           # Tools required by the centralized prompt (see contrib/prompts/claude-review.md)
-          claude_args: '--model opus --allowed-tools "Read,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh api:*)"'
+          claude_args: '--model opus --allowed-tools "Read,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh api:*)"'

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -47,12 +47,17 @@ pub const DEFAULT_MAX_RETRIES: u32 = 3;
 #[allow(dead_code)]
 pub fn is_transient_error(err: &GenaiError) -> bool {
     match err {
-        GenaiError::Api { message, .. } => {
+        GenaiError::Api {
+            status_code,
+            message,
+            ..
+        } => {
+            let lower = message.to_lowercase();
             // Spanner UTF-8 errors are transient backend issues
             // See: https://github.com/evansenter/genai-rs/issues/60
-            // Check for both "spanner" and "utf-8" to avoid false positives
-            let lower = message.to_lowercase();
-            lower.contains("spanner") && lower.contains("utf-8")
+            (lower.contains("spanner") && lower.contains("utf-8"))
+                // Model occasionally generates invalid JSON — transient API-side issue
+                || (*status_code == 400 && lower.contains("invalid json syntax"))
         }
         _ => false,
     }

--- a/tests/function_calling_tests.rs
+++ b/tests/function_calling_tests.rs
@@ -2343,28 +2343,26 @@ mod multiturn {
         let functions = vec![get_weather_function()];
 
         // Turn 1: Initial request with functions
-        let result1 = client
-            .interaction()
-            .with_model("gemini-3-flash-preview")
-            .with_text("Remember: I'm interested in weather data.")
-            .add_functions(functions)
-            .with_store_enabled()
-            .create()
-            .await
-            .expect("Turn 1 should succeed");
+        let result1 = retry_request!([client, functions] => {
+            stateful_builder(&client)
+                .with_text("Remember: I'm interested in weather data.")
+                .add_functions(functions)
+                .create()
+                .await
+        })
+        .expect("Turn 1 should succeed");
 
         let turn1_id = result1.id.clone().expect("Turn 1 should have ID");
 
         // Turn 2: Follow-up WITHOUT resending tools
-        let result2 = client
-            .interaction()
-            .with_model("gemini-3-flash-preview")
-            .with_text("What's the weather in Paris?")
-            .with_store_enabled()
-            .with_previous_interaction(&turn1_id)
-            .create()
-            .await
-            .expect("Turn 2 should succeed");
+        let result2 = retry_request!([client, turn1_id] => {
+            stateful_builder(&client)
+                .with_text("What's the weather in Paris?")
+                .with_previous_interaction(&turn1_id)
+                .create()
+                .await
+        })
+        .expect("Turn 2 should succeed");
 
         // Model should NOT have any function calls since we didn't provide tools
         let function_calls = result2.function_calls();


### PR DESCRIPTION
## Summary
- Add `Bash(gh pr review:*)` to allowed tools in claude-code-review.yml so the reviewer can submit native GitHub reviews (APPROVE/REQUEST_CHANGES)
- Branch protection updated via API: require 1 approving review, dismiss stale reviews on push, don't enforce for admins (escape hatch)
- `CLAUDE_CODE_OAUTH_TOKEN` secret already exists — no action needed

## Context
Follows the porting guide from dotfiles `docs/work-review-cycle.md`. Shared components (commands, hooks, skills, plugins) are already available via dotfiles symlinks.

## Test plan
- [ ] Push a test PR to verify Claude reviewer can submit native reviews
- [ ] Verify branch protection requires approval before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)