### PR TITLE
Release prep: fold #399 changelog entries into 0.8.0, date 2026-07-14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,41 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-- **Antigravity: workspace announcement.** `add_workspace(..)` roots are now
-  announced to the model automatically — `spawn()` appends a concise,
-  delimited note listing the configured workspace root(s) to the effective
-  system instructions (the string passed to `with_system_instructions` is
-  never mutated), and appends the same note to every subagent's instructions.
-  Agents no longer guess workspace paths. Opt out with
-  `AgentBuilder::with_workspace_announcement(false)`. The wire protocol has no
-  native announcement field, so this is prompt-level grounding.
-- **Antigravity: `ToolAction::subagent_name()`** and a typed
-  `ActionInvokeSubagent::name` field (Evergreen; `None` on harness 0.1.5,
-  which emits an empty `invokeSubagent` action).
-- **Antigravity: `ToolDecision`** (`Allowed` / `Denied { reason }`) and
-  **`ErrorSeverity`** (`Transient` / `Severe`) public enums.
-
-### Changed
-
-- **Antigravity (breaking): `AgentEvent::ToolAction`** is now a struct variant
-  `ToolAction { action, decision, trajectory_id }`. `decision` distinguishes
-  executed actions from policy/hook-denied ones (previously indistinguishable
-  in the stream), and `trajectory_id` tells parent and subagent actions apart.
-- **Antigravity (breaking): `AgentEvent::Error(String)`** is now
-  `Error { message, severity }` so consumers can ignore transient
-  harness-internal noise (retried internally; the turn continues) and react
-  only to `Severe` errors. Turn-ending failures still surface as
-  `AntigravityError::Turn`.
-- **Antigravity (behavior): `ToolOutcome.result`** passed to post-tool hooks
-  is now the inner tool result, not the raw `{"result": ...}` wire envelope
-  (a scalar arrives as its string form; an object is passed through
-  serialized).
-
-## [0.8.0] - 2026-07-07
+## [0.8.0] - 2026-07-14
 
 This release migrates the crate to Interactions API wire revision
 **2026-05-20** (the steps model), adds the remaining 2026-05-20 API surface
@@ -326,6 +292,20 @@ still rustls.
   application: repo workspace, read-only built-ins, custom `#[tool]`
   severity classifier, subagents, structured report output.
 
+- **Antigravity: workspace announcement.** `add_workspace(..)` roots are now
+  announced to the model automatically — `spawn()` appends a concise,
+  delimited note listing the configured workspace root(s) to the effective
+  system instructions (the string passed to `with_system_instructions` is
+  never mutated), and appends the same note to every subagent's instructions.
+  Agents no longer guess workspace paths. Opt out with
+  `AgentBuilder::with_workspace_announcement(false)`. The wire protocol has no
+  native announcement field, so this is prompt-level grounding.
+- **Antigravity: `ToolAction::subagent_name()`** and a typed
+  `ActionInvokeSubagent::name` field (Evergreen; `None` on harness 0.1.5,
+  which emits an empty `invokeSubagent` action).
+- **Antigravity: `ToolDecision`** (`Allowed` / `Denied { reason }`) and
+  **`ErrorSeverity`** (`Transient` / `Severe`) public enums.
+
 ### Changed
 
 #### Breaking — response model (`outputs` → `steps`)
@@ -457,6 +437,20 @@ still rustls.
   process-global counter).
 - Proptest roundtrip comparisons use `serde_json::Value` for HashMap key
   order independence.
+
+- **Antigravity (breaking): `AgentEvent::ToolAction`** is now a struct variant
+  `ToolAction { action, decision, trajectory_id }`. `decision` distinguishes
+  executed actions from policy/hook-denied ones (previously indistinguishable
+  in the stream), and `trajectory_id` tells parent and subagent actions apart.
+- **Antigravity (breaking): `AgentEvent::Error(String)`** is now
+  `Error { message, severity }` so consumers can ignore transient
+  harness-internal noise (retried internally; the turn continues) and react
+  only to `Severe` errors. Turn-ending failures still surface as
+  `AntigravityError::Turn`.
+- **Antigravity (behavior): `ToolOutcome.result`** passed to post-tool hooks
+  is now the inner tool result, not the raw `{"result": ...}` wire envelope
+  (a scalar arrives as its string form; an object is passed through
+  serialized).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,19 +279,6 @@ still rustls.
     names are unique; nested subagents are force-disabled (harness
     limitation, reference-SDK parity).
 
-#### New examples
-
-- `examples/webhooks_and_background.rs` — webhook resource lifecycle +
-  per-request webhook routing (runs without an API key, printing request
-  shapes).
-- `examples/retrieval_grounding.rs` — retrieval tool over Vertex AI
-  Search, RAG store, and Exa.ai backends.
-- `examples/antigravity_agent.rs` — Antigravity harness walkthrough
-  (requires `--features antigravity`).
-- `examples/real_world/repo_auditor/` — end-to-end Antigravity bridge
-  application: repo workspace, read-only built-ins, custom `#[tool]`
-  severity classifier, subagents, structured report output.
-
 - **Antigravity: workspace announcement.** `add_workspace(..)` roots are now
   announced to the model automatically — `spawn()` appends a concise,
   delimited note listing the configured workspace root(s) to the effective
@@ -305,6 +292,19 @@ still rustls.
   which emits an empty `invokeSubagent` action).
 - **Antigravity: `ToolDecision`** (`Allowed` / `Denied { reason }`) and
   **`ErrorSeverity`** (`Transient` / `Severe`) public enums.
+
+#### New examples
+
+- `examples/webhooks_and_background.rs` — webhook resource lifecycle +
+  per-request webhook routing (runs without an API key, printing request
+  shapes).
+- `examples/retrieval_grounding.rs` — retrieval tool over Vertex AI
+  Search, RAG store, and Exa.ai backends.
+- `examples/antigravity_agent.rs` — Antigravity harness walkthrough
+  (requires `--features antigravity`).
+- `examples/real_world/repo_auditor/` — end-to-end Antigravity bridge
+  application: repo workspace, read-only built-ins, custom `#[tool]`
+  severity classifier, subagents, structured report output.
 
 ### Changed
 
@@ -426,17 +426,7 @@ still rustls.
 - Minor dependency bumps: tokio 1.48 → 1.52, proptest 1.9 → 1.11,
   utoipa 5.4 → 5.5.
 
-#### Other changes
-
-- `Tool::GoogleSearch` is now a struct variant with optional
-  `search_types` field (was unit variant).
-- New default-on feature `wire-color` gates the `colored`/`colored_json`
-  dependencies; build with `default-features = false` for plain-text wire
-  output.
-- Wire debug request ids are now per-`Client` (previously a
-  process-global counter).
-- Proptest roundtrip comparisons use `serde_json::Value` for HashMap key
-  order independence.
+#### Antigravity
 
 - **Antigravity (breaking): `AgentEvent::ToolAction`** is now a struct variant
   `ToolAction { action, decision, trajectory_id }`. `decision` distinguishes
@@ -451,6 +441,18 @@ still rustls.
   is now the inner tool result, not the raw `{"result": ...}` wire envelope
   (a scalar arrives as its string form; an object is passed through
   serialized).
+
+#### Other changes
+
+- `Tool::GoogleSearch` is now a struct variant with optional
+  `search_types` field (was unit variant).
+- New default-on feature `wire-color` gates the `colored`/`colored_json`
+  dependencies; build with `default-features = false` for plain-text wire
+  output.
+- Wire debug request ids are now per-`Client` (previously a
+  process-global counter).
+- Proptest roundtrip comparisons use `serde_json::Value` for HashMap key
+  order independence.
 
 ### Fixed
 


### PR DESCRIPTION
# Summary

CHANGELOG-only release prep for tagging `v0.8.0`. The #399 ergonomics follow-up (workspace announcement, `ToolDecision`/`ErrorSeverity`, trajectory id, result unwrapping) ships in 0.8.0, but its entries sat under `[Unreleased]`. This folds them verbatim into the existing `[0.8.0]` section's `### Added`/`### Changed` lists and sets the release date to 2026-07-14 (tag date).

No code changes. Once merged, `v0.8.0` will be tagged on the merge commit — the tag push triggers `release.yml` (validate → crates.io publish → GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqkKDDoTDKUp9zBk4M8WGH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqkKDDoTDKUp9zBk4M8WGH)_