### PR TITLE
0.9.0 follow-up: antigravity harness 0.1.10, model migration, and two live-API fixes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,6 +90,11 @@ jobs:
       # by hand, not by any test. Both finish in seconds.
       - name: Smoke-run antigravity examples
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        # Belt and braces alongside the examples' own with_turn_timeout: a
+        # harness that stops signalling turn completion hangs rather than
+        # errors, and an unbounded step would burn the runner's full budget
+        # instead of going red.
+        timeout-minutes: 15
         run: |
           set -eo pipefail
           for ex in session_resume workspace_explorer; do

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,6 +58,9 @@ jobs:
   test-antigravity:
     name: Test Suite (antigravity)
     runs-on: ubuntu-latest
+    # Same-repo guard as test-integration: the harness tests below need
+    # GEMINI_API_KEY, so forks must not run them.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -67,11 +70,19 @@ jobs:
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Install pinned localharness wheel
         # Version must match SUPPORTED_HARNESS_VERSION in src/antigravity/.
-        run: pip install google-antigravity==0.1.5
+        run: pip install google-antigravity==0.1.10
       - name: Run unit tests with antigravity feature
         run: cargo nextest run --workspace --features antigravity
-      - name: Run harness integration tests (API-key tests self-skip)
+      # The model-backed tests in this binary are the only ones that
+      # drive a real turn end-to-end, which makes them the only guard
+      # against a harness protocol change breaking turn completion. They
+      # self-skip without a key — so omitting it here made them pass
+      # vacuously, and the harness 0.1.5 -> 0.1.10 terminal-state rename
+      # (every turn hanging to timeout) went unnoticed.
+      - name: Run harness integration tests
         run: cargo nextest run --features antigravity --run-ignored all -E 'binary(antigravity_harness)'
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   test-integration:
     name: Integration Tests (${{ matrix.group }})

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,7 +81,10 @@ jobs:
       # running the antigravity-gated unit tests entirely.
       - name: Run harness integration tests
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        run: cargo nextest run --features antigravity --run-ignored all -E 'binary(antigravity_harness)'
+        # --retries 2 for the same reason as the integration matrix: this
+        # step now draws on the same shared key, so it sees the same
+        # low-rate 429s. A retried test is reported FLAKY, not hidden.
+        run: cargo nextest run --features antigravity --run-ignored all --retries 2 -E 'binary(antigravity_harness)'
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       # Examples were compiled but never executed, so bugs that only show
@@ -144,7 +147,14 @@ jobs:
             # closed and the skip warning still fires on a failing run —
             # the run where the skip count is most diagnostic.
             rc=0
-            cargo nextest run --test $test --run-ignored all --success-output=final 2>&1 | tee "/tmp/$test.log" || rc=$?
+            # --retries 2: the shared project key sees a low-rate 429 under
+            # a five-way matrix, and nextest is fail-fast — so one transient
+            # error discards the rest of the group (observed: 30 of 37 tests
+            # skipped for a single 429). Retrying only the failed test costs
+            # one call instead of re-running the matrix. Nothing is hidden:
+            # a test that needed a retry is reported FLAKY, which is exactly
+            # what the ci-flakiness-report job is for.
+            cargo nextest run --test $test --run-ignored all --retries 2 --success-output=final 2>&1 | tee "/tmp/$test.log" || rc=$?
             echo "::endgroup::"
             skips=$(grep -c SEMANTIC_VALIDATION_SKIPPED "/tmp/$test.log" || true)
             if [ "${skips:-0}" -gt 3 ]; then

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,7 +97,15 @@ jobs:
         # harness that stops signalling turn completion hangs rather than
         # errors, and an unbounded step would burn the runner's full budget
         # instead of going red.
-        timeout-minutes: 15
+        #
+        # Sized above what the retry loop below can actually spend: five
+        # examples, up to three attempts each, per-turn budgets of 120s
+        # (180s for cancellable_turn) plus spawn and backoff. At 15 the
+        # ceiling sat *below* the retry policy's own worst case, so a run
+        # where a few examples retried would go red on the timeout — which
+        # reads as "an example failed" rather than "the retries ran long",
+        # the exact misattribution the retry loop exists to avoid.
+        timeout-minutes: 30
         run: |
           set -eo pipefail
           # Retry each example, for the same reason the nextest steps use

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,7 +100,7 @@ jobs:
         timeout-minutes: 15
         run: |
           set -eo pipefail
-          for ex in session_resume workspace_explorer; do
+          for ex in session_resume workspace_explorer mcp_toolbelt proactive_agent cancellable_turn; do
             echo "::group::cargo run --example $ex"
             cargo run --features antigravity --example "$ex"
             echo "::endgroup::"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,6 +84,21 @@ jobs:
         run: cargo nextest run --features antigravity --run-ignored all -E 'binary(antigravity_harness)'
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      # Examples were compiled but never executed, so bugs that only show
+      # up in a real run stayed invisible: `on_post_tool` reporting every
+      # successful builtin as a failure was found by running one of these
+      # by hand, not by any test. Both finish in seconds.
+      - name: Smoke-run antigravity examples
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          set -eo pipefail
+          for ex in session_resume workspace_explorer; do
+            echo "::group::cargo run --example $ex"
+            cargo run --features antigravity --example "$ex"
+            echo "::endgroup::"
+          done
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   test-integration:
     name: Integration Tests (${{ matrix.group }})

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,9 +58,6 @@ jobs:
   test-antigravity:
     name: Test Suite (antigravity)
     runs-on: ubuntu-latest
-    # Same-repo guard as test-integration: the harness tests below need
-    # GEMINI_API_KEY, so forks must not run them.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -79,7 +76,11 @@ jobs:
       # self-skip without a key — so omitting it here made them pass
       # vacuously, and the harness 0.1.5 -> 0.1.10 terminal-state rename
       # (every turn hanging to timeout) went unnoticed.
+      # Same-repo guard on this step only, not the job: the unit-test step
+      # above needs no key, and gating the whole job would stop forks from
+      # running the antigravity-gated unit tests entirely.
       - name: Run harness integration tests
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         run: cargo nextest run --features antigravity --run-ignored all -E 'binary(antigravity_harness)'
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,9 +100,26 @@ jobs:
         timeout-minutes: 15
         run: |
           set -eo pipefail
+          # Retry each example, for the same reason the nextest steps use
+          # --retries: four of the five hard-fail on LLM-dependent outcomes
+          # (no MCP call made, fewer than N chars streamed before the halt,
+          # no trigger inside the window, empty restored history). Those
+          # assertions are deliberate — a run that proves nothing must not
+          # pass green — but a single unlucky turn should not redden an
+          # unrelated PR. `cargo run` has no --retries, hence the loop.
           for ex in session_resume workspace_explorer mcp_toolbelt proactive_agent cancellable_turn; do
             echo "::group::cargo run --example $ex"
-            cargo run --features antigravity --example "$ex"
+            attempt=1
+            until cargo run --features antigravity --example "$ex"; do
+              if [ "$attempt" -ge 3 ]; then
+                echo "::error::$ex failed $attempt times"
+                echo "::endgroup::"
+                exit 1
+              fi
+              echo "::warning::$ex failed (attempt $attempt), retrying"
+              attempt=$((attempt + 1))
+              sleep 5
+            done
             echo "::endgroup::"
           done
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate and ignored the value, which meant filtering did not work on the
   one surface that emits WebSocket messages at all.
 
+- **`LOUD_WIRE` selectors reach step actions.** A selector now matches one
+  level into a WebSocket payload, so `LOUD_WIRE=mcpTool` (or `runCommand`,
+  `viewFile`, …) selects the steps carrying that action — previously those
+  names matched nothing at all, because every builtin action lives under
+  the single `stepUpdate` key. Summary lines are qualified to match
+  (`stepUpdate/mcpTool`), so what you asked for is what the output names.
+
+- **The protocol-drift guard now covers field renames, not just enum
+  values.** The 0.1.5 → 0.1.10 upgrade shipped one of each — `STATE_IDLE`
+  → `STATE_FULLY_IDLE` (a value) and `usageMetadata` → `usageUpdate` (a
+  field) — so a guard checking only enums would have caught half the break
+  it was written for. It now also checks the `OutputEvent` and `InputEvent`
+  wire fields the crate reads by hand, where a rename yields a silent
+  `None` rather than a parse error.
+
 - **Three more antigravity worked examples**, all runnable against a real
   harness and smoke-run in CI: `mcp_toolbelt` (external tools over MCP,
   with a dependency-free stdio server fixture and the `mcp_<server>_<tool>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,74 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Changed
-
-- **Default model guidance moves to `gemini-3.6-flash`** (from
-  `gemini-3-flash-preview`) across docs, examples, and tests, and image
-  generation moves to `gemini-3.1-flash-image` (from
-  `gemini-3-pro-image-preview`). Both were probed live before migrating.
-
-  One capability difference surfaced and is worth knowing: `gemini-3.6-flash`
-  returns `400 invalid_request` for **inline (base64) video bytes** while
-  accepting video **by URI**. Image, audio and PDF inline data are
-  unaffected. The three inline-video tests are pinned to a model that
-  accepts that form (`tests/common::VIDEO_INLINE_MODEL`) so they keep
-  testing the bytes path rather than the model's appetite for it.
-
-### Fixed
-
-- **`ThinkingSummaries` sent a value the API now rejects.**
-  `to_agent_config_value()` emitted the SCREAMING_CASE
-  `THINKING_SUMMARIES_AUTO` / `_NONE` spelling; verified live 2026-08-10
-  the API responds `The value 'THINKING_SUMMARIES_AUTO' is not supported
-  for 'agent_config.thinking_summaries'. Supported values: 'auto',
-  'none'.` — so deep-research requests carrying thinking summaries failed
-  outright. Both contexts now emit the lowercase form; deserialization
-  still accepts either spelling.
-
-- **Antigravity harness 0.1.10 support (turn completion was broken).** The
-  supported harness moves 0.1.5 → 0.1.10. Two wire spellings the bridge
-  depends on were renamed in that range, and both failed silently rather
-  than loudly:
-  - `STATE_IDLE` → `STATE_FULLY_IDLE`. Only that value ends a turn, so
-    against a 0.1.6+ harness **every turn ran to its timeout** — no parse
-    error, no failed assertion, just a bare
-    `Timeout { operation: "agent turn" }` after the full budget.
-  - `usageMetadata` → `usageUpdate` (now `{agents[], total}`), which
-    silently zeroed token accounting and was additionally misreported as
-    an unknown payload variant.
-
-  Both old spellings are accepted as aliases, so a single build drives
-  either harness revision; verified by running the full harness suite
-  against 0.1.5 and 0.1.10 (10/10 each). Also adds the non-terminal
-  `STATE_WAITING_FOR_TASKS` state introduced in 0.1.10.
-
-### Added
-
-- Wire enums accept alias spellings, so a value renamed between harness
-  revisions resolves to one variant while `as_wire_str` keeps emitting
-  the canonical (current-harness) form.
-- A stalled turn now diagnoses itself. When a turn times out having seen
-  unrecognized *main-trajectory* states, the timeout names them and
-  points at `SUPPORTED_HARNESS_VERSION` instead of reporting an
-  undifferentiated stall — the failure that took a wire trace to
-  diagnose now reads as a version mismatch on the error itself.
-
-### Changed
-
-- CI's antigravity job now receives `GEMINI_API_KEY` (with the same
-  same-repo guard the integration matrix uses). Its model-backed tests
-  are the only ones that drive a real turn end-to-end, and without a key
-  they self-skipped — which is why the turn-completion break above
-  reached a release unnoticed.
-- `docs/ANTIGRAVITY.md` no longer claims newer harnesses "degrade
-  gracefully". Unknown-value preservation stops a crash, but when a
-  *renamed* value is one the bridge matches on, preservation is exactly
-  what makes the breakage silent.
-
-## [0.9.0] - 2026-08-09
+## [0.9.0] - 2026-08-10
 
 ### Changed (breaking)
 
@@ -87,24 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`antigravity::protocol::MultipleChoice` — behind the `antigravity`
   feature — likewise gains a public flattened `extra` field.)
 
-### Changed
-
-- All five resource list envelopes (`AgentListResponse`,
-  `WebhookListResponse`, and the new trigger/execution/environment ones)
-  now degrade a null or malformed list key to an empty page and drop
-  undeserializable elements individually with a `tracing::warn!`, instead
-  of failing the whole response. For the two pre-existing types this
-  changes observable behavior: `list_agents()`/`list_webhooks()` calls
-  that previously returned `Err` on a malformed page now return the
-  surviving entries.
-- `Webhook::create_time`/`update_time` and `SigningSecret::expire_time`
-  now deserialize leniently like the trigger and environment timestamps:
-  a response whose timestamp encoding diverges from RFC 3339 yields the
-  field as `None` (with a `tracing::warn!`) instead of failing the call —
-  so an absent timestamp on a returned webhook can mean either "not sent"
-  or "sent but unparseable"; the warn log distinguishes them.
-
 ### Added
+
+- Wire enums accept alias spellings, so a value renamed between harness
+  revisions resolves to one variant while `as_wire_str` keeps emitting
+  the canonical (current-harness) form.
+- A stalled turn now diagnoses itself. When a turn times out having seen
+  unrecognized *main-trajectory* states, the timeout names them and
+  points at `SUPPORTED_HARNESS_VERSION` instead of reporting an
+  undifferentiated stall — the failure that took a wire trace to
+  diagnose now reads as a version mismatch on the error itself.
+
 
 - **Triggers resource** (`/v1beta/triggers`): server-side scheduled
   interactions with full CRUD plus `run_trigger` and
@@ -144,6 +70,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resource types uniformly. The pre-existing `Agent` and
   `AgentListResponse` gain it too, completing the set.
 
+### Changed
+
+- **Default model guidance moves to `gemini-3.6-flash`** (from
+  `gemini-3-flash-preview`) across docs, examples, and tests, and image
+  generation moves to `gemini-3.1-flash-image` (from
+  `gemini-3-pro-image-preview`). Both were probed live before migrating.
+
+  One capability difference surfaced and is worth knowing: `gemini-3.6-flash`
+  returns `400 invalid_request` for **inline (base64) video bytes** while
+  accepting video **by URI**. Image, audio and PDF inline data are
+  unaffected. The three inline-video tests are pinned to a model that
+  accepts that form (`tests/common::VIDEO_INLINE_MODEL`) so they keep
+  testing the bytes path rather than the model's appetite for it.
+
+
+- CI's antigravity job now receives `GEMINI_API_KEY` (with the same
+  same-repo guard the integration matrix uses). Its model-backed tests
+  are the only ones that drive a real turn end-to-end, and without a key
+  they self-skipped — which is why the turn-completion break above
+  reached a release unnoticed.
+- `docs/ANTIGRAVITY.md` no longer claims newer harnesses "degrade
+  gracefully". Unknown-value preservation stops a crash, but when a
+  *renamed* value is one the bridge matches on, preservation is exactly
+  what makes the breakage silent.
+
+
+
+- All five resource list envelopes (`AgentListResponse`,
+  `WebhookListResponse`, and the new trigger/execution/environment ones)
+  now degrade a null or malformed list key to an empty page and drop
+  undeserializable elements individually with a `tracing::warn!`, instead
+  of failing the whole response. For the two pre-existing types this
+  changes observable behavior: `list_agents()`/`list_webhooks()` calls
+  that previously returned `Err` on a malformed page now return the
+  surviving entries.
+- `Webhook::create_time`/`update_time` and `SigningSecret::expire_time`
+  now deserialize leniently like the trigger and environment timestamps:
+  a response whose timestamp encoding diverges from RFC 3339 yields the
+  field as `None` (with a `tracing::warn!`) instead of failing the call —
+  so an absent timestamp on a returned webhook can mean either "not sent"
+  or "sent but unparseable"; the warn log distinguishes them.
+
 ### Deprecated
 
 - `response_modalities` is marked deprecated by the official SDK in
@@ -153,6 +121,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from this crate — the API rejects it in every form.)
 
 ### Fixed
+
+- **`ThinkingSummaries` sent a value the API now rejects.**
+  `to_agent_config_value()` emitted the SCREAMING_CASE
+  `THINKING_SUMMARIES_AUTO` / `_NONE` spelling; verified live 2026-08-10
+  the API responds `The value 'THINKING_SUMMARIES_AUTO' is not supported
+  for 'agent_config.thinking_summaries'. Supported values: 'auto',
+  'none'.` — so deep-research requests carrying thinking summaries failed
+  outright. Both contexts now emit the lowercase form; deserialization
+  still accepts either spelling.
+
+- **Antigravity harness 0.1.10 support (turn completion was broken).** The
+  supported harness moves 0.1.5 → 0.1.10. Two wire spellings the bridge
+  depends on were renamed in that range, and both failed silently rather
+  than loudly:
+  - `STATE_IDLE` → `STATE_FULLY_IDLE`. Only that value ends a turn, so
+    against a 0.1.6+ harness **every turn ran to its timeout** — no parse
+    error, no failed assertion, just a bare
+    `Timeout { operation: "agent turn" }` after the full budget.
+  - `usageMetadata` → `usageUpdate` (now `{agents[], total}`), which
+    silently zeroed token accounting and was additionally misreported as
+    an unknown payload variant.
+
+  Both old spellings are accepted as aliases, so a single build drives
+  either harness revision; verified by running the full harness suite
+  against 0.1.5 and 0.1.10 (10/10 each). Also adds the non-terminal
+  `STATE_WAITING_FOR_TASKS` state introduced in 0.1.10.
+
 
 - Resource IDs are now percent-encoded when interpolated into URL paths
   (interactions get/delete/cancel/stream and the agents, webhooks, triggers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   output was unusable for antigravity sessions, where a few turns produce
   thousands of lines. Exposed programmatically as `wire::WireFilter` and
   `LoudWirePrinter::with_filter`; `LoudWirePrinter` is consequently no
-  longer `Copy` (it still derives `Clone`).
+  longer `Copy` (it still derives `Clone`). The antigravity agent
+  builder honors the filter too — it previously re-implemented the env
+  gate and ignored the value, which meant filtering did not work on the
+  one surface that emits WebSocket messages at all.
+
+- **Antigravity e2e coverage for structured output and cancellation.**
+  `with_response_schema` and `CancelHandle` are now exercised against a
+  real harness. The cancellation test corrected a documented claim: harness
+  0.1.10 answers a halt with `STATE_FULLY_IDLE`, the same terminal state as
+  a natural completion, so a cancelled turn **resolves normally with
+  partial output** rather than failing with `AntigravityError::Turn` as
+  `CancelHandle` and `docs/ANTIGRAVITY.md` previously stated. The `Turn`
+  error remains the outcome for harness-initiated cancellation.
 
 - **Protocol-drift diagnostics for the antigravity bridge.**
   `protocol::drift_report()` returns every unrecognized wire value seen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one surface that emits WebSocket messages at all.
 
 - **Antigravity e2e coverage for structured output and cancellation.**
-  `with_response_schema` and `CancelHandle` are now exercised against a
-  real harness. The cancellation test corrected a documented claim: harness
+  `with_response_schema`, `CancelHandle` and the `on_questions` hook are
+  now exercised against a real harness. The cancellation test corrected a documented claim: harness
   0.1.10 answers a halt with `STATE_FULLY_IDLE`, the same terminal state as
   a natural completion, so a cancelled turn **resolves normally with
   partial output** rather than failing with `AntigravityError::Turn` as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Default model guidance moves to `gemini-3.6-flash`** (from
+  `gemini-3-flash-preview`) across docs, examples, and tests, and image
+  generation moves to `gemini-3.1-flash-image` (from
+  `gemini-3-pro-image-preview`). Both were probed live before migrating.
+
+  One capability difference surfaced and is worth knowing: `gemini-3.6-flash`
+  returns `400 invalid_request` for **inline (base64) video bytes** while
+  accepting video **by URI**. Image, audio and PDF inline data are
+  unaffected. The three inline-video tests are pinned to a model that
+  accepts that form (`tests/common::VIDEO_INLINE_MODEL`) so they keep
+  testing the bytes path rather than the model's appetite for it.
+
 ### Fixed
+
+- **`ThinkingSummaries` sent a value the API now rejects.**
+  `to_agent_config_value()` emitted the SCREAMING_CASE
+  `THINKING_SUMMARIES_AUTO` / `_NONE` spelling; verified live 2026-08-10
+  the API responds `The value 'THINKING_SUMMARIES_AUTO' is not supported
+  for 'agent_config.thinking_summaries'. Supported values: 'auto',
+  'none'.` — so deep-research requests carrying thinking summaries failed
+  outright. Both contexts now emit the lowercase form; deserialization
+  still accepts either spelling.
 
 - **Antigravity harness 0.1.10 support (turn completion was broken).** The
   supported harness moves 0.1.5 → 0.1.10. Two wire spellings the bridge
@@ -813,7 +836,7 @@ still rustls.
   ```rust
   // Now possible - conditional chaining
   let mut builder = client.interaction()
-      .with_model("gemini-3-flash-preview")
+      .with_model("gemini-3.6-flash")
       .with_text("Hello");
 
   if let Some(prev_id) = previous_interaction_id {
@@ -927,7 +950,7 @@ let content = Content::text("Hello");  // Static constructor
 ```rust
 // Before (0.6.0)
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Describe this image")
     .add_image_file("photo.jpg").await?
     .create()
@@ -935,7 +958,7 @@ let response = client.interaction()
 
 // After (0.7.0) - Option A: Content constructors
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("Describe this image"),
         Content::image_data(base64_data, "image/png"),
@@ -947,7 +970,7 @@ let response = client.interaction()
 use genai_rs::image_from_file;
 let image = image_from_file("photo.jpg").await?;
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("Describe this image"),
         image,
@@ -961,7 +984,7 @@ let response = client.interaction()
 // Before (0.6.0)
 let file = client.upload_file("video.mp4").await?;
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .add_file(&file)
     .with_text("Describe this video")
     .create()
@@ -970,7 +993,7 @@ let response = client.interaction()
 // After (0.7.0)
 let file = client.upload_file("video.mp4").await?;
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("Describe this video"),
         Content::from_file(&file),
@@ -996,7 +1019,7 @@ Content::image_data(base64, "image/png").with_resolution(Resolution::High)
 // Before (0.6.0)
 // with_turns().with_text() silently overwrote history - bug!
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_turns(history)
     .create()
     .await?;
@@ -1004,7 +1027,7 @@ let response = client.interaction()
 // After (0.7.0)
 // Renamed to with_history(), and now composes correctly with with_text()
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_history(history)
     .with_text("Current message")  // Appended as final user turn
     .create()
@@ -1756,7 +1779,7 @@ This release removes the legacy GenerateContent API in favor of the unified Inte
 #### Before (v0.1.x - GenerateContent API):
 ```rust
 let response = client
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_prompt("Hello, world!")
     .generate()
     .await?;
@@ -1768,7 +1791,7 @@ println!("{}", response.text.unwrap());
 ```rust
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Hello, world!")
     .create()
     .await?;
@@ -1780,14 +1803,14 @@ println!("{}", response.text().unwrap_or("No text"));
 ```rust
 // Before
 let stream = client
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_prompt("Hello")
     .generate_stream()?;
 
 // After
 let stream = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Hello")
     .create_stream();
 ```
@@ -1796,7 +1819,7 @@ let stream = client
 ```rust
 // Before
 let response = client
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_prompt("What's the weather?")
     .generate_with_auto_functions()
     .await?;
@@ -1804,7 +1827,7 @@ let response = client
 // After
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's the weather?")
     .create_with_auto_functions()
     .await?;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Antigravity harness 0.1.10 support (turn completion was broken).** The
+  supported harness moves 0.1.5 → 0.1.10. Two wire spellings the bridge
+  depends on were renamed in that range, and both failed silently rather
+  than loudly:
+  - `STATE_IDLE` → `STATE_FULLY_IDLE`. Only that value ends a turn, so
+    against a 0.1.6+ harness **every turn ran to its timeout** — no parse
+    error, no failed assertion, just a bare
+    `Timeout { operation: "agent turn" }` after the full budget.
+  - `usageMetadata` → `usageUpdate` (now `{agents[], total}`), which
+    silently zeroed token accounting and was additionally misreported as
+    an unknown payload variant.
+
+  Both old spellings are accepted as aliases, so a single build drives
+  either harness revision; verified by running the full harness suite
+  against 0.1.5 and 0.1.10 (10/10 each). Also adds the non-terminal
+  `STATE_WAITING_FOR_TASKS` state introduced in 0.1.10.
+
+### Added
+
+- Wire enums accept alias spellings, so a value renamed between harness
+  revisions resolves to one variant while `as_wire_str` keeps emitting
+  the canonical (current-harness) form.
+- A stalled turn now diagnoses itself. When a turn times out having seen
+  unrecognized *main-trajectory* states, the timeout names them and
+  points at `SUPPORTED_HARNESS_VERSION` instead of reporting an
+  undifferentiated stall — the failure that took a wire trace to
+  diagnose now reads as a version mismatch on the error itself.
+
+### Changed
+
+- CI's antigravity job now receives `GEMINI_API_KEY` (with the same
+  same-repo guard the integration matrix uses). Its model-backed tests
+  are the only ones that drive a real turn end-to-end, and without a key
+  they self-skipped — which is why the turn-completion break above
+  reached a release unnoticed.
+- `docs/ANTIGRAVITY.md` no longer claims newer harnesses "degrade
+  gracefully". Unknown-value preservation stops a crash, but when a
+  *renamed* value is one the bridge matches on, preservation is exactly
+  what makes the breakage silent.
+
 ## [0.9.0] - 2026-08-09
 
 ### Changed (breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   filter in addition to `1`: category selectors (`request`, `response`,
   `sse`, `upload`, `harness`, `ws`), any WebSocket payload key
   (`stepUpdate`, `toolCall`, …, matched case-insensitively), and a
-  `summary` modifier that collapses each event to one line. The historical
-  "on" spellings (`1`, `true`, `yes`, `on`, `all`, empty) still mean
-  everything-pretty-printed, so existing usage is unchanged. Unfiltered
+  `summary` modifier that collapses each event to one line (order-free:
+  `1,summary` and `summary,1` agree). The historical "on" spellings (`1`,
+  `true`, `yes`, `on`, `all`, empty) still mean everything-pretty-printed.
+  Note that the gate was previously "is the variable set at all", so *any*
+  value produced the firehose; other values are now parsed as selectors,
+  and a value matching no category and no payload key — `0`, `false`,
+  `off` — prints nothing where it previously printed everything. Unfiltered
   output was unusable for antigravity sessions, where a few turns produce
   thousands of lines. Exposed programmatically as `wire::WireFilter` and
   `LoudWirePrinter::with_filter`; `LoudWirePrinter` is consequently no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Protocol-drift diagnostics for the antigravity bridge.**
+  `protocol::drift_report()` returns every unrecognized wire value seen
+  (`"EnumName=WIRE_VALUE" -> count`) with `clear_drift_report()` to reset
+  it, `all_wire_values()` on each wire enum exposes the spellings the
+  crate recognizes, and `shutdown()` logs the aggregate once. Unknown-value
+  preservation previously produced no signal beyond a `warn!` nobody
+  reads — which is what let a renamed value silently stop matching. CI
+  additionally diffs the installed wheel's protobuf descriptor against
+  these enums and fails naming anything the harness can send that the
+  crate does not model. See the Debugging section of `docs/ANTIGRAVITY.md`.
+
 - **Two antigravity worked examples**, both runnable against a real
   harness: `examples/real_world/session_resume` (trajectory persistence —
   the `with_save_dir` + `conversation_id()` + `with_conversation_id` round
@@ -89,7 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   One capability difference surfaced and is worth knowing: `gemini-3.6-flash`
   returns `400 invalid_request` for **inline (base64) video bytes** while
   accepting video **by URI**. Image, audio and PDF inline data are
-  unaffected. The three inline-video tests are pinned to a model that
+  unaffected. The four inline-video tests are pinned to a model that
   accepts that form (`tests/common::VIDEO_INLINE_MODEL`) so they keep
   testing the bytes path rather than the model's appetite for it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Two antigravity worked examples**, both runnable against a real
+  harness: `examples/real_world/session_resume` (trajectory persistence —
+  the `with_save_dir` + `conversation_id()` + `with_conversation_id` round
+  trip, and the fact that resuming an unknown id comes back *empty* rather
+  than erroring) and `examples/real_world/workspace_explorer` (workspaces
+  with real files, the typed `AgentEvent::ToolAction` stream, and an
+  `on_pre_tool` hook that refuses by content where a name-based policy
+  cannot). Both are covered by new harness integration tests.
+
 - Wire enums accept alias spellings, so a value renamed between harness
   revisions resolves to one variant while `as_wire_str` keeps emitting
   the canonical (current-harness) form.
@@ -121,6 +130,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from this crate — the API rejects it in every form.)
 
 ### Fixed
+
+- **`on_post_tool` reported successful harness tools as failures.** The
+  harness sends `"error": ""` — protobuf's default for an unset string —
+  on calls that succeeded, and the bridge surfaced that as `Some("")`, so
+  `ToolOutcome::error.is_some()` (the check the field's own docs invite)
+  was true for every successful builtin. Blank now normalizes to `None` on
+  both dispatch paths. Found by running the new `workspace_explorer`
+  example against a live harness; invisible to every existing test.
 
 - **`ThinkingSummaries` sent a value the API now rejects.**
   `to_agent_config_value()` emitted the SCREAMING_CASE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate and ignored the value, which meant filtering did not work on the
   one surface that emits WebSocket messages at all.
 
+- **Three more antigravity worked examples**, all runnable against a real
+  harness and smoke-run in CI: `mcp_toolbelt` (external tools over MCP,
+  with a dependency-free stdio server fixture and the `mcp_<server>_<tool>`
+  policy-target spelling), `proactive_agent` (`add_trigger`, and observing
+  deliveries through a wire inspector — the only way to see one today), and
+  `cancellable_turn` (`cancel_handle` from another task, keeping partial
+  output). Together with the existing four, every antigravity builder
+  surface now has an example.
+
+  Writing them surfaced a harness limitation now documented in
+  `docs/ANTIGRAVITY.md`: **a trigger that fires into a conversation with no
+  history crashes harness 0.1.10 outright** (`earliest step index is out of
+  bounds: 0 vs 0`), taking the session with it. One completed turn first
+  avoids it.
+
 - **Antigravity e2e coverage for the last untested surfaces.**
   `with_response_schema`, `CancelHandle`, the `on_questions` hook,
   `add_mcp_server` and subagent *invocation* (as opposed to subagent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`LOUD_WIRE` filtering.** The variable now takes a comma-separated
+  filter in addition to `1`: category selectors (`request`, `response`,
+  `sse`, `upload`, `harness`, `ws`), any WebSocket payload key
+  (`stepUpdate`, `toolCall`, …, matched case-insensitively), and a
+  `summary` modifier that collapses each event to one line. The historical
+  "on" spellings (`1`, `true`, `yes`, `on`, `all`, empty) still mean
+  everything-pretty-printed, so existing usage is unchanged. Unfiltered
+  output was unusable for antigravity sessions, where a few turns produce
+  thousands of lines. Exposed programmatically as `wire::WireFilter` and
+  `LoudWirePrinter::with_filter`; `LoudWirePrinter` is consequently no
+  longer `Copy` (it still derives `Clone`).
+
 - **Protocol-drift diagnostics for the antigravity bridge.**
   `protocol::drift_report()` returns every unrecognized wire value seen
   (`"EnumName=WIRE_VALUE" -> count`) with `clear_drift_report()` to reset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate and ignored the value, which meant filtering did not work on the
   one surface that emits WebSocket messages at all.
 
-- **Antigravity e2e coverage for structured output and cancellation.**
-  `with_response_schema`, `CancelHandle` and the `on_questions` hook are
-  now exercised against a real harness. The cancellation test corrected a documented claim: harness
+- **Antigravity e2e coverage for the last untested surfaces.**
+  `with_response_schema`, `CancelHandle`, the `on_questions` hook,
+  `add_mcp_server` and subagent *invocation* (as opposed to subagent
+  config, which was already covered) are now exercised against a real
+  harness — the MCP test drives a stdio server fixture end to end and
+  asserts on a token the model cannot have guessed.
+
+  The cancellation test corrected a documented claim: harness
   0.1.10 answers a halt with `STATE_FULLY_IDLE`, the same terminal state as
   a natural completion, so a cancelled turn **resolves normally with
   partial output** rather than failing with `AntigravityError::Turn` as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ GitHub Actions runs: check, test, test-strict-unknown, test-integration (5 matri
 
 ## Project Conventions
 
-- **Model name**: Always use `gemini-3-flash-preview` (exceptions: `gemini-3-pro-image-preview` for image generation, `gemini-2.5-pro-preview-tts` for text-to-speech)
+- **Model name**: Always use `gemini-3.6-flash` (exceptions: `gemini-3.1-flash-image` for image generation, `gemini-2.5-pro-preview-tts` for text-to-speech, and `tests/common::VIDEO_INLINE_MODEL` for **inline base64 video** — verified live 2026-08-10, `gemini-3.6-flash` returns 400 on inline video bytes while accepting video by URI)
 
 ### Naming Conventions
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,16 @@ path = "examples/real_world/repo_auditor/main.rs"
 required-features = ["antigravity"]
 
 [[example]]
+name = "session_resume"
+path = "examples/real_world/session_resume/main.rs"
+required-features = ["antigravity"]
+
+[[example]]
+name = "workspace_explorer"
+path = "examples/real_world/workspace_explorer/main.rs"
+required-features = ["antigravity"]
+
+[[example]]
 name = "rag_system"
 path = "examples/real_world/rag_system/main.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,21 @@ path = "examples/real_world/workspace_explorer/main.rs"
 required-features = ["antigravity"]
 
 [[example]]
+name = "mcp_toolbelt"
+path = "examples/real_world/mcp_toolbelt/main.rs"
+required-features = ["antigravity"]
+
+[[example]]
+name = "proactive_agent"
+path = "examples/real_world/proactive_agent/main.rs"
+required-features = ["antigravity"]
+
+[[example]]
+name = "cancellable_turn"
+path = "examples/real_world/cancellable_turn/main.rs"
+required-features = ["antigravity"]
+
+[[example]]
 name = "rag_system"
 path = "examples/real_world/rag_system/main.rs"
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ async fn main() -> Result<(), genai_rs::GenaiError> {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Explain Rust's ownership model in one sentence.")
         .create()
         .await?;
@@ -249,7 +249,7 @@ use genai_rs::InteractionRequest;
 
 // Build request without executing (Clone + Serialize)
 let request: InteractionRequest = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Hello!")
     .build()?;
 
@@ -275,7 +275,7 @@ use genai_rs::antigravity::{AntigravityAgent, policy};
 
 let mut agent = AntigravityAgent::builder()
     .with_api_key(std::env::var("GEMINI_API_KEY")?)
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .add_workspace("/path/to/repo")
     .add_policy(policy::deny_all())          // policies evaluated in Rust,
     .add_policy(policy::allow("view_file"))  // before every tool dispatch
@@ -397,7 +397,7 @@ Common issues and solutions are documented in [TROUBLESHOOTING.md](TROUBLESHOOTI
 
 **Quick fixes:**
 - **"API key not valid"** - Check `GEMINI_API_KEY` is set
-- **"Model not found"** - Use `gemini-3-flash-preview`
+- **"Model not found"** - Use `gemini-3.6-flash`
 - **Functions not executing** - Use `create_with_auto_functions()`
 - **TLS errors in minimal containers** - Install a CA bundle (OS trust store is used since reqwest 0.13)
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ agent.shutdown().await?;
 ```
 
 The same `#[tool]` functions work in both modes, and `LOUD_WIRE=1` covers
-harness sessions too. Setup (`pip install google-antigravity==0.1.5`),
+harness sessions too. Setup (`pip install google-antigravity==0.1.10`),
 capabilities, policies/hooks, MCP servers, subagents, triggers, and session
 resume are covered in [docs/ANTIGRAVITY.md](docs/ANTIGRAVITY.md); see
 [`repo_auditor`](examples/real_world/repo_auditor/main.rs) for a complete

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -27,7 +27,7 @@ Output shows:
 ```text
 [REQ#1] POST https://generativelanguage.googleapis.com/v1beta/interactions
 {
-  "model": "gemini-3-flash-preview",
+  "model": "gemini-3.6-flash",
   "input": "Hello!",
   ...
 }
@@ -105,14 +105,14 @@ GenaiError::Api { status_code: 404, message: "Model not found..." }
 ```
 
 **Solutions:**
-1. Check model name spelling: `gemini-3-flash-preview` (not `gemini-flash`)
+1. Check model name spelling: `gemini-3.6-flash` (not `gemini-flash`)
 2. Verify model availability in your region
 3. Check if model requires special access
 
 ```rust,ignore
 // Correct model names
-const STANDARD_MODEL: &str = "gemini-3-flash-preview";
-const IMAGE_MODEL: &str = "gemini-3-pro-image-preview";
+const STANDARD_MODEL: &str = "gemini-3.6-flash";
+const IMAGE_MODEL: &str = "gemini-3.1-flash-image";
 const TTS_MODEL: &str = "gemini-2.5-pro-preview-tts";
 ```
 
@@ -158,7 +158,7 @@ GenaiError::Timeout(duration)
 // Increase timeout
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text(complex_prompt)
     .with_timeout(Duration::from_secs(180))
     .create()
@@ -302,7 +302,7 @@ let decl = FunctionDeclaration::builder("set_unit")
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's the weather?")
     .with_store_enabled()  // Explicit, but default is true
     .create()
@@ -425,7 +425,7 @@ match client
 
 1. **Ensure correct model:**
 ```rust,ignore
-.with_model("gemini-3-pro-image-preview")  // NOT gemini-3-flash-preview
+.with_model("gemini-3.1-flash-image")  // NOT gemini-3.6-flash
 ```
 
 2. **Ensure image output enabled:**
@@ -495,7 +495,7 @@ let mut stream = client.interaction().create_stream();
 
 3. **Use appropriate model:**
 ```rust,ignore
-// gemini-3-flash-preview is faster than gemini-3.1-pro-preview
+// gemini-3.6-flash is faster than gemini-3.1-pro-preview
 ```
 
 ### High Token Usage

--- a/docs/AGENTS_AND_BACKGROUND.md
+++ b/docs/AGENTS_AND_BACKGROUND.md
@@ -23,7 +23,7 @@ Gemini supports two types of interactions:
 
 | Type | Entry Point | Execution | Use Case |
 |------|-------------|-----------|----------|
-| **Model** | `with_model("gemini-3-flash-preview")` | Synchronous | Quick responses, streaming |
+| **Model** | `with_model("gemini-3.6-flash")` | Synchronous | Quick responses, streaming |
 | **Agent** | `with_agent("deep-research-pro-preview")` | Background | Long-running tasks, research |
 
 Agents are specialized systems that perform multi-step tasks autonomously.
@@ -37,7 +37,7 @@ Direct interaction with a language model:
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Explain quantum computing")
     .create()
     .await?;
@@ -216,7 +216,7 @@ let follow_up = client
 The Antigravity managed agent above is the one whose config is
 live-verified end to end (2026-08-09): the environment is **required**,
 and `AntigravityConfig` tunes the run — leave its `model` unset (an
-unavailable value 404s, including `gemini-3-flash-preview`, the crate's
+unavailable value 404s, including `gemini-3.6-flash`, the crate's
 default model elsewhere):
 
 ```rust,ignore
@@ -333,7 +333,7 @@ Background mode allows requests to return immediately while processing continues
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")  // or with_agent()
+    .with_model("gemini-3.6-flash")  // or with_agent()
     .with_text("Complex analysis task...")
     .with_background(true)
     .with_store_enabled()  // Must enable storage to retrieve results

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -25,7 +25,7 @@ genai-rs = { version = "0.9", features = ["antigravity"] }
 Install the harness binary (it ships inside the platform-specific wheel):
 
 ```bash
-pip install google-antigravity==0.1.5
+pip install google-antigravity==0.1.10
 ```
 
 ### Version pinning
@@ -33,10 +33,26 @@ pip install google-antigravity==0.1.5
 The harness wire protocol is internal to Google's SDK and changes across
 0.1.x releases. Each genai-rs release is verified against exactly one wheel
 version, exposed as `antigravity::SUPPORTED_HARNESS_VERSION` (currently
-`0.1.5`) — pin that version. Newer harnesses degrade gracefully rather than
-erroring: unknown events, fields, and enum values are preserved in `Unknown`
-variants and `extra` maps (the crate's Evergreen philosophy), but only the
-pinned version is tested end-to-end.
+`0.1.10`) — pin that version.
+
+**Unknown-value preservation is not the same as forward compatibility.**
+Unrecognized events, fields, and enum values are preserved in `Unknown`
+variants and `extra` maps rather than erroring (the crate's Evergreen
+philosophy), so a newer harness will not crash the bridge. But when a
+*renamed* value is one the bridge **matches on**, preservation is exactly
+what makes the breakage silent: the match simply stops firing.
+
+The 0.1.5 → 0.1.10 upgrade is the worked example. `STATE_IDLE` became
+`STATE_FULLY_IDLE`, and since only that value ends a turn, every turn ran
+to its timeout with no error, no failed parse, and a single `warn!` as the
+only evidence. `usageMetadata` likewise became `usageUpdate`, silently
+zeroing token accounting. Both old spellings are now accepted as aliases,
+so one build drives either revision — but the lesson generalizes: when
+moving to an unverified harness, run the integration suite
+(`--run-ignored all -E 'binary(antigravity_harness)'`) rather than
+trusting that a clean parse means a working bridge, and see
+[Debugging](#debugging) for the drift diagnostics that surface this class
+of mismatch.
 
 ### Binary discovery
 

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -490,6 +490,15 @@ Delivery semantics (see `antigravity::triggers` for details):
 
 - The first firing happens after the first interval elapses, not
   immediately. Intervals must be non-zero (`spawn()` validates).
+- **Give the conversation one real turn before a trigger can fire.** On
+  harness 0.1.10, a trigger delivered into a conversation with no history
+  crashes the harness *process* — its pre-invocation hook asks for "tokens
+  since the last checkpoint", finds no steps, and aborts the agent run
+  (`earliest step index is out of bounds: 0 vs 0`). The session dies with
+  it, so the next send fails on a closed socket or a broken pipe. One
+  completed turn is enough. Reproduced by
+  `examples/real_world/proactive_agent`, which opens with a turn for
+  exactly this reason.
 - A firing is delivered **only while the agent is idle** (no
   `chat`/`send_streaming` turn in flight). If it comes due mid-turn, it is
   deferred until the turn ends, and missed intervals collapse into a single

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -74,7 +74,7 @@ use genai_rs::antigravity::{AntigravityAgent, policy};
 
 let mut agent = AntigravityAgent::builder()
     .with_api_key(std::env::var("GEMINI_API_KEY")?)
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_system_instructions("You are a code-review assistant.")
     .add_workspace("/path/to/repo")
     .add_policy(policy::deny_all())

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -557,6 +557,38 @@ The Antigravity client feeds the crate's canonical wire-inspection layer
 LOUD_WIRE=1 cargo run --example antigravity_agent --features antigravity
 ```
 
+`LOUD_WIRE=1` is the right default for a single HTTP request and the wrong
+one for a harness session: a few turns produce thousands of pretty-printed
+lines, and finding the message that matters means grepping raw JSON out of
+the scrollback. So `LOUD_WIRE` also takes a comma-separated filter.
+
+| Value | Keeps |
+|-------|-------|
+| `1`, `true`, `yes`, `on`, `all` | Everything (unchanged) |
+| `harness` | Spawn and stderr lines |
+| `ws` | Every WebSocket message |
+| `request`, `response`, `sse`, `upload` | The HTTP-side categories |
+| *any other token* | WebSocket messages whose top-level key matches |
+| `summary` | Modifier: one line per event instead of full bodies |
+
+The last two are what make a session readable. Selectors name the proto
+oneof arm — `stepUpdate`, `toolCall`, `userInput`, `trajectoryStateUpdate`
+— matched case-insensitively, and envelope bookkeeping (`seqNum`,
+`timestampMicros`) is ignored so it cannot match everything.
+
+```bash
+LOUD_WIRE=summary                  # the whole session, one line per message
+LOUD_WIRE=toolCall,summary         # just the tool traffic, one line each
+LOUD_WIRE=trajectoryStateUpdate    # why a turn will not finish
+LOUD_WIRE=harness                  # spawn + stderr only, no protocol noise
+```
+
+`LOUD_WIRE=summary` renders each message as its payload keys, which is
+usually enough to see the shape and order of a turn; drop to a selector
+once you know which message you want in full. The same filtering is
+available programmatically via `wire::WireFilter` and
+`LoudWirePrinter::with_filter`.
+
 For programmatic capture, register inspectors on the builder — the
 `WireEvent` variants are `HarnessSpawn`, `WsSend`, `WsReceive`, and
 `HarnessStderr`, sharing one correlation id per harness session:

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -431,8 +431,18 @@ task, take a handle first:
 ```rust,ignore
 let cancel = agent.cancel_handle();
 // ... later, from any task:
-cancel.cancel().await?;   // the in-flight turn fails with AntigravityError::Turn
+cancel.cancel().await?;   // the in-flight turn ends early, keeping partial output
 ```
+
+**What a cancelled turn returns**: harness 0.1.10 answers a halt by taking
+the trajectory to `STATE_FULLY_IDLE` — the same terminal state as a natural
+completion, not `STATE_CANCELLED`. The turn therefore resolves *normally*
+with whatever partial output it had produced, rather than failing with
+`AntigravityError::Turn`. Treat `cancel()` as "stop early and keep what you
+have", and record the cancellation on your side if you need to distinguish
+a halted turn from a completed one. (`AntigravityError::Turn` is still the
+outcome when the harness cancels a turn of its own accord.) Verified live
+by `test_antigravity_cancel_handle_halts_an_in_flight_turn`.
 
 `with_turn_timeout(Duration)` bounds each turn's wall-clock time. When the
 budget is exceeded, the crate halts the harness's still-running turn and

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -516,6 +516,36 @@ println!("restored {} steps", agent.initial_history().len());
 
 ## Debugging
 
+### Diagnosing protocol drift
+
+Three signals exist specifically for the failure mode described under
+[Version pinning](#version-pinning) — a harness that speaks a dialect this
+build only partly understands, which otherwise presents as "the agent just
+didn't do anything":
+
+| Signal | What it tells you |
+|--------|-------------------|
+| `protocol::drift_report()` | Every unrecognized wire value seen, as `"EnumName=WIRE_VALUE" -> count`. Empty is healthy. Process-wide and cumulative; `clear_drift_report()` resets it. |
+| The `warn!` on `shutdown()` | The same aggregate, logged once at the natural end of a session, so it does not scroll past like the per-value warns do. |
+| `AntigravityError::Timeout` | When a turn times out having seen unrecognized *main-trajectory* states, the `operation` field names them and points at `SUPPORTED_HARNESS_VERSION` instead of reporting an undifferentiated stall. |
+
+Programmatic check, for anything long-running:
+
+```rust,ignore
+let drift = genai_rs::antigravity::protocol::drift_report();
+if !drift.is_empty() {
+    eprintln!("harness sent values this build does not model: {drift:?}");
+}
+```
+
+CI runs a stronger version of this: `test_antigravity_protocol_enums_have_not_drifted`
+diffs the installed wheel's protobuf descriptor against the crate's wire
+enums and fails naming any value the harness can send that the crate does
+not model. That is the check that turns a renamed enum from a silent hang
+into a red test.
+
+### Wire inspection
+
 The Antigravity client feeds the crate's canonical wire-inspection layer
 (`genai_rs::wire`). `LOUD_WIRE=1` pretty-prints everything to stderr:
 

--- a/docs/ANTIGRAVITY_BRIDGE_DESIGN.md
+++ b/docs/ANTIGRAVITY_BRIDGE_DESIGN.md
@@ -210,7 +210,7 @@ use genai_rs::antigravity::{AntigravityAgent, policy};
 
 let mut agent = AntigravityAgent::builder()
     .with_api_key(std::env::var("GEMINI_API_KEY")?)   // or with_model_target(...)
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_system_instructions("You are a code-review assistant.")
     .with_workspace("/path/to/repo")
     .add_tool(get_weather_declaration())               // same #[tool] fns as Interactions

--- a/docs/BUILDER_API.md
+++ b/docs/BUILDER_API.md
@@ -20,7 +20,7 @@ The `InteractionBuilder` provides a fluent interface for constructing requests t
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_system_instruction("You are helpful")
     .with_text("Hello!")
     .create()
@@ -160,7 +160,7 @@ use genai_rs::{Client, Content};
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("Describe this image"),
         Content::image_data(base64_data, "image/png"),
@@ -177,7 +177,7 @@ use genai_rs::{Client, Content, image_from_file};
 let image_content = image_from_file("photo.jpg").await?;
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("What's in this image?"),
         image_content,
@@ -219,7 +219,7 @@ Content input (via `with_content()`) is for single-turn multimodal messages. It 
 ```rust,ignore
 // ERROR: Cannot combine content with history
 client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_history(conversation_history)
     .with_content(vec![Content::image_data(base64, "image/png")])
     .build()  // Returns Err!
@@ -239,7 +239,7 @@ let mut history = existing_history;
 history.push(multimodal_step);
 
 client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_history(history)
     .create()
     .await?;
@@ -252,7 +252,7 @@ You must specify exactly one of `with_model()` or `with_agent()`:
 ```rust,ignore
 // ERROR: Both specified
 client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_agent("deep-research-pro-preview-12-2025")
     .build()  // Returns Err!
 
@@ -269,7 +269,7 @@ client.interaction()
 ```rust,ignore
 // ERROR: agent_config without agent
 client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_agent_config(DeepResearchConfig::new())
     .with_text("Research AI trends")
     .build()  // Returns Err!
@@ -290,7 +290,7 @@ Certain combinations of builder methods are invalid because they conflict with s
 ```rust,ignore
 // Runtime error from build(): "Chained interactions require storage..."
 client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Hello")
     .with_previous_interaction("id-123")
     .with_store_disabled()
@@ -307,7 +307,7 @@ let previous_interaction_id: Option<String> = session.last_interaction_id();
 let should_disable_storage: bool = config.privacy_mode;
 
 let mut builder = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Hello");
 
 // Conditionally add previous interaction
@@ -348,7 +348,7 @@ use genai_rs::CallableFunction;
 
 client.interaction()
     // Target
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     // Context
     .with_system_instruction("You are helpful")
     .with_history(history)
@@ -367,7 +367,7 @@ Call `build()` explicitly when you want to validate without executing:
 
 ```rust,ignore
 let request = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Hello")
     .build()?;  // Validate configuration
 
@@ -381,7 +381,7 @@ For test fixtures or inline conversation construction. `.user()` and `.model()` 
 
 ```rust,ignore
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .conversation()
         .user("What is 2+2?")
         .model("4")

--- a/docs/BUILT_IN_TOOLS.md
+++ b/docs/BUILT_IN_TOOLS.md
@@ -41,7 +41,7 @@ Ground responses in real-time web data.
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What are the latest Rust 2024 features?")
     .with_google_search()
     .create()
@@ -73,7 +73,7 @@ use genai_rs::{GoogleSearchConfig, SearchType};
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Find enterprise deployment guides for Kubernetes")
     .add_tool(GoogleSearchConfig::new().with_search_types(vec![
         SearchType::WebSearch,
@@ -115,7 +115,7 @@ use futures_util::StreamExt;
 
 let mut stream = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Latest AI news?")
     .with_google_search()
     .create_stream();
@@ -141,7 +141,7 @@ Execute Python code in a secure sandbox.
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Calculate the first 20 Fibonacci numbers")
     .with_code_execution()
     .create()
@@ -200,7 +200,7 @@ Fetch and analyze web pages.
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Summarize this article: https://example.com/article")
     .with_url_context()
     .create()
@@ -224,7 +224,7 @@ for result in response.url_context_results() {
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Compare https://example.com/page1 and https://example.com/page2")
     .with_url_context()
     .create()
@@ -265,7 +265,7 @@ use genai_rs::ComputerUseConfig;
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Go to example.com and describe what you see")
     .add_tool(ComputerUseConfig::new())  // defaults to the "browser" environment
     .create()
@@ -289,7 +289,7 @@ let config = ComputerUseConfig::new()
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Search for Rust tutorials")
     .add_tool(config)
     .create()
@@ -321,7 +321,7 @@ use genai_rs::FileSearchConfig;
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What does the report say about Q4 revenue?")
     .add_tool(FileSearchConfig::new(vec!["stores/my-store-123".to_string()]))
     .create()
@@ -346,7 +346,7 @@ let config = FileSearchConfig::new(vec!["stores/my-store-123".to_string()])
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Find all mentions of 'performance optimization'")
     .add_tool(config)
     .create()
@@ -377,7 +377,7 @@ use genai_rs::{Client, RetrievalConfig, VertexAiSearchConfig};
 # let client = Client::new("api-key".to_string());
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What does our handbook say about vacation policy?")
     .add_tool(RetrievalConfig::new().with_vertex_ai_search(
         VertexAiSearchConfig::new()
@@ -401,7 +401,7 @@ use genai_rs::{
 # let client = Client::new("api-key".to_string());
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Summarize the design documents about caching")
     .add_tool(RetrievalConfig::new().with_rag_store(
         RagStoreConfig::new(vec![
@@ -435,7 +435,7 @@ use genai_rs::{Client, ExaAiSearchConfig, ParallelAiSearchConfig, RetrievalConfi
 let exa_key = std::env::var("EXA_API_KEY")?;
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Find recent papers on speculative decoding")
     .add_tool(RetrievalConfig::new().with_exa_ai_search(
         ExaAiSearchConfig::new(exa_key)
@@ -467,7 +467,7 @@ Ground responses in place and location data.
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Find highly rated coffee shops near the Ferry Building in San Francisco")
     .with_google_maps()
     .create()
@@ -496,7 +496,7 @@ use genai_rs::GoogleMapsConfig;
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What are the best lunch spots nearby?")
     .add_tool(
         GoogleMapsConfig::new()
@@ -521,7 +521,7 @@ use std::collections::HashMap;
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("List the files in the project root")
     .add_tool(
         McpServerConfig::new("filesystem", "https://mcp.example.com/fs")
@@ -558,7 +558,7 @@ Multiple built-in tools can be enabled simultaneously.
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Research the latest Rust async features and write example code")
     .with_google_search()      // Find current information
     .with_code_execution()     // Write and test code
@@ -573,7 +573,7 @@ use genai_rs::FileSearchConfig;
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Compare our internal report with public benchmarks")
     .add_tool(FileSearchConfig::new(vec!["stores/reports".to_string()]))
     .with_url_context()
@@ -598,7 +598,7 @@ fn get_user_prefs() -> String {
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Personalize search results based on my preferences")
     .with_google_search()
     .add_function(GetUserPrefsCallable.declaration())

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -50,7 +50,7 @@ let config = GenerationConfig {
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Write a short story")
     .with_generation_config(config)
     .create()
@@ -68,7 +68,7 @@ Most common settings have dedicated builder methods:
 # async fn example(client: &Client) -> Result<(), genai_rs::GenaiError> {
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Solve this step by step: 2x + 5 = 15")
     .with_seed(42)
     .with_stop_sequences(vec!["THE END".to_string()])
@@ -147,7 +147,7 @@ Discourage the model from repeating itself. Both penalties accept values in the 
 # async fn example(client: &Client) -> Result<(), genai_rs::GenaiError> {
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Brainstorm 20 startup ideas")
     .with_presence_penalty(0.5)   // Encourage new topics
     .with_frequency_penalty(0.3)  // Reduce word repetition
@@ -184,7 +184,7 @@ let config = GenerationConfig {
 
 | Model | Default Max | Absolute Max |
 |-------|-------------|--------------|
-| gemini-3-flash-preview | 8192 | 8192 |
+| gemini-3.6-flash | 8192 | 8192 |
 | gemini-3.1-pro-preview | 8192 | 8192 |
 
 Note: Actual limits vary by model version. Check [Google's documentation](https://ai.google.dev/models/gemini) for current values.
@@ -200,7 +200,7 @@ Seeds enable reproducible outputs for testing and debugging.
 # async fn example(client: &Client) -> Result<(), genai_rs::GenaiError> {
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Generate a random number")
     .with_seed(42)
     .create()
@@ -217,7 +217,7 @@ let response = client
 // Same seed + same input = same output
 let response1 = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What is 2+2?")
     .with_seed(42)
     .create()
@@ -225,7 +225,7 @@ let response1 = client
 
 let response2 = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What is 2+2?")
     .with_seed(42)
     .create()
@@ -256,7 +256,7 @@ Halt generation when specific strings are produced.
 # async fn example(client: &Client) -> Result<(), genai_rs::GenaiError> {
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Tell me a story. End with 'THE END'.")
     .with_stop_sequences(vec!["THE END".to_string()])
     .create()
@@ -272,7 +272,7 @@ let response = client
 # async fn example(client: &Client) -> Result<(), genai_rs::GenaiError> {
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Generate a list")
     .with_stop_sequences(vec![
         "---".to_string(),
@@ -336,7 +336,7 @@ Override client-level timeout for specific requests:
 // Long-running analysis task
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Analyze this large document...")
     .with_timeout(Duration::from_secs(300))  // 5 minute timeout
     .create()
@@ -371,7 +371,7 @@ Unrecognized tiers deserialize into `ServiceTier::Unknown { tier_type, data }` (
 # async fn example(client: &Client) -> Result<(), genai_rs::GenaiError> {
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Hello")
     .with_service_tier(ServiceTier::Flex)
     .create()
@@ -389,7 +389,7 @@ Reference an explicit context cache to reuse large, repeated context (e.g., a lo
 # async fn example(client: &Client) -> Result<(), genai_rs::GenaiError> {
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Summarize the cached document")
     .with_cached_content("cachedContents/xyz")
     .create()
@@ -419,7 +419,7 @@ Control how the model uses declared functions. Modes serialize as lowercase stri
 // Force function use
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's the weather?")
     .add_function(weather_declaration)
     .with_function_calling_mode(FunctionCallingMode::Any)
@@ -443,7 +443,7 @@ let config = GenerationConfig {
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Get current time")
     .add_function(time_declaration)
     .with_generation_config(config)
@@ -462,7 +462,7 @@ let response = client
 # async fn example(client: &Client, weather_declaration: FunctionDeclaration) -> Result<(), genai_rs::GenaiError> {
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Get weather in Tokyo")
     .add_function(weather_declaration)
     .with_allowed_tools(vec!["get_weather".to_string()])
@@ -479,7 +479,7 @@ For full control over the union, use `with_tool_choice()`:
 # async fn example(client: &Client) -> Result<(), genai_rs::GenaiError> {
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's the weather?")
     .with_tool_choice(ToolChoice::allowed_tools(
         Some(FunctionCallingMode::Any),
@@ -501,7 +501,7 @@ let response = client
 // Let the API use sensible defaults
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Hello!")
     .create()
     .await?;
@@ -520,7 +520,7 @@ mod tests {
     async fn test_model_output() {
         let response = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text("Generate test data")
             .with_seed(TEST_SEED)
             .create()
@@ -539,7 +539,7 @@ mod tests {
 // Factual query - low temperature
 let fact_response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What is the capital of France?")
     .with_generation_config(GenerationConfig {
         temperature: Some(0.0),
@@ -551,7 +551,7 @@ let fact_response = client
 // Creative task - higher temperature
 let story_response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Write a creative poem about the moon")
     .with_generation_config(GenerationConfig {
         temperature: Some(0.9),
@@ -572,7 +572,7 @@ let story_response = client
 // Quick lookup
 let quick = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What is 2+2?")
     .with_timeout(Duration::from_secs(30))
     .create()
@@ -581,7 +581,7 @@ let quick = client
 // Complex analysis
 let analysis = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text(&long_document)
     .with_timeout(Duration::from_secs(180))
     .create()
@@ -606,7 +606,7 @@ let creative_config = GenerationConfig {
 for prompt in creative_prompts {
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(prompt)
         .with_generation_config(creative_config.clone())
         .create()

--- a/docs/CONVERSATION_PATTERNS.md
+++ b/docs/CONVERSATION_PATTERNS.md
@@ -34,7 +34,7 @@ The server maintains conversation history:
 // Turn 1: Start conversation
 let response1 = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("My name is Alice")
     .with_store_enabled()
     .create()
@@ -43,7 +43,7 @@ let response1 = client
 // Turn 2: Server remembers context
 let response2 = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's my name?")
     .with_previous_interaction(response1.id.as_ref().unwrap())
     .with_store_enabled()
@@ -73,7 +73,7 @@ let history = vec![
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_history(history)
     .create()
     .await?;
@@ -95,7 +95,7 @@ Fluent API for inline conversation construction. `.user()` and `.model()` produc
 # async fn example(client: &Client) -> Result<(), genai_rs::GenaiError> {
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .conversation()
     .user("What is 2+2?")
     .model("2+2 equals 4.")
@@ -116,7 +116,7 @@ let response = client
 # async fn example(client: &Client) -> Result<(), genai_rs::GenaiError> {
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_system_instruction("You are a helpful math tutor")
     .conversation()
     .user("I need help with fractions")
@@ -144,7 +144,7 @@ let multimodal_step = Step::user_input(vec![
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_history(vec![multimodal_step])
     .create()
     .await?;
@@ -176,7 +176,7 @@ let history = vec![
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_history(history)
     .create()
     .await?;
@@ -203,7 +203,7 @@ let history: Vec<Step> = db_history
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_history(history)
     .create()
     .await?;
@@ -234,7 +234,7 @@ loop {
     // Send full history
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(history.clone())
         .create()
         .await?;
@@ -302,7 +302,7 @@ async fn summarize_and_trim(
 
     let summary = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(&summary_prompt)
         .create()
         .await?;
@@ -326,7 +326,7 @@ System instructions are not inherited across turns by the API — set them expli
 # async fn example(client: &Client, history: Vec<Step>) -> Result<(), genai_rs::GenaiError> {
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_system_instruction("You are a Python expert. Always provide code examples.")
     .with_history(history)
     .create()
@@ -351,7 +351,7 @@ fn get_weather(city: String) -> String {
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_history(history)
     .add_function(GetWeatherCallable.declaration())
     .create_with_auto_functions()
@@ -366,7 +366,7 @@ let response = client
 # async fn example(client: &Client, history: Vec<Step>) -> Result<(), genai_rs::GenaiError> {
 let mut stream = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_history(history)
     .create_stream();
 
@@ -430,7 +430,7 @@ Both ConversationBuilder and `with_history()` produce the same wire format — a
 
 ```json
 {
-  "model": "gemini-3-flash-preview",
+  "model": "gemini-3.6-flash",
   "input": [
     { "type": "user_input", "content": [{ "type": "text", "text": "Hello" }] },
     { "type": "model_output", "content": [{ "type": "text", "text": "Hi!" }] },

--- a/docs/ENUM_WIRE_FORMATS.md
+++ b/docs/ENUM_WIRE_FORMATS.md
@@ -1138,8 +1138,9 @@ on a standard key.
 ```
 
 `Visualization`: `"off"` | `"auto"` (+ `Unknown { visualization_type, data }`).
-Note the contrast with `thinking_summaries`, which uses `THINKING_SUMMARIES_*`
-in agent_config; `visualization` is lowercase per the spec.
+`visualization` is lowercase per the spec — as is `thinking_summaries`,
+which the API reversed (it previously took `THINKING_SUMMARIES_*` here and
+now rejects it; see the `ThinkingSummaries` entry above).
 
 **Status**: ✅ Verified live 2026-07: the API's validation error for
 `agent_config.visualization` lists exactly `off` | `auto`;

--- a/docs/ENUM_WIRE_FORMATS.md
+++ b/docs/ENUM_WIRE_FORMATS.md
@@ -1117,7 +1117,7 @@ non-video models.
 the supported `agent_config.type` values as `dynamic`, `deep-research`,
 `code-mender`, `antigravity`. `model` is server-validated per agent — an
 unavailable value returns 404 `not_found` (observed with
-`gemini-3-flash-preview`), and the agent's model catalog is not enumerable
+`gemini-3.6-flash`), and the agent's model catalog is not enumerable
 on a standard key.
 
 ### Visualization (Deep Research agent_config)
@@ -1190,7 +1190,7 @@ When adding new enums, always test the actual wire format with `curl`:
 curl -s "https://generativelanguage.googleapis.com/v1beta/interactions?key=$GEMINI_API_KEY" \
   -H "Content-Type: application/json" \
   -H "Api-Revision: 2026-05-20" \
-  -d '{"model": "gemini-3-flash-preview", "input": "test", ...}'
+  -d '{"model": "gemini-3.6-flash", "input": "test", ...}'
 ```
 
 Common patterns to try:

--- a/docs/ENUM_WIRE_FORMATS.md
+++ b/docs/ENUM_WIRE_FORMATS.md
@@ -105,7 +105,7 @@ Helper methods on each type:
 | `InteractionStatus` | snake_case | `"in_progress"`, `"requires_action"`, `"budget_exceeded"` | `budget_exceeded` new; pending live verification (2026-05-20 revision). `Default` is `InProgress` |
 | `SearchType` | snake_case string | `"web_search"`, `"image_search"`, `"enterprise_web_search"` | `enterprise_web_search` new; pending live verification (2026-05-20 revision) |
 | `GroundingToolCount` | `{"type": ..., "count": n}` | `{"type": "google_search", "count": 2}` | In `usage.grounding_tool_count`. Pending live verification (2026-05-20 revision) |
-| `ThinkingSummaries` | `THINKING_SUMMARIES_*` | `"THINKING_SUMMARIES_AUTO"` | Docs claim `auto`/`none` - **wrong** |
+| `ThinkingSummaries` | lowercase | `"auto"`, `"none"` | Send side. Was `THINKING_SUMMARIES_*` until the API reversed it (see below); both accepted on deserialize |
 | `ThinkingLevel` | lowercase | `"low"`, `"medium"`, `"high"` | Docs are correct |
 | `Resolution` | snake_case | `"low"`, `"medium"`, `"high"`, `"ultra_high"` | Image/video content |
 | `Tool::FileSearch` | snake_case object | `{"type": "file_search", ...}` | Rust: `store_names`, Wire: `file_search_store_names` |
@@ -484,17 +484,28 @@ Used in `agent_config.thinking_summaries` for Deep Research agent.
 {
   "agent_config": {
     "type": "deep-research",
-    "thinking_summaries": "THINKING_SUMMARIES_AUTO"
+    "thinking_summaries": "auto"
   }
 }
 ```
 
-| Rust Enum | Wire Value | Doc Claims (wrong) |
-|-----------|------------|-------------------|
-| `ThinkingSummaries::Auto` | `"THINKING_SUMMARIES_AUTO"` | `"auto"` |
-| `ThinkingSummaries::None` | `"THINKING_SUMMARIES_NONE"` | `"none"` |
+| Rust Enum | Wire Value (send) | Also accepted (deserialize) |
+|-----------|-------------------|-----------------------------|
+| `ThinkingSummaries::Auto` | `"auto"` | `"THINKING_SUMMARIES_AUTO"` |
+| `ThinkingSummaries::None` | `"none"` | `"THINKING_SUMMARIES_NONE"` |
 
-**Discovered**: 2026-01-04 - API returned `"unknown enum value: 'auto'"` until we tested the fully-qualified format.
+**This reversed.** History, because the reversal is the point:
+
+- **2026-01-04** — the API rejected `"auto"` with `unknown enum value: 'auto'`,
+  so `to_agent_config_value()` was written to emit `THINKING_SUMMARIES_*`
+  while `generation_config` kept lowercase. Two spellings, two contexts.
+- **2026-08-10** — verified live, exactly inverted:
+  `The value 'THINKING_SUMMARIES_AUTO' is not supported for
+  'agent_config.thinking_summaries'. Supported values: 'auto', 'none'.`
+  Deep-research requests carrying thinking summaries failed outright.
+
+Both contexts now emit lowercase. Deserialization accepts either spelling,
+so config files written against the old format still load.
 
 ### ThinkingLevel (generation_config)
 
@@ -1245,7 +1256,24 @@ If a `test-support` feature for constructing mock instances becomes commonly req
 The `genai_rs::antigravity::protocol` module speaks the localharness
 proto-JSON protocol (see `docs/ANTIGRAVITY.md`). Wire formats were verified
 against the descriptor set and a live harness from the
-`google-antigravity` 0.1.5 wheel (`LOUD_WIRE=1` on a real session):
+`google-antigravity` 0.1.10 wheel, and re-verified against 0.1.5
+(`LOUD_WIRE=1` on a real session, plus a descriptor diff between the two):
+
+### Alias spellings — a documented exception to Preserve Data Roundtrip
+
+These enums accept **alias** wire values: a value renamed between harness
+revisions deserializes to one variant, and `as_wire_str` re-emits the
+*canonical* (current-harness) spelling. So `STATE_IDLE` in, `STATE_FULLY_IDLE`
+out — deliberately **not** a faithful roundtrip, which is a departure from
+the Preserve Data Roundtrip principle in CLAUDE.md.
+
+The trade is worth naming. These are inbound-only enums (the client never
+sends a `TrajectoryState`), so the asymmetry cannot reach the wire; what it
+buys is one build that drives either harness revision. The alternative —
+preserving the old spelling as an `Unknown` variant — is what caused the
+0.1.5 → 0.1.10 breakage in the first place: `STATE_IDLE` became
+`STATE_FULLY_IDLE`, only `Idle` ends a turn, and every turn silently ran to
+its timeout. Preservation without recognition is not compatibility.
 
 - Field names are **camelCase**; enums are **SCREAMING_SNAKE_CASE** strings.
 - 64-bit integers (`seqNum`, token counts) arrive as JSON **strings**; the
@@ -1258,7 +1286,7 @@ Enums with Unknown variants (same pattern and helper methods as above):
 | `StepState` | src/antigravity/protocol.rs | `state_type` | `STATE_ACTIVE`, `STATE_DONE`, `STATE_WAITING_FOR_USER`, `STATE_ERROR` |
 | `StepSource` | src/antigravity/protocol.rs | `source_type` | `SOURCE_SYSTEM`, `SOURCE_USER`, `SOURCE_MODEL` |
 | `StepTarget` | src/antigravity/protocol.rs | `target_type` | `TARGET_USER`, `TARGET_MODEL`, `TARGET_ENVIRONMENT` |
-| `TrajectoryState` | src/antigravity/protocol.rs | `state_type` | `STATE_RUNNING`, `STATE_IDLE`, `STATE_CANCELLED` |
+| `TrajectoryState` | src/antigravity/protocol.rs | `state_type` | `STATE_RUNNING`, `STATE_FULLY_IDLE` (terminal; alias `STATE_IDLE`), `STATE_WAITING_FOR_TASKS`, `STATE_CANCELLED` |
 | `ModelType` | src/antigravity/protocol.rs | `model_type` | `MODEL_TYPE_TEXT`, `MODEL_TYPE_IMAGE` |
 | `LifecycleHook` | src/antigravity/protocol.rs | `hook_type` | `LIFECYCLE_HOOK_PRE_TOOL`, `LIFECYCLE_HOOK_POST_TOOL`, ... |
 | `HookDecision` | src/antigravity/protocol.rs | `decision_type` | `ALLOW`, `DENY` |

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -165,7 +165,7 @@ if api_key.is_empty() || !api_key.starts_with("AI") {
 // Error: GenaiError::Api { status_code: 404, message: "Model not found..." }
 
 // Prevention: Use known model constants
-const MODEL: &str = "gemini-3-flash-preview";
+const MODEL: &str = "gemini-3.6-flash";
 ```
 
 ### Rate Limiting
@@ -184,7 +184,7 @@ const MODEL: &str = "gemini-3-flash-preview";
 // Prevention: Set appropriate timeout
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Complex analysis task...")
     .with_timeout(Duration::from_secs(120))  // 2 minutes
     .create()
@@ -416,7 +416,7 @@ loop {
         client.get_interaction_stream(id, Some(event_id))
     } else {
         client.interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text("Tell me a story")
             .with_store_enabled()  // Required to resume by interaction ID
             .create_stream()

--- a/docs/EXAMPLES_INDEX.md
+++ b/docs/EXAMPLES_INDEX.md
@@ -116,6 +116,9 @@ Located in `examples/real_world/`:
 | `repo_auditor/` | Agentic security audit on the Antigravity harness: subagent, policies, structured report (`--features antigravity`) | Advanced |
 | [`session_resume/`](../examples/real_world/session_resume/) | Agent that remembers across process restarts — trajectory persistence, `conversation_id` round trip, `initial_history` (`--features antigravity`) | Advanced |
 | [`workspace_explorer/`](../examples/real_world/workspace_explorer/) | Watching an agent work and gating it live — workspaces, typed `ToolAction` stream, content-based `on_pre_tool` deny (`--features antigravity`) | Advanced |
+| [`mcp_toolbelt/`](../examples/real_world/mcp_toolbelt/) | Giving an agent tools it didn't ship with — `add_mcp_server` (stdio), `mcp_<server>_<tool>` policy targets, MCP alongside `Capabilities::none()` (`--features antigravity`) | Advanced |
+| [`proactive_agent/`](../examples/real_world/proactive_agent/) | Work that starts without a user turn — `add_trigger`, observing deliveries via a wire inspector, the trigger/user-turn discard boundary (`--features antigravity`) | Advanced |
+| [`cancellable_turn/`](../examples/real_world/cancellable_turn/) | Stopping an agent mid-thought — `cancel_handle` from another task, partial output kept, contrast with `with_turn_timeout` (`--features antigravity`) | Advanced |
 
 ## Example Details
 
@@ -311,7 +314,7 @@ write-capable `AskQuestion` builtin), `send_streaming()`, `shutdown()`.
 | `computer_use` | Computer Use capability access |
 | `file_search` | Pre-configured file search store |
 | `google_search` | Google Search grounding access |
-| `antigravity_agent`, `repo_auditor`, `session_resume`, `workspace_explorer` | `localharness` binary (`pip install google-antigravity==0.1.10`) + `--features antigravity` |
+| `antigravity_agent`, `repo_auditor`, `session_resume`, `workspace_explorer`, `mcp_toolbelt`, `proactive_agent`, `cancellable_turn` | `localharness` binary (`pip install google-antigravity==0.1.10`) + `--features antigravity` |
 
 ## Example Progression
 

--- a/docs/EXAMPLES_INDEX.md
+++ b/docs/EXAMPLES_INDEX.md
@@ -309,7 +309,7 @@ write-capable `AskQuestion` builtin), `send_streaming()`, `shutdown()`.
 | `computer_use` | Computer Use capability access |
 | `file_search` | Pre-configured file search store |
 | `google_search` | Google Search grounding access |
-| `antigravity_agent`, `repo_auditor` | `localharness` binary (`pip install google-antigravity==0.1.10`) + `--features antigravity` |
+| `antigravity_agent`, `repo_auditor`, `session_resume`, `workspace_explorer` | `localharness` binary (`pip install google-antigravity==0.1.10`) + `--features antigravity` |
 
 ## Example Progression
 

--- a/docs/EXAMPLES_INDEX.md
+++ b/docs/EXAMPLES_INDEX.md
@@ -114,6 +114,8 @@ Located in `examples/real_world/`:
 | `data_analysis/` | CSV data analysis with functions | Intermediate |
 | `rag_system/` | Retrieval-augmented generation | Advanced |
 | `repo_auditor/` | Agentic security audit on the Antigravity harness: subagent, policies, structured report (`--features antigravity`) | Advanced |
+| [`session_resume/`](../examples/real_world/session_resume/) | Agent that remembers across process restarts | Trajectory persistence, `conversation_id` round trip, `initial_history` (`--features antigravity`) |
+| [`workspace_explorer/`](../examples/real_world/workspace_explorer/) | Watching an agent work, and gating it live | Workspaces, typed `ToolAction` stream, content-based `on_pre_tool` deny (`--features antigravity`) |
 
 ## Example Details
 

--- a/docs/EXAMPLES_INDEX.md
+++ b/docs/EXAMPLES_INDEX.md
@@ -234,7 +234,7 @@ Generate images from text prompts.
 cargo run --example image_generation
 ```
 **Learn**: `with_image_output()`, `first_image_bytes()`, image iteration.
-**Note**: Requires `gemini-3-pro-image-preview` model.
+**Note**: Requires `gemini-3.1-flash-image` model.
 
 #### text_to_speech
 Convert text to spoken audio.
@@ -303,7 +303,7 @@ write-capable `AskQuestion` builtin), `send_streaming()`, `shutdown()`.
 
 | Example | Special Requirements |
 |---------|---------------------|
-| `image_generation` | `gemini-3-pro-image-preview` model access |
+| `image_generation` | `gemini-3.1-flash-image` model access |
 | `text_to_speech` | `gemini-2.5-pro-preview-tts` model access |
 | `deep_research` | Deep Research agent access |
 | `computer_use` | Computer Use capability access |

--- a/docs/EXAMPLES_INDEX.md
+++ b/docs/EXAMPLES_INDEX.md
@@ -114,8 +114,8 @@ Located in `examples/real_world/`:
 | `data_analysis/` | CSV data analysis with functions | Intermediate |
 | `rag_system/` | Retrieval-augmented generation | Advanced |
 | `repo_auditor/` | Agentic security audit on the Antigravity harness: subagent, policies, structured report (`--features antigravity`) | Advanced |
-| [`session_resume/`](../examples/real_world/session_resume/) | Agent that remembers across process restarts | Trajectory persistence, `conversation_id` round trip, `initial_history` (`--features antigravity`) |
-| [`workspace_explorer/`](../examples/real_world/workspace_explorer/) | Watching an agent work, and gating it live | Workspaces, typed `ToolAction` stream, content-based `on_pre_tool` deny (`--features antigravity`) |
+| [`session_resume/`](../examples/real_world/session_resume/) | Agent that remembers across process restarts — trajectory persistence, `conversation_id` round trip, `initial_history` (`--features antigravity`) | Advanced |
+| [`workspace_explorer/`](../examples/real_world/workspace_explorer/) | Watching an agent work and gating it live — workspaces, typed `ToolAction` stream, content-based `on_pre_tool` deny (`--features antigravity`) | Advanced |
 
 ## Example Details
 

--- a/docs/EXAMPLES_INDEX.md
+++ b/docs/EXAMPLES_INDEX.md
@@ -297,7 +297,7 @@ cargo run --example antigravity_agent --features antigravity
 harness, `policy::deny_all()`/`allow()`, `on_questions()` (enabling the
 write-capable `AskQuestion` builtin), `send_streaming()`, `shutdown()`.
 **Note**: Requires the `localharness` binary
-(`pip install google-antigravity==0.1.5`) and `GEMINI_API_KEY`.
+(`pip install google-antigravity==0.1.10`) and `GEMINI_API_KEY`.
 
 ## Prerequisites by Example
 
@@ -309,7 +309,7 @@ write-capable `AskQuestion` builtin), `send_streaming()`, `shutdown()`.
 | `computer_use` | Computer Use capability access |
 | `file_search` | Pre-configured file search store |
 | `google_search` | Google Search grounding access |
-| `antigravity_agent`, `repo_auditor` | `localharness` binary (`pip install google-antigravity==0.1.5`) + `--features antigravity` |
+| `antigravity_agent`, `repo_auditor` | `localharness` binary (`pip install google-antigravity==0.1.10`) + `--features antigravity` |
 
 ## Example Progression
 

--- a/docs/FUNCTION_CALLING.md
+++ b/docs/FUNCTION_CALLING.md
@@ -84,7 +84,7 @@ let _declaration = GetWeatherCallable.declaration();
 // Functions are auto-discovered from the global registry
 let result = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's the weather in Tokyo?")
     .create_with_auto_functions()  // Auto-discovers and executes
     .await?;
@@ -100,7 +100,7 @@ use genai_rs::CallableFunction;
 // Only expose specific functions (not all registered ones)
 let result = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's the weather in Tokyo?")
     .add_function(GetWeatherCallable.declaration())  // Only weather
     .create_with_auto_functions()
@@ -211,7 +211,7 @@ let service = Arc::new(MyToolService {
 
 let result = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's the weather in Tokyo?")
     .with_tool_service(service.clone())  // Inject the service
     .create_with_auto_functions()
@@ -271,7 +271,7 @@ let get_weather = FunctionDeclaration::builder("get_weather")
 // Initial request
 let mut response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's the weather in Tokyo?")
     .add_functions(vec![get_weather])
     .create()  // NOT create_with_auto_functions
@@ -295,7 +295,7 @@ while response.has_function_calls() {
     // Send results back as function_result steps
     response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_previous_interaction(response.id.as_ref().unwrap())
         .with_history(results)
         .create()

--- a/docs/MULTIMODAL.md
+++ b/docs/MULTIMODAL.md
@@ -192,9 +192,11 @@ use genai_rs::{Client, Content, video_from_file};
 
 // From file helper
 let video_content = video_from_file("clip.mp4").await?;
+// video_from_file reads the file into inline bytes, so it needs an
+// inline-capable model too (see the note on the base64 form below).
 let response = client
     .interaction()
-    .with_model("gemini-3.6-flash")
+    .with_model("gemini-3-flash-preview")
     .with_content(vec![
         Content::text("Describe what happens in this video"),
         video_content,
@@ -202,10 +204,14 @@ let response = client
     .create()
     .await?;
 
-// From base64
+// From base64 — NOTE the model. Inline video bytes need a model that
+// accepts them: verified live 2026-08-10, gemini-3.6-flash returns
+// 400 invalid_request for inline video while accepting video by URI.
+// Prefer the Files API URI form below unless you specifically need
+// inline bytes.
 let response = client
     .interaction()
-    .with_model("gemini-3.6-flash")
+    .with_model("gemini-3-flash-preview")
     .with_content(vec![
         Content::text("Summarize this video"),
         Content::video_data(base64_video, "video/mp4"),

--- a/docs/MULTIMODAL.md
+++ b/docs/MULTIMODAL.md
@@ -35,7 +35,7 @@ use genai_rs::{Client, Content};
 // From base64 data
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("What's in this image?"),
         Content::image_data(base64_string, "image/png"),
@@ -46,7 +46,7 @@ let response = client
 // From URI (Files API or public URL)
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("Describe the uploaded image"),
         Content::image_uri(&file_metadata.uri, "image/png"),
@@ -65,7 +65,7 @@ let image_content = image_from_file("photo.jpg").await?;
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("What do you see?"),
         image_content,
@@ -82,7 +82,7 @@ use genai_rs::{Client, Content};
 // Compare multiple images
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("Compare these images:"),
         Content::image_data(base64_image1, "image/png"),
@@ -112,7 +112,7 @@ use genai_rs::{Client, Content, audio_from_file};
 let audio_content = audio_from_file("recording.mp3").await?;
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("Transcribe this audio"),
         audio_content,
@@ -123,7 +123,7 @@ let response = client
 // From base64
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("What's being said?"),
         Content::audio_data(base64_audio, "audio/mp3"),
@@ -194,7 +194,7 @@ use genai_rs::{Client, Content, video_from_file};
 let video_content = video_from_file("clip.mp4").await?;
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("Describe what happens in this video"),
         video_content,
@@ -205,7 +205,7 @@ let response = client
 // From base64
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("Summarize this video"),
         Content::video_data(base64_video, "video/mp4"),
@@ -221,7 +221,7 @@ let file = client
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("What's in this video?"),
         Content::video_uri(&file.uri, "video/mp4"),
@@ -251,7 +251,7 @@ use genai_rs::{Client, Content, document_from_file};
 let doc_content = document_from_file("report.pdf").await?;
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("Summarize this document"),
         doc_content,
@@ -262,7 +262,7 @@ let response = client
 // From base64
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("Extract key points from this PDF"),
         Content::document_data(base64_pdf, "application/pdf"),
@@ -276,7 +276,7 @@ let response = client
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("Analyze this code"),
         Content::document_data(base64_text, "text/plain"),
@@ -355,7 +355,7 @@ if metadata.is_active() {
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("Analyze this file"),
         Content::from_file(&file),
@@ -405,7 +405,7 @@ use genai_rs::{Client, Content, Resolution};
 // With resolution using builder method
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_content(vec![
         Content::text("What color is this?"),
         Content::image_data(base64, "image/png").with_resolution(Resolution::Low),
@@ -512,7 +512,7 @@ Generate images from text prompts.
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-pro-image-preview")  // Image generation model
+    .with_model("gemini-3.1-flash-image")  // Image generation model
     .with_text("A sunset over mountains, digital art style")
     .with_image_output()
     .create()

--- a/docs/MULTI_TURN_FUNCTION_CALLING.md
+++ b/docs/MULTI_TURN_FUNCTION_CALLING.md
@@ -34,7 +34,7 @@ The Gemini Interactions API supports two modes controlled by the `store` paramet
 ```rust,ignore
 // First turn
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Hi, I'm Alice")
     .with_system_instruction("You are a helpful assistant")
     .with_store_enabled()  // Server stores conversation
@@ -43,7 +43,7 @@ let response = client.interaction()
 
 // Subsequent turns - just chain with previous_interaction_id
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's my name?")  // Model remembers: "Alice"
     .with_previous_interaction(&response.id.unwrap())
     .with_store_enabled()
@@ -75,7 +75,7 @@ let mut history: Vec<Step> = vec![];
 history.push(Step::user_text("Hi, I'm Alice"));
 
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_history(history.clone())
     .with_system_instruction("You are a helpful assistant")
     .with_store_disabled()  // No server state
@@ -89,7 +89,7 @@ history.extend(response.output_steps());
 history.push(Step::user_text("What's my name?"));
 
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_history(history.clone())
     .with_system_instruction("You are a helpful assistant")
     .with_store_disabled()
@@ -280,7 +280,7 @@ for _ in 0..MAX_ITERATIONS {
     }
 
     response = client.interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_previous_interaction(response.id.as_ref().unwrap())
         .with_history(results)
         .create()
@@ -385,7 +385,7 @@ When using `previous_interaction_id` (stateful mode), some settings are inherite
 ```rust,ignore
 // First turn
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Hello!")
     .with_system_instruction("You are a helpful assistant")
     .with_store_enabled()
@@ -394,7 +394,7 @@ let response = client.interaction()
 
 // Subsequent turn - set system_instruction again if needed
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What can you help me with?")
     .with_previous_interaction(&response.id.unwrap())
     .with_system_instruction("You are a helpful assistant")  // Set explicitly
@@ -410,7 +410,7 @@ For `create_with_auto_functions()`, the system instruction is automatically incl
 ```rust,ignore
 // System instruction is sent on every internal iteration automatically
 let result = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's the weather?")
     .with_system_instruction("You are a weather assistant")
     .create_with_auto_functions()
@@ -425,7 +425,7 @@ let system_prompt = "You are a helpful assistant";
 
 // Each turn: always include system_instruction and tools
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text(message)
     .add_functions(functions.clone())
     .with_system_instruction(system_prompt)
@@ -547,7 +547,7 @@ impl Agent {
         let response = match &self.last_id {
             Some(prev_id) => {
                 self.client.interaction()
-                    .with_model("gemini-3-flash-preview")
+                    .with_model("gemini-3.6-flash")
                     .with_text(message)
                     .add_functions(self.functions.clone())
                     .with_previous_interaction(prev_id)
@@ -556,7 +556,7 @@ impl Agent {
             }
             None => {
                 self.client.interaction()
-                    .with_model("gemini-3-flash-preview")
+                    .with_model("gemini-3.6-flash")
                     .with_text(message)
                     .add_functions(self.functions.clone())
                     .with_system_instruction("...")
@@ -595,7 +595,7 @@ impl StatelessSession {
         self.history.push(Step::user_text(message));
 
         let response = self.client.interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_history(self.history.clone())
             .add_functions(self.functions.clone())
             .with_system_instruction(&self.system_instruction)

--- a/docs/OUTPUT_MODALITIES.md
+++ b/docs/OUTPUT_MODALITIES.md
@@ -23,7 +23,7 @@ Gemini models can generate different types of output content:
 | Modality | Method | Model Required | Use Case |
 |----------|--------|----------------|----------|
 | **Text** | Default | Any | Conversations, analysis |
-| **Image** | `with_image_output()` | `gemini-3-pro-image-preview` | Image generation |
+| **Image** | `with_image_output()` | `gemini-3.1-flash-image` | Image generation |
 | **Audio** | `with_audio_output()` | `gemini-2.5-pro-preview-tts` | Text-to-speech |
 | **Video** | `with_video_output()` | Video-capable model (e.g., Veo previews) | Video generation (background) |
 | **JSON** | `with_response_format()` | Any | Structured data extraction |
@@ -38,7 +38,7 @@ Text is the default output modality - no special configuration needed.
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Explain quantum computing")
     .create()
     .await?;
@@ -67,7 +67,7 @@ Generate images from text prompts.
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-pro-image-preview")  // Image generation model required
+    .with_model("gemini-3.1-flash-image")  // Image generation model required
     .with_text("A sunset over mountains, digital art style")
     .with_image_output()
     .create()
@@ -115,7 +115,7 @@ Image generation requires specific models:
 
 | Model | Capability |
 |-------|------------|
-| `gemini-3-pro-image-preview` | Text-to-image generation |
+| `gemini-3.1-flash-image` | Text-to-image generation |
 
 Note: Image generation may not be available in all regions.
 
@@ -304,7 +304,7 @@ use serde_json::json;
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Generate a user profile for John Doe, age 30")
     .with_response_format(json!({
         "type": "object",
@@ -350,7 +350,7 @@ let schema = json!({
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("List 3 popular smartphones with prices")
     .with_response_format(schema)
     .create()
@@ -384,7 +384,7 @@ Structured output works with built-in tools:
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's the weather in Tokyo?")
     .with_google_search()
     .with_response_format(json!({
@@ -431,7 +431,7 @@ let image = ResponseFormat::Image {
 // List form: one format per requested modality
 let response = client
     .interaction()
-    .with_model("gemini-3-pro-image-preview")
+    .with_model("gemini-3.1-flash-image")
     .with_text("A labeled diagram of a volcano")
     .with_response_formats(vec![ResponseFormat::text_plain(), image])
     .create()
@@ -452,7 +452,7 @@ The structured output still uses text modality internally:
 ```rust,ignore
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Analyze this sentiment")
     .with_response_format(sentiment_schema)
     .create()
@@ -555,7 +555,7 @@ for content in response.thought_summaries() {
 ```rust,ignore
 // Image generation - requires image model
 client.interaction()
-    .with_model("gemini-3-pro-image-preview")  // Correct
+    .with_model("gemini-3.1-flash-image")  // Correct
     .with_image_output()
 
 // TTS - requires TTS model
@@ -565,7 +565,7 @@ client.interaction()
 
 // Text/JSON - any model works
 client.interaction()
-    .with_model("gemini-3-flash-preview")  // Standard model fine
+    .with_model("gemini-3.6-flash")  // Standard model fine
     .with_response_format(schema)
 ```
 

--- a/docs/RELIABILITY_PATTERNS.md
+++ b/docs/RELIABILITY_PATTERNS.md
@@ -74,7 +74,7 @@ where
 let response = with_retry(3, || async {
     client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .create()
         .await
@@ -236,7 +236,7 @@ Override for specific requests:
 // Long analysis task
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text(&large_document)
     .with_timeout(Duration::from_secs(300))  // 5 minutes
     .create()
@@ -446,7 +446,7 @@ use genai_rs::ServiceTier;
 // Batch/offline work tolerates queuing - use Flex
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Summarize this document...")
     .with_service_tier(ServiceTier::Flex)
     .create()
@@ -469,7 +469,7 @@ async fn with_fallback(
 ) -> String {
     match client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(prompt)
         .create()
         .await
@@ -493,7 +493,7 @@ async fn with_model_fallback(
     prompt: &str,
 ) -> Result<String, GenaiError> {
     let models = [
-        "gemini-3-flash-preview",
+        "gemini-3.6-flash",
         "gemini-3.1-pro-preview",
     ];
 
@@ -541,7 +541,7 @@ impl CachedClient {
         // Make request
         let response = self.client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text(prompt)
             .create()
             .await?;
@@ -610,7 +610,7 @@ where
 async fn health_check(client: &Client) -> bool {
     match client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("ping")
         .with_timeout(Duration::from_secs(10))
         .create()
@@ -654,7 +654,7 @@ impl ReliableClient {
         for attempt in 0..=self.max_retries {
             let result = self.client
                 .interaction()
-                .with_model("gemini-3-flash-preview")
+                .with_model("gemini-3.6-flash")
                 .with_text(prompt)
                 .create()
                 .await;

--- a/docs/RETRY_PATTERNS.md
+++ b/docs/RETRY_PATTERNS.md
@@ -23,7 +23,7 @@ Rather than building an opinionated retry system that won't fit everyone's needs
 
 ```rust
 let request = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Hello")
     .build()?;
 

--- a/docs/STREAMING_API.md
+++ b/docs/STREAMING_API.md
@@ -43,7 +43,7 @@ The key decision points are:
 # async fn example() -> Result<(), genai_rs::GenaiError> {
 # let client = Client::new("your-api-key".to_string());
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Write a poem about Rust")
     .create()
     .await?;
@@ -68,7 +68,7 @@ use genai_rs::{Client, StreamChunk};
 # async fn example() -> Result<(), genai_rs::GenaiError> {
 # let client = Client::new("your-api-key".to_string());
 let mut stream = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Write a poem about Rust")
     .create_stream();
 
@@ -316,7 +316,7 @@ use genai_rs::{Client, StreamChunk};
 let client = Client::new("your-api-key".to_string());
 
 let mut stream = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Count to 10")
     .create_stream();
 
@@ -412,7 +412,7 @@ use genai_rs::{Client, Step, StreamChunk};
 let client = Client::new("your-api-key".to_string());
 
 let mut stream = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's the weather in Tokyo?")
     .add_functions(functions)
     .create_stream();
@@ -464,7 +464,7 @@ let client = Client::new("your-api-key".to_string());
 
 // Functions are auto-discovered from the #[tool] registry / tool service.
 let mut stream = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's the weather in Tokyo?")
     .create_stream_with_auto_functions();
 
@@ -527,7 +527,7 @@ use genai_rs::{AutoFunctionResultAccumulator, AutoFunctionStreamChunk, Client};
 # async fn example() -> Result<(), genai_rs::GenaiError> {
 # let client = Client::new("your-api-key".to_string());
 # let mut stream = client.interaction()
-#     .with_model("gemini-3-flash-preview")
+#     .with_model("gemini-3.6-flash")
 #     .with_text("What's the weather in Tokyo?")
 #     .create_stream_with_auto_functions();
 let mut accumulator = AutoFunctionResultAccumulator::new();
@@ -581,7 +581,7 @@ let mut last_event_id: Option<String> = None;
 let mut interaction_id: Option<String> = None;
 
 let mut stream = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Count to 100")
     .with_store_enabled()  // Required for resume
     .create_stream();
@@ -760,7 +760,7 @@ impl StreamingSession {
         let mut full_text = String::new();
 
         let mut stream = self.client.interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text(prompt)
             .with_store_enabled()
             .create_stream();
@@ -846,7 +846,7 @@ async fn stream_with_retry(
         } else {
             // Initial stream
             Box::pin(client.interaction()
-                .with_model("gemini-3-flash-preview")
+                .with_model("gemini-3.6-flash")
                 .with_text(prompt)
                 .with_store_enabled()
                 .create_stream())
@@ -953,7 +953,7 @@ With `LOUD_WIRE=1`, you'll see the raw SSE events:
 
 ```text
 [REQ#1] POST /v1beta/interactions?alt=sse
-  model: gemini-3-flash-preview
+  model: gemini-3.6-flash
   input: "Write a poem"
 
 [RES#1] SSE stream:

--- a/docs/THINKING_MODE.md
+++ b/docs/THINKING_MODE.md
@@ -49,7 +49,7 @@ use genai_rs::{Client, ThinkingLevel};
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Solve step by step: If a train travels 120 miles in 2 hours, what's its speed?")
     .with_thinking_level(ThinkingLevel::Medium)
     .create()
@@ -122,7 +122,7 @@ use genai_rs::{ThinkingLevel, ThinkingSummaries};
 
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Explain photosynthesis step by step")
     .with_thinking_level(ThinkingLevel::High)
     .with_thinking_summaries(ThinkingSummaries::Auto)
@@ -154,7 +154,7 @@ use genai_rs::{StepDelta, StreamChunk, ThinkingLevel, ThinkingSummaries};
 
 let mut stream = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Solve: What is 15% of 240?")
     .with_thinking_level(ThinkingLevel::Medium)
     .with_thinking_summaries(ThinkingSummaries::Auto)
@@ -311,7 +311,7 @@ Thinking works with function calling to show reasoning about tool use:
 use genai_rs::CallableFunction;
 
 let response = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("What's the weather in Tokyo and should I bring an umbrella?")
     .with_thinking_level(ThinkingLevel::Medium)
     .add_function(GetWeatherCallable.declaration())
@@ -338,7 +338,7 @@ When managing conversation history yourself (stateless mode), include the model'
 // Turn 1
 let response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text("Think about the fastest route from A to B")
     .with_thinking_level(ThinkingLevel::Medium)
     .create()
@@ -351,7 +351,7 @@ history.extend(response.output_steps());
 // Turn 2 - signatures replay automatically via the history
 let followup = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_history(history)
     .with_text("Now assume road B2 is closed")
     .create()

--- a/examples/antigravity_agent.rs
+++ b/examples/antigravity_agent.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Policies are evaluated Rust-side before every tool dispatch.
     let mut agent = AntigravityAgent::builder()
         .with_api_key(api_key)
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_system_instructions(
             "You are a concise assistant. Prefer tools over guessing. When a request is \
              ambiguous (e.g. no city given for weather), use ask_question to clarify \

--- a/examples/antigravity_agent.rs
+++ b/examples/antigravity_agent.rs
@@ -5,7 +5,7 @@
 //!
 //! Requirements:
 //! - The `localharness` binary (ships in the `google-antigravity` Python
-//!   wheel): `pip install google-antigravity==0.1.5`, or set
+//!   wheel): `pip install google-antigravity==0.1.10`, or set
 //!   `ANTIGRAVITY_HARNESS_PATH` to the binary.
 //! - `GEMINI_API_KEY` for model calls.
 //!
@@ -162,7 +162,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("--- Production Considerations ---");
     println!(
-        "• Pin the harness: pip install google-antigravity==0.1.5 (see SUPPORTED_HARNESS_VERSION)"
+        "• Pin the harness: pip install google-antigravity==0.1.10 (see SUPPORTED_HARNESS_VERSION)"
     );
     println!("• Always add policies before enabling write tools (run_command, edit_file)");
     println!(

--- a/examples/audio_input.rs
+++ b/examples/audio_input.rs
@@ -20,7 +20,7 @@ const DEMO_WAV_BASE64: &str = "UklGRuwAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZ
 async fn main() -> Result<(), Box<dyn Error>> {
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not found in environment");
     let client = Client::builder(api_key).build()?;
-    let model_name = "gemini-3-flash-preview";
+    let model_name = "gemini-3.6-flash";
 
     // =========================================================================
     // Example 1: Basic Audio Transcription (Fluent Builder Pattern)
@@ -82,7 +82,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
    let response = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("Transcribe this audio with proper punctuation."),
            Content::audio_data(&base64_audio, "audio/mp3"),
@@ -101,7 +101,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         r#"
    let response = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("Analyze this audio:
                - How many speakers are there?
@@ -123,7 +123,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         r#"
    let response = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("In this podcast, what are the main topics discussed?"),
            Content::audio_data(&podcast_audio, "audio/mp3"),
@@ -144,7 +144,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // First turn: Send audio and get initial analysis
    let first = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("Summarize this audio recording."),
            Content::audio_data(&base64_audio, "audio/mp3"),
@@ -156,7 +156,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // Second turn: Ask follow-up (audio is remembered)
    let second = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_text("What emotions did you detect in the speaker's voice?")
        .with_previous_interaction(&first.id)
        .create()
@@ -231,7 +231,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // Build the request using with_content
    let response = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("Transcribe this audio."),
            audio_content,
@@ -255,7 +255,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // Send with with_content
    let response = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("Transcribe this audio."),
            Content::audio_data(&base64_audio, "audio/mp3"),

--- a/examples/auto_function_calling.rs
+++ b/examples/auto_function_calling.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(prompt)
         // No with_functions() needed - auto-discovers from registry!
         .create_with_auto_functions()
@@ -128,7 +128,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let result2 = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(limited_prompt)
         .add_function(weather_func) // Only weather, not time
         .create_with_auto_functions()
@@ -153,7 +153,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut stream = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(stream_prompt)
         .add_function(time_func) // Provide declaration but no auto-execution
         .create_stream(); // Note: create_stream, not create_stream_with_auto_functions
@@ -212,7 +212,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(auto_prompt)
         .add_function(GetWeatherCallable.declaration())
         .with_function_calling_mode(FunctionCallingMode::Auto) // Model decides
@@ -237,7 +237,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(any_prompt)
         .add_function(GetWeatherCallable.declaration())
         .with_function_calling_mode(FunctionCallingMode::Any) // MUST call a function
@@ -259,7 +259,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(none_prompt)
         .add_function(GetWeatherCallable.declaration())
         .with_function_calling_mode(FunctionCallingMode::None) // Disabled
@@ -279,7 +279,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(validated_prompt)
         .add_function(GetWeatherCallable.declaration())
         .with_function_calling_mode(FunctionCallingMode::Validated) // Schema adherence

--- a/examples/code_execution.rs
+++ b/examples/code_execution.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let client = Client::builder(api_key).build()?;
 
     // 2. Create an interaction with code execution enabled
-    let model_name = "gemini-3-flash-preview";
+    let model_name = "gemini-3.6-flash";
     let prompt = "Calculate the first 20 prime numbers using Python. \
                   Show both the code and explain the results.";
 

--- a/examples/computer_use.rs
+++ b/examples/computer_use.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Create the client
     let client = Client::builder(api_key).build()?;
 
-    let model_name = "gemini-3-flash-preview";
+    let model_name = "gemini-3.6-flash";
 
     // 2. Basic Computer Use - Enable browser automation
     println!("=== Computer Use: Basic Browser Automation ===\n");

--- a/examples/explicit_turns.rs
+++ b/examples/explicit_turns.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .conversation()
         .user("What is 2+2?")
         .model("2+2 equals 4.")
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(history)
         .create()
         .await?;
@@ -91,7 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Send full conversation history
         let response = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_history(history.clone())
             .create()
             .await?;

--- a/examples/file_search.rs
+++ b/examples/file_search.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         "stores/your-store-id-here".to_string(), // Replace with your store ID
     ];
 
-    let model_name = "gemini-3-flash-preview";
+    let model_name = "gemini-3.6-flash";
     let prompt = "What information do my documents contain about Rust programming?";
 
     println!("=== File Search Example ===\n");

--- a/examples/files_api.rs
+++ b/examples/files_api.rs
@@ -65,7 +65,7 @@ to analyze multiple times without resending the data.
     println!("3. Using file in interaction...");
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::from_file(&ready_file),
             Content::text("What are the main points about the Files API in this document?"),
@@ -85,7 +85,7 @@ to analyze multiple times without resending the data.
     println!("4. Reusing file in another interaction...");
     let response2 = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::from_file(&ready_file),
             Content::text("What file types are supported according to this document?"),

--- a/examples/google_maps.rs
+++ b/examples/google_maps.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not found in environment");
     let client = Client::builder(api_key).build()?;
 
-    let model_name = "gemini-3-flash-preview";
+    let model_name = "gemini-3.6-flash";
 
     // === Basic Google Maps usage ===
     println!("=== Google Maps: Find Places ===\n");

--- a/examples/google_search.rs
+++ b/examples/google_search.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let client = Client::builder(api_key).build()?;
 
     // 2. Create an interaction with Google Search enabled
-    let model_name = "gemini-3-flash-preview";
+    let model_name = "gemini-3.6-flash";
     let prompt = "What are the latest developments in Rust programming language in 2024? \
                   Include specific version numbers and features.";
 

--- a/examples/image_generation.rs
+++ b/examples/image_generation.rs
@@ -16,7 +16,7 @@
 //! # Model Support
 //!
 //! Image generation requires a model that supports the "image" response modality.
-//! Currently supported: `gemini-3-pro-image-preview`
+//! Currently supported: `gemini-3.1-flash-image`
 //!
 //! # Regional Availability
 //!
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ==========================================================================
     println!("--- Example 1: Birman Cat ---\n");
 
-    let model = "gemini-3-pro-image-preview";
+    let model = "gemini-3.1-flash-image";
     let prompt = "A white and orange Birman cat sitting cozily on an electric blanket on a couch.";
 
     println!("Model: {}", model);
@@ -169,7 +169,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("--- Key Takeaways ---");
     println!("• with_image_output() sets response modality to \"image\"");
-    println!("• Requires gemini-3-pro-image-preview model");
+    println!("• Requires gemini-3.1-flash-image model");
     println!("• response.first_image_bytes() extracts the first image");
     println!("• response.images() iterator for multiple images with metadata\n");
 
@@ -199,9 +199,7 @@ fn handle_image_generation_error(e: &GenaiError) {
             eprintln!("API Error (HTTP {}): {}", status_code, message);
 
             if message.contains("not found") || message.contains("not supported") {
-                eprintln!(
-                    "\nNote: Image generation requires the gemini-3-pro-image-preview model."
-                );
+                eprintln!("\nNote: Image generation requires the gemini-3.1-flash-image model.");
                 eprintln!("This model may not be available in all regions or API configurations.");
             }
         }

--- a/examples/manual_function_calling.rs
+++ b/examples/manual_function_calling.rs
@@ -101,7 +101,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Step 1: Initial request with function declarations
     let mut response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(prompt)
         .add_functions(functions.clone())
         .create() // NOT create_with_auto_functions() - we handle execution
@@ -139,7 +139,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .ok_or("Response missing ID. Multi-turn requires store=true (the default).")?;
         response = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_previous_interaction(prev_id) // Continue the conversation
             .with_history(results) // function_result steps as input
             .add_functions(functions.clone()) // Keep functions available

--- a/examples/multimodal_image.rs
+++ b/examples/multimodal_image.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::text("What color is this image? Describe it."),
             Content::image_data(TINY_RED_PNG_BASE64, "image/png"),
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let comparison = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(comparison_contents)
         .with_store_enabled()
         .create()
@@ -96,7 +96,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Low resolution - good for simple color/shape detection, costs fewer tokens
     let low_res_response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::text("What color is this image?"),
             Content::image_data(TINY_RED_PNG_BASE64, "image/png").with_resolution(Resolution::Low),
@@ -115,7 +115,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // High resolution - for detailed analysis of complex images
     let high_res_response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::text("What color is this image?"),
             Content::image_data(TINY_RED_PNG_BASE64, "image/png").with_resolution(Resolution::High),
@@ -135,7 +135,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nUsing Content::image_data().with_resolution() builder:");
     let helper_response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::text("Describe this image briefly."),
             Content::image_data(TINY_BLUE_PNG_BASE64, "image/png")
@@ -154,7 +154,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let follow_up = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_previous_interaction(
             comparison
                 .id

--- a/examples/parallel_and_compositional_functions.rs
+++ b/examples/parallel_and_compositional_functions.rs
@@ -185,7 +185,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let mut response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("What's the weather and time in Tokyo, London, and New York?")
         .add_functions(functions.clone())
         .with_store_enabled()
@@ -239,7 +239,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         // Send results back - no need to resend tools on function result turns
         response = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_previous_interaction(response.id.as_ref().unwrap())
             .with_history(result_steps) // Just the result steps, no tools needed
             .create()
@@ -262,7 +262,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let mut response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("What activities do you recommend for my current location based on the weather?")
         .add_functions(functions.clone())
         .with_store_enabled()
@@ -305,7 +305,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         // But for function result turns, we don't need to
         response = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_previous_interaction(response.id.as_ref().unwrap())
             .with_history(result_steps)
             .create()

--- a/examples/pdf_input.rs
+++ b/examples/pdf_input.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::text("What text content does this PDF document contain?"),
             Content::document_data(SAMPLE_PDF_BASE64, "application/pdf"),
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Use stateful conversation to ask follow-up questions about the PDF
     let follow_up = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_previous_interaction(
             response
                 .id
@@ -111,7 +111,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut stream = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(stream_contents)
         .create_stream();
 

--- a/examples/real_world/README.md
+++ b/examples/real_world/README.md
@@ -17,6 +17,9 @@ This directory contains comprehensive example applications demonstrating practic
 | [Repo Auditor](./repo_auditor/) | Agentic security audit (Antigravity harness) | Subagents, policies + hooks, structured report (`--features antigravity`) |
 | [Session Resume](./session_resume/) | Agent that remembers across process restarts | Trajectory persistence, `conversation_id` round trip, `initial_history` (`--features antigravity`) |
 | [Workspace Explorer](./workspace_explorer/) | Watching an agent work, and gating it live | Workspaces, typed `ToolAction` stream, content-based `on_pre_tool` deny (`--features antigravity`) |
+| [MCP Toolbelt](./mcp_toolbelt/) | Giving an agent tools it didn't ship with | `add_mcp_server` (stdio), `mcp_<server>_<tool>` policy targets (`--features antigravity`) |
+| [Proactive Agent](./proactive_agent/) | Work that starts without a user turn | `add_trigger`, observing deliveries via a wire inspector (`--features antigravity`) |
+| [Cancellable Turn](./cancellable_turn/) | Stopping an agent mid-thought | `cancel_handle` from another task, partial output kept (`--features antigravity`) |
 
 ## Running Examples
 

--- a/examples/real_world/README.md
+++ b/examples/real_world/README.md
@@ -38,7 +38,7 @@ cargo run --example testing_assistant
 ```
 
 The Antigravity-based example additionally needs the `localharness` binary
-(`pip install google-antigravity==0.1.5`) and the crate feature:
+(`pip install google-antigravity==0.1.10`) and the crate feature:
 
 ```bash
 cargo run --example repo_auditor --features antigravity

--- a/examples/real_world/README.md
+++ b/examples/real_world/README.md
@@ -15,6 +15,8 @@ This directory contains comprehensive example applications demonstrating practic
 | [Web Scraper Agent](./web_scraper_agent/) | Web research assistant | Google Search grounding, streaming |
 | [Testing Assistant](./testing_assistant/) | Test generation from code | Coverage analysis, property tests |
 | [Repo Auditor](./repo_auditor/) | Agentic security audit (Antigravity harness) | Subagents, policies + hooks, structured report (`--features antigravity`) |
+| [Session Resume](./session_resume/) | Agent that remembers across process restarts | Trajectory persistence, `conversation_id` round trip, `initial_history` (`--features antigravity`) |
+| [Workspace Explorer](./workspace_explorer/) | Watching an agent work, and gating it live | Workspaces, typed `ToolAction` stream, content-based `on_pre_tool` deny (`--features antigravity`) |
 
 ## Running Examples
 

--- a/examples/real_world/cancellable_turn/README.md
+++ b/examples/real_world/cancellable_turn/README.md
@@ -1,0 +1,57 @@
+# Cancellable Turn Example
+
+Stopping an agent mid-thought with `cancel_handle()`, and keeping what it
+had already produced.
+
+## Overview
+
+`send_streaming` borrows the agent mutably for the whole turn, so the
+streaming loop itself cannot call `cancel()`. `cancel_handle()` returns a
+cheap, cloneable handle that escapes that borrow — hand copies to a UI
+button, a signal handler, and a watchdog at once.
+
+This example asks for a long essay and halts once 200 characters of
+*answer text* have streamed, then shows the partial answer that survived.
+
+## The part worth reading twice
+
+**A cancelled turn does not fail.** On harness 0.1.10 a halt takes the
+trajectory to the same terminal state a natural completion does, so the
+turn resolves normally, carrying whatever text it had produced. Nothing in
+the response distinguishes a halted turn from a finished one — record that
+on your side if it matters.
+
+(`AntigravityError::Turn` is still the outcome when the *harness* cancels
+a turn of its own accord. Different event.)
+
+## What it covers that the other examples don't
+
+| Surface | Why it matters |
+|---------|----------------|
+| `cancel_handle()` from another task | The only way to reach the agent mid-turn |
+| Cancelling on a condition | A timer races the model; real output does not |
+| Partial output | The text produced before the halt is in the response |
+| Contrast with `with_turn_timeout` | The timeout *errors* and discards the turn; cancel succeeds and keeps it |
+
+## Running
+
+```bash
+pip install google-antigravity==0.1.10   # or set ANTIGRAVITY_HARNESS_PATH
+export GEMINI_API_KEY=...
+cargo run --example cancellable_turn --features antigravity
+
+# Watch the halt and the terminal state it produces:
+LOUD_WIRE=haltRequest,trajectoryStateUpdate cargo run --example cancellable_turn --features antigravity
+```
+
+## Gotchas
+
+- **Thinking deltas are not answer text.** Halting mid-thought keeps
+  nothing. Trigger on `TextDelta` if partial output is the point — an
+  earlier draft of this example halted after 404 characters of *thinking*
+  and kept an empty string.
+- **Take the handle before starting the turn.**
+- **Cancelling before any output is a no-op** — there is no turn to halt
+  yet and the request is dropped.
+- The harness's `context canceled` stderr line is the expected trace of a
+  successful halt, not an error to alert on.

--- a/examples/real_world/cancellable_turn/main.rs
+++ b/examples/real_world/cancellable_turn/main.rs
@@ -1,0 +1,231 @@
+//! # Cancellable Turn — stopping an agent mid-thought
+//!
+//! A long turn you can't interrupt is a hung UI. `cancel_handle()` gives
+//! you a cheap, cloneable handle that can halt an in-flight turn from
+//! anywhere — which matters because `send_streaming` borrows the agent
+//! mutably for the duration, so the streaming loop itself cannot call
+//! `cancel()`.
+//!
+//! **The part worth reading twice**: a cancelled turn does *not* fail. On
+//! harness 0.1.10 a halt takes the trajectory to the same terminal state a
+//! natural completion does, so the turn resolves normally, carrying
+//! whatever text it had produced. Treat `cancel()` as "stop early and keep
+//! what you have" — and record the cancellation yourself, because nothing
+//! in the response distinguishes a halted turn from a finished one.
+//!
+//! (`AntigravityError::Turn` is still the outcome when the *harness*
+//! cancels a turn of its own accord. That is a different event.)
+//!
+//! What this example demonstrates that the others don't:
+//!
+//! - **`cancel_handle()` used from another task**, escaping the `&mut`
+//!   borrow the stream holds.
+//! - **Cancelling on a condition** — here, once enough text has arrived —
+//!   rather than on a timer that races the model.
+//! - **Partial output is real output**: the text produced before the halt
+//!   is in the response.
+//! - **The contrast with `with_turn_timeout`**, which *does* produce an
+//!   error and discards the turn.
+//!
+//! ## Requirements
+//!
+//! ```bash
+//! pip install google-antigravity==0.1.10   # or set ANTIGRAVITY_HARNESS_PATH
+//! export GEMINI_API_KEY=...
+//! cargo run --example cancellable_turn --features antigravity
+//! LOUD_WIRE=haltRequest,trajectoryStateUpdate cargo run --example cancellable_turn --features antigravity
+//! ```
+//!
+//! ## Expected output
+//!
+//! ```text
+//! === Cancellable Turn ===
+//!
+//! Asking for a long essay, then halting once 200 characters arrive.
+//! [stream] 200 chars produced — sending halt
+//! ✓ Turn ended 0.4s after the halt (budget was 180s)
+//!
+//! Partial answer (312 chars kept):
+//!   The history of the bicycle begins in the early nineteenth century...
+//!
+//! ✓ The turn resolved normally — cancellation is not an error.
+//! ```
+
+use futures_util::StreamExt;
+use genai_rs::antigravity::{AgentEvent, AntigravityAgent, Capabilities};
+use std::time::{Duration, Instant};
+
+/// Halt once this much *answer text* has streamed. Keying off real output
+/// rather than a timer means the turn is provably mid-generation when the
+/// halt lands — a fixed delay races the model and can arrive after it
+/// finished.
+///
+/// Deliberately counts `TextDelta` only, not `ThinkingDelta`: thinking is
+/// not answer text, so halting during it keeps nothing. Getting this wrong
+/// is how you end up with a "successful" cancel that returns an empty
+/// string (observed while writing this example — 404 chars of thinking,
+/// zero chars kept).
+const HALT_AFTER_CHARS: usize = 200;
+
+/// Generous: if the halt is ignored, we want to see *that*, not a timeout
+/// that looks like a clean stop.
+const TURN_BUDGET: Duration = Duration::from_secs(180);
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = match std::env::var("GEMINI_API_KEY") {
+        Ok(key) if !key.trim().is_empty() => key,
+        _ => {
+            // Empty counts as absent: a fork push gets the secret as ""
+            // rather than unset, and spawning with it fails mid-turn
+            // instead of skipping.
+            println!("Skipping: GEMINI_API_KEY not set");
+            return Ok(());
+        }
+    };
+
+    println!("=== Cancellable Turn ===\n");
+
+    let mut agent = AntigravityAgent::builder()
+        // Deliberately far above what this example needs: the timeout is
+        // the *other* mechanism, and letting it fire here would mask
+        // whether cancellation worked.
+        .with_turn_timeout(TURN_BUDGET)
+        .with_api_key(api_key)
+        .with_model("gemini-3.6-flash")
+        .with_capabilities(Capabilities::none())
+        .spawn()
+        .await?;
+
+    // Taken BEFORE the stream borrows the agent. This is the whole point
+    // of the handle: `send_streaming` holds `&mut agent` for the turn, so
+    // there is no way to call `agent.cancel()` while consuming it.
+    let handle = agent.cancel_handle();
+
+    // The streaming loop signals; a separate task does the halting. A
+    // oneshot rather than a flag so the canceller cannot fire twice, and
+    // so a stream that ends early drops the sender and wakes it anyway.
+    let (halt_tx, halt_rx) = tokio::sync::oneshot::channel::<()>();
+    let canceller = tokio::spawn(async move {
+        if halt_rx.await.is_err() {
+            // Stream ended before the threshold; nothing to halt.
+            return None;
+        }
+        Some(handle.cancel().await)
+    });
+
+    println!("Asking for a long essay, then halting once {HALT_AFTER_CHARS} characters arrive.");
+
+    let started = Instant::now();
+    let (answer, produced, thought, halted_at) = {
+        let mut stream = agent
+            .send_streaming(
+                "Write an extremely detailed 3000-word essay on the history of \
+                 the bicycle. Include many sections and go slowly.",
+            )
+            .await?;
+
+        let mut halt_tx = Some(halt_tx);
+        let mut produced = 0usize;
+        let mut thought = 0usize;
+        let mut halted_at = None;
+        let mut answer = String::new();
+
+        while let Some(event) = stream.next().await {
+            match event? {
+                AgentEvent::TextDelta(chunk) => {
+                    produced += chunk.chars().count();
+                    if produced >= HALT_AFTER_CHARS
+                        && let Some(tx) = halt_tx.take()
+                    {
+                        println!("[stream] {produced} chars of answer text — sending halt");
+                        let _ = tx.send(());
+                        halted_at = Some(Instant::now());
+                    }
+                }
+                // Counted separately and never used as the halt trigger:
+                // see HALT_AFTER_CHARS.
+                AgentEvent::ThinkingDelta(chunk) => thought += chunk.chars().count(),
+                // The turn RESOLVES rather than erroring — this arm is the
+                // one that runs after a cancel, not an error arm.
+                AgentEvent::Finished(response) => {
+                    answer = response.text().trim().to_string();
+                    break;
+                }
+                _ => {}
+            }
+        }
+        (answer, produced, thought, halted_at)
+    };
+    let elapsed = started.elapsed();
+
+    match canceller.await.expect("canceller task") {
+        Some(Ok(())) => {}
+        Some(Err(err)) => return Err(err.into()),
+        None => {
+            agent.shutdown().await?;
+            return Err(format!(
+                "the turn streamed only {produced} chars of answer text \
+                 ({thought} thinking), below the {HALT_AFTER_CHARS} needed to \
+                 trigger a halt — nothing was cancelled, so this run shows \
+                 nothing"
+            )
+            .into());
+        }
+    }
+
+    if let Some(halted_at) = halted_at {
+        println!(
+            "✓ Turn ended {:.1}s after the halt (budget was {}s)",
+            halted_at.elapsed().as_secs_f64(),
+            TURN_BUDGET.as_secs()
+        );
+    }
+
+    // Partial output is the deliverable, not a consolation prize.
+    println!(
+        "\nPartial answer ({} chars kept, after {thought} chars of thinking):",
+        answer.chars().count()
+    );
+    let preview: String = answer.chars().take(160).collect();
+    println!("  {preview}...");
+
+    if elapsed >= TURN_BUDGET {
+        println!("\n⚠ The turn ran to its budget — the halt did not stop it.");
+    } else {
+        println!("\n✓ The turn resolved normally — cancellation is not an error.");
+    }
+
+    agent.shutdown().await?;
+
+    println!("\n=== Example Complete ===\n");
+
+    println!("--- What You'll See with LOUD_WIRE=1 ---");
+    println!("  WS Send: {{\"userInput\": \"Write an extremely detailed...\"}}");
+    println!("  WS Receive: {{\"stepUpdate\": ...}} - deltas as the essay streams");
+    println!("  WS Send: {{\"haltRequest\": true}} - the cancel handle firing");
+    println!("  STDERR: \"received model response error: context canceled\"");
+    println!("    - the harness aborting its upstream request; expected, not a bug");
+    println!("  WS Receive: {{\"trajectoryStateUpdate\": {{\"state\": \"STATE_FULLY_IDLE\"}}}}");
+    println!("    - the SAME terminal state a natural completion sends, which is");
+    println!("      why the turn resolves instead of failing");
+    println!("  Try LOUD_WIRE=haltRequest,trajectoryStateUpdate to see just this\n");
+
+    println!("--- Production Considerations ---");
+    println!("• A cancelled turn RESOLVES, carrying partial text. Nothing in the");
+    println!("  response says it was halted — record that on your side if it matters");
+    println!("• Take the handle before starting the turn: send_streaming holds");
+    println!("  &mut agent, so you cannot reach the agent while consuming it");
+    println!("• cancel() vs with_turn_timeout: cancel keeps partial output and");
+    println!("  succeeds; the timeout discards the turn and returns Timeout");
+    println!("• The handle is cheap to clone — hand copies to a UI button, a");
+    println!("  shutdown signal handler, and a watchdog all at once");
+    println!("• Thinking deltas are not answer text. Halting mid-thought keeps");
+    println!("  nothing — trigger on TextDelta if partial output is the point");
+    println!("• Cancelling before any output is a no-op worth guarding: there is");
+    println!("  no turn to halt yet, and the halt is simply dropped");
+    println!("• The harness's \"context canceled\" stderr is the expected trace of");
+    println!("  a successful halt, not an error to alert on");
+
+    Ok(())
+}

--- a/examples/real_world/code_assistant/main.rs
+++ b/examples/real_world/code_assistant/main.rs
@@ -149,7 +149,7 @@ impl CodeAssistant {
         let response = self
             .client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are an expert code analyst. Analyze code thoroughly and provide \
                  actionable insights. Focus on code quality, maintainability, and \
@@ -205,7 +205,7 @@ impl CodeAssistant {
         let response = self
             .client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are a technical writer specializing in code documentation. \
                  Write clear, concise documentation that explains the purpose, \
@@ -236,7 +236,7 @@ impl CodeAssistant {
         let response = self
             .client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are a patient programming tutor. Explain code clearly and \
                  thoroughly, using analogies where helpful. Assume the reader \
@@ -273,7 +273,7 @@ impl CodeAssistant {
         let response = self
             .client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are a senior software engineer conducting a code review. \
                  Focus on maintainability, readability, and best practices. \

--- a/examples/real_world/data_analysis/main.rs
+++ b/examples/real_world/data_analysis/main.rs
@@ -379,7 +379,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         let result = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are a data analyst assistant. Use the available tools to analyze \
                  the sales data and answer questions. Always provide clear, concise \

--- a/examples/real_world/mcp_toolbelt/README.md
+++ b/examples/real_world/mcp_toolbelt/README.md
@@ -1,0 +1,62 @@
+# MCP Toolbelt Example
+
+Giving an agent tools it didn't ship with, over the
+[Model Context Protocol](https://modelcontextprotocol.io).
+
+## Overview
+
+Unlike `#[tool]` functions — which *your* process executes — MCP tools run
+in the server's process and the harness brokers the call. That makes MCP
+the way to reach a tool you didn't write: a git server, a database bridge,
+an internal API wrapper.
+
+This example spawns `widgets_server.py` (next to this file), a
+dependency-free stdio MCP server whose answers are values no model could
+guess. A correct response is therefore evidence of a real round trip
+rather than of the model improvising.
+
+## What it covers that the other examples don't
+
+| Surface | Why it matters |
+|---------|----------------|
+| `add_mcp_server` (stdio) | The whole external-tool path; nothing else exercises it |
+| `McpServer::with_name` | The name is the `<server>` half of the policy target, not cosmetic |
+| `mcp_<server>_<tool>` naming | What a policy or `on_pre_tool` hook must match on — the usual reason an MCP policy silently never applies |
+| `Capabilities::none()` + MCP | MCP is configured independently of the builtin set, so an agent can have *only* external tools |
+
+## Running
+
+```bash
+pip install google-antigravity==0.1.10   # or set ANTIGRAVITY_HARNESS_PATH
+export GEMINI_API_KEY=...
+cargo run --example mcp_toolbelt --features antigravity
+
+# Just the MCP traffic, one line per message:
+LOUD_WIRE=mcpTool,summary cargo run --example mcp_toolbelt --features antigravity
+```
+
+## Swapping in a real server
+
+The fixture stands in for something like:
+
+```rust,ignore
+McpServer::stdio("uvx", ["mcp-server-git"]).with_name("git")
+// or
+McpServer::http("http://localhost:8931/mcp").with_name("api")
+```
+
+Both forms take `with_enabled_tools` / `with_disabled_tools` to narrow the
+surface, and `with_timeout_seconds` to bound a slow server.
+
+## Gotchas
+
+- **The server name drives the policy target.** Omit `with_name` and it
+  defaults to the command's basename (`python3` here), so a policy naming
+  `mcp_widgets_*` would never match.
+- **MCP tools run in the server's process** — the server's filesystem,
+  network and credentials, not your agent's. Capability gating does not
+  contain them.
+- **Tool errors come back as results, not transport failures.** A server
+  returning `isError` surfaces to the model, which can adapt.
+- **Stdio servers are spawned per agent**, so a slow-starting server
+  delays `spawn()`.

--- a/examples/real_world/mcp_toolbelt/main.rs
+++ b/examples/real_world/mcp_toolbelt/main.rs
@@ -1,0 +1,180 @@
+//! # MCP Toolbelt — giving an agent tools it didn't ship with
+//!
+//! The harness can connect to [Model Context
+//! Protocol](https://modelcontextprotocol.io) servers and expose their
+//! tools to the model. Unlike `#[tool]` functions — which *your* process
+//! executes — MCP tools run in the server's process, and the harness
+//! brokers the call. That makes MCP the way to reach a tool you didn't
+//! write: a git server, a database bridge, an internal API wrapper.
+//!
+//! This example spawns a small stdio server (`widgets_server.py`, next to
+//! this file) whose answers are values no model could guess, so a correct
+//! response is evidence of a real round trip rather than of the model
+//! improvising.
+//!
+//! What this example demonstrates that the others don't:
+//!
+//! - **`add_mcp_server`** with a stdio transport, plus `with_name` — the
+//!   name is not cosmetic, it is the `<server>` half of the policy target.
+//! - **`mcp_<server>_<tool>` naming**, which is what a policy or an
+//!   `on_pre_tool` hook has to match on. Getting this wrong is the usual
+//!   reason an MCP policy silently fails to apply.
+//! - **Policy gating an MCP tool** exactly like a builtin — MCP tools run
+//!   harness-side, so they go through the same engine.
+//! - **`Capabilities::none()` alongside MCP** — MCP servers are configured
+//!   independently of the builtin capability set, so an agent can have
+//!   *only* external tools.
+//!
+//! ## Requirements
+//!
+//! ```bash
+//! pip install google-antigravity==0.1.10   # or set ANTIGRAVITY_HARNESS_PATH
+//! export GEMINI_API_KEY=...
+//! cargo run --example mcp_toolbelt --features antigravity
+//! LOUD_WIRE=mcpTool,summary cargo run --example mcp_toolbelt --features antigravity
+//! ```
+//!
+//! ## Expected output
+//!
+//! ```text
+//! === MCP Toolbelt ===
+//!
+//! Serving tools from: .../widgets_server.py
+//!
+//! [mcp] mcp_widgets_list_widgets     (allowed)
+//! [mcp] mcp_widgets_lookup_widget    (allowed)
+//! Agent: The flange has code wibble-3317-quux, with 42 in stock.
+//!
+//! ✓ The answer carries a value only the MCP server knows.
+//! ```
+
+use futures_util::StreamExt;
+use genai_rs::antigravity::{AgentEvent, AntigravityAgent, Capabilities, McpServer, policy};
+
+/// A code only the MCP server knows (see `widgets_server.py`). Its
+/// presence in the answer is the proof the round trip happened — the model
+/// cannot derive it.
+const FLANGE_CODE: &str = "wibble-3317-quux";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = match std::env::var("GEMINI_API_KEY") {
+        Ok(key) if !key.trim().is_empty() => key,
+        _ => {
+            // Empty counts as absent: a fork push gets the secret as ""
+            // rather than unset, and spawning with it fails mid-turn
+            // instead of skipping.
+            println!("Skipping: GEMINI_API_KEY not set");
+            return Ok(());
+        }
+    };
+
+    // Ship the server alongside the example so `cargo run` works from any
+    // directory. A real deployment would name a command on PATH instead,
+    // e.g. McpServer::stdio("uvx", ["mcp-server-git"]).
+    let server_script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples/real_world/mcp_toolbelt/widgets_server.py");
+    if !server_script.is_file() {
+        return Err(format!("missing MCP server script: {}", server_script.display()).into());
+    }
+
+    println!("=== MCP Toolbelt ===\n");
+    println!("Serving tools from: {}\n", server_script.display());
+
+    let mut agent = AntigravityAgent::builder()
+        // The builder default is *unlimited*; always set a budget.
+        .with_turn_timeout(std::time::Duration::from_secs(120))
+        .with_api_key(api_key)
+        .with_model("gemini-3.6-flash")
+        .with_system_instructions(
+            "Widget codes and stock levels come only from the `widgets` MCP \
+             tools. Never guess them. List the widgets first if you need to \
+             know what exists, then look up what the user asked about.",
+        )
+        .add_mcp_server(
+            McpServer::stdio("python3", [server_script.to_string_lossy().to_string()])
+                // The name is the `<server>` half of `mcp_<server>_<tool>`,
+                // so policies have to agree with it. Without this it would
+                // default to the command basename ("python3"), which is
+                // both wrong and a footgun for the policy target.
+                .with_name("widgets"),
+        )
+        // No builtins at all: this agent's entire toolbelt is external.
+        // MCP servers are configured independently of the capability set,
+        // so `none()` does not disable them.
+        .with_capabilities(Capabilities::none())
+        // MCP tools run harness-side, so the policy engine sees them just
+        // like `view_file` or `run_command`. Swap this for a targeted
+        // allow to gate individual tools:
+        //     policy::allow("mcp_widgets_lookup_widget")
+        .add_policy(policy::allow_all())
+        .spawn()
+        .await?;
+
+    let mut calls = Vec::new();
+    let mut answer = String::new();
+    {
+        let mut stream = agent
+            .send_streaming("What is the code for the flange, and how many are in stock?")
+            .await?;
+        while let Some(event) = stream.next().await {
+            match event? {
+                AgentEvent::ToolAction {
+                    action, decision, ..
+                } => {
+                    let name = action.tool_name();
+                    println!("[mcp] {name:<28} ({decision:?})");
+                    calls.push(name);
+                }
+                AgentEvent::Finished(response) => {
+                    answer = response.text().trim().to_string();
+                    break;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    println!("Agent: {answer}\n");
+
+    // Two independent checks, because they fail for different reasons: no
+    // tool action at all means the server never connected, whereas an
+    // action without the code means the call happened but its result did
+    // not reach the model.
+    if !calls.iter().any(|c| c.starts_with("mcp_widgets_")) {
+        agent.shutdown().await?;
+        return Err("no MCP tool ran — the harness did not reach the server".into());
+    }
+    if answer.contains(FLANGE_CODE) {
+        println!("✓ The answer carries a value only the MCP server knows.");
+    } else {
+        println!("⚠ The answer did not include the server's code ({FLANGE_CODE}).");
+    }
+
+    agent.shutdown().await?;
+
+    println!("\n=== Example Complete ===\n");
+
+    println!("--- What You'll See with LOUD_WIRE=1 ---");
+    println!("  WS Send: {{\"config\": {{\"mcpServers\": [{{\"name\": \"widgets\", ...}}]}}}}");
+    println!("    - the server config, sent once at conversation init");
+    println!("  WS Receive: {{\"stepUpdate\": {{\"mcpTool\": {{\"serverName\": \"widgets\",");
+    println!("    \"toolName\": \"lookup_widget\", \"argumentsJson\": \"...\"}}}}}}");
+    println!("    - one per call; the harness brokers it, your process does not");
+    println!("  Try LOUD_WIRE=mcpTool,summary to see only these, one line each\n");
+
+    println!("--- Production Considerations ---");
+    println!("• The server name is the `<server>` in `mcp_<server>_<tool>` —");
+    println!("  a policy naming the wrong one silently never matches");
+    println!("• MCP tools run in the SERVER's process, not yours: they get the");
+    println!("  server's filesystem, network and credentials, not your agent's");
+    println!("• Capabilities and MCP are independent — Capabilities::none() still");
+    println!("  leaves MCP tools available, which is how you build an agent whose");
+    println!("  only tools are external");
+    println!("• Stdio servers are spawned per agent; a slow-starting server delays");
+    println!("  spawn(), so prefer with_timeout_seconds over an unbounded wait");
+    println!("• Tool errors (isError) come back as tool results, not transport");
+    println!("  failures — the model sees them and can adapt");
+
+    Ok(())
+}

--- a/examples/real_world/mcp_toolbelt/main.rs
+++ b/examples/real_world/mcp_toolbelt/main.rs
@@ -43,7 +43,7 @@
 //!
 //! [mcp] mcp_widgets_list_widgets     (allowed)
 //! [mcp] mcp_widgets_lookup_widget    (allowed)
-//! Agent: The flange has code wibble-3317-quux, with 42 in stock.
+//! Agent: The flange has code plonkish-4402-vex, with 42 in stock.
 //!
 //! ✓ The answer carries a value only the MCP server knows.
 //! ```
@@ -54,7 +54,7 @@ use genai_rs::antigravity::{AgentEvent, AntigravityAgent, Capabilities, McpServe
 /// A code only the MCP server knows (see `widgets_server.py`). Its
 /// presence in the answer is the proof the round trip happened — the model
 /// cannot derive it.
-const FLANGE_CODE: &str = "wibble-3317-quux";
+const FLANGE_CODE: &str = "plonkish-4402-vex";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -171,8 +171,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("• Capabilities and MCP are independent — Capabilities::none() still");
     println!("  leaves MCP tools available, which is how you build an agent whose");
     println!("  only tools are external");
-    println!("• Stdio servers are spawned per agent; a slow-starting server delays");
-    println!("  spawn(), so prefer with_timeout_seconds over an unbounded wait");
+    println!("• Stdio servers are spawned per agent, so a slow-starting server");
+    println!("  delays spawn() itself. with_timeout_seconds bounds each tool");
+    println!("  CALL, not startup — budget the spawn on your side if it matters");
     println!("• Tool errors (isError) come back as tool results, not transport");
     println!("  failures — the model sees them and can adapt");
 

--- a/examples/real_world/mcp_toolbelt/widgets_server.py
+++ b/examples/real_world/mcp_toolbelt/widgets_server.py
@@ -17,8 +17,12 @@ PROTOCOL_VERSION = "2024-11-05"
 
 # The inventory. Deliberately arbitrary — nothing in a model's training
 # could supply these, so an answer containing them came from this process.
+#
+# Kept distinct from the token in tests/fixtures/mcp_echo_server.py: that
+# fixture's whole argument is that its value exists nowhere else, and
+# reusing it here would quietly make that false.
 INVENTORY = {
-    "flange": {"code": "wibble-3317-quux", "in_stock": 42},
+    "flange": {"code": "plonkish-4402-vex", "in_stock": 42},
     "grommet": {"code": "zorble-8891-frob", "in_stock": 0},
     "sprocket": {"code": "quaffle-2205-nurb", "in_stock": 7},
 }

--- a/examples/real_world/mcp_toolbelt/widgets_server.py
+++ b/examples/real_world/mcp_toolbelt/widgets_server.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""A minimal stdio MCP server, spawned by the `mcp_toolbelt` example.
+
+Real deployments point `McpServer::stdio` at something like `uvx
+mcp-server-git`. This stands in for that: a dependency-free server whose
+answers are values the model provably cannot know, so a correct response
+is evidence of a real MCP round trip rather than of the model guessing.
+
+Speaks JSON-RPC 2.0 over stdin/stdout, one message per line:
+`initialize` -> `tools/list` -> `tools/call`.
+"""
+
+import json
+import sys
+
+PROTOCOL_VERSION = "2024-11-05"
+
+# The inventory. Deliberately arbitrary — nothing in a model's training
+# could supply these, so an answer containing them came from this process.
+INVENTORY = {
+    "flange": {"code": "wibble-3317-quux", "in_stock": 42},
+    "grommet": {"code": "zorble-8891-frob", "in_stock": 0},
+    "sprocket": {"code": "quaffle-2205-nurb", "in_stock": 7},
+}
+
+TOOLS = [
+    {
+        "name": "lookup_widget",
+        "description": (
+            "Look up a widget's internal code and stock level. This is the "
+            "only source for widget codes; they cannot be guessed."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "widget": {
+                    "type": "string",
+                    "description": "Widget name, e.g. 'flange'.",
+                }
+            },
+            "required": ["widget"],
+        },
+    },
+    {
+        "name": "list_widgets",
+        "description": "List every widget name this server knows about.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+]
+
+
+def respond(msg_id, result):
+    return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+
+def error(msg_id, code, message):
+    return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}
+
+
+def text_result(text, is_error=False):
+    return {"content": [{"type": "text", "text": text}], "isError": is_error}
+
+
+def call_tool(params):
+    name = params.get("name")
+    args = params.get("arguments") or {}
+
+    if name == "list_widgets":
+        return text_result("Known widgets: " + ", ".join(sorted(INVENTORY)))
+
+    if name == "lookup_widget":
+        widget = args.get("widget", "")
+        entry = INVENTORY.get(widget.lower().strip())
+        if entry is None:
+            # A tool-level failure, not a protocol error: the model should
+            # see this and adapt rather than the call blowing up.
+            return text_result(f"No widget named {widget!r}.", is_error=True)
+        return text_result(
+            f"Widget {widget!r}: code {entry['code']}, {entry['in_stock']} in stock."
+        )
+
+    return None
+
+
+def handle(request):
+    """Returns a response dict, or None for notifications (no id)."""
+    method = request.get("method")
+    msg_id = request.get("id")
+
+    # Notifications carry no id and must not be answered.
+    if msg_id is None:
+        return None
+
+    if method == "initialize":
+        return respond(
+            msg_id,
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "widgets", "version": "0.0.1"},
+            },
+        )
+    if method == "tools/list":
+        return respond(msg_id, {"tools": TOOLS})
+    if method == "tools/call":
+        result = call_tool(request.get("params") or {})
+        if result is None:
+            return error(msg_id, -32602, f"unknown tool: {(request.get('params') or {}).get('name')!r}")
+        return respond(msg_id, result)
+    if method in ("ping", "shutdown"):
+        return respond(msg_id, {})
+
+    return error(msg_id, -32601, f"method not found: {method}")
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        try:
+            response = handle(request)
+        except Exception as exc:  # noqa: BLE001 - a fixture must not die silently
+            response = error(request.get("id"), -32603, f"internal error: {exc!r}")
+        if response is not None:
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/real_world/multi_turn_agent_auto/README.md
+++ b/examples/real_world/multi_turn_agent_auto/README.md
@@ -41,7 +41,7 @@ internally, so system_instruction is present on all internal iterations:
 ```rust
 // System instruction set on each turn for clarity
 let result = client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text(message)
     .with_previous_interaction(&prev_id)  // Chain to previous turn
     .with_system_instruction("You are a helpful assistant")

--- a/examples/real_world/multi_turn_agent_auto/main.rs
+++ b/examples/real_world/multi_turn_agent_auto/main.rs
@@ -262,7 +262,7 @@ impl SupportSession {
                 // Subsequent turns: chain to previous, include system instruction
                 self.client
                     .interaction()
-                    .with_model("gemini-3-flash-preview")
+                    .with_model("gemini-3.6-flash")
                     .with_text(message)
                     .add_functions(functions)
                     .with_store_enabled()
@@ -275,7 +275,7 @@ impl SupportSession {
                 // First turn: same setup, system instruction included
                 self.client
                     .interaction()
-                    .with_model("gemini-3-flash-preview")
+                    .with_model("gemini-3.6-flash")
                     .with_text(message)
                     .add_functions(functions)
                     .with_store_enabled()

--- a/examples/real_world/multi_turn_agent_manual/README.md
+++ b/examples/real_world/multi_turn_agent_manual/README.md
@@ -29,7 +29,7 @@ This example demonstrates the same customer support agent as `multi_turn_agent_a
 // Build initial request with functions
 let mut response = client
     .interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text(message)
     .add_functions(declarations)
     .with_store_enabled()
@@ -59,7 +59,7 @@ for _ in 0..MAX_ITERATIONS {
     // Send results back
     response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_previous_interaction(response.id.as_ref().unwrap())
         .set_content(results)
         .with_store_enabled()

--- a/examples/real_world/multi_turn_agent_manual/main.rs
+++ b/examples/real_world/multi_turn_agent_manual/main.rs
@@ -332,7 +332,7 @@ impl SupportSession {
                 // Subsequent turns: chain to previous, include system instruction
                 self.client
                     .interaction()
-                    .with_model("gemini-3-flash-preview")
+                    .with_model("gemini-3.6-flash")
                     .with_text(message)
                     .add_functions(self.functions.clone())
                     .with_store_enabled()
@@ -345,7 +345,7 @@ impl SupportSession {
                 // First turn: same setup, system instruction included
                 self.client
                     .interaction()
-                    .with_model("gemini-3-flash-preview")
+                    .with_model("gemini-3.6-flash")
                     .with_text(message)
                     .add_functions(self.functions.clone())
                     .with_store_enabled()
@@ -381,7 +381,7 @@ impl SupportSession {
             response = self
                 .client
                 .interaction()
-                .with_model("gemini-3-flash-preview")
+                .with_model("gemini-3.6-flash")
                 .with_previous_interaction(response.id.as_ref().ok_or("Missing interaction ID")?)
                 .with_history(results)
                 .with_store_enabled()

--- a/examples/real_world/multi_turn_agent_manual_stateless/main.rs
+++ b/examples/real_world/multi_turn_agent_manual_stateless/main.rs
@@ -286,7 +286,7 @@ impl StatelessSupportSession {
         let mut response = self
             .client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_history(self.conversation_history.clone())
             .add_functions(self.functions.clone())
             .with_system_instruction(&self.system_instruction)
@@ -330,7 +330,7 @@ impl StatelessSupportSession {
             response = self
                 .client
                 .interaction()
-                .with_model("gemini-3-flash-preview")
+                .with_model("gemini-3.6-flash")
                 .with_history(self.conversation_history.clone())
                 .add_functions(self.functions.clone())
                 .with_system_instruction(&self.system_instruction)

--- a/examples/real_world/proactive_agent/README.md
+++ b/examples/real_world/proactive_agent/README.md
@@ -1,0 +1,50 @@
+# Proactive Agent Example
+
+Work that starts without a user turn, via `add_trigger`.
+
+## Overview
+
+Every other example is request/response. Triggers invert that: a message
+is injected on a fixed interval with no user behind it — the shape you
+want for a watcher that polls a queue, re-checks a build, or summarizes
+what changed.
+
+This example registers a 2s trigger, waits for the first delivery, then
+issues a user turn that interrupts the trigger's turn.
+
+## What it covers that the other examples don't
+
+| Surface | Why it matters |
+|---------|----------------|
+| `add_trigger` / `TriggerConfig` | The only non-request/response entry point |
+| Wire inspector on `automatedTrigger` | The **only** way to observe a delivery today — there is no agent-stream event |
+| The discard boundary | A `chat` after a trigger answers *your* message, never the trigger's |
+
+## Running
+
+```bash
+pip install google-antigravity==0.1.10   # or set ANTIGRAVITY_HARNESS_PATH
+export GEMINI_API_KEY=...
+cargo run --example proactive_agent --features antigravity
+
+# Just the deliveries:
+LOUD_WIRE=automatedTrigger,summary cargo run --example proactive_agent --features antigravity
+```
+
+## Gotchas
+
+- **Open with a real turn before any trigger can fire.** On harness
+  0.1.10 a trigger delivered into a conversation with *no history* crashes
+  the harness process — its pre-invocation hook asks for "tokens since the
+  last checkpoint", finds no steps, and aborts the run
+  (`earliest step index is out of bounds: 0 vs 0`). The session dies with
+  it. This example opens with a turn for exactly that reason.
+- **A trigger's turn is not surfaced.** Its text never reaches your
+  stream; the next `chat`/`send_streaming` halts it and discards its
+  events. Use triggers for side effects, and read results with a normal
+  turn afterwards.
+- **Delivery is idle-only.** A firing due mid-turn is deferred, and missed
+  intervals collapse into one — there is no backlog.
+- **The first firing is after one interval**, not at spawn.
+- **Intervals must be non-zero**; `spawn()` validates this.
+- Trigger tasks stop on `shutdown()` and on drop, so no timers leak.

--- a/examples/real_world/proactive_agent/main.rs
+++ b/examples/real_world/proactive_agent/main.rs
@@ -1,0 +1,219 @@
+//! # Proactive Agent — work that starts without a user turn
+//!
+//! Every other example is request/response: you call `chat`, the agent
+//! answers. Triggers invert that. `add_trigger` injects a message on a
+//! fixed interval with no user turn behind it, which is the shape you want
+//! for a watcher — poll a queue, re-check a build, summarize what changed.
+//!
+//! The sharp edge, and the reason this example exists: **a trigger's turn
+//! runs unobserved.** The next `chat`/`send_streaming` halts it and
+//! discards its events, so a trigger can never surface as (or desync) your
+//! turn's response. Its effects on conversation history do persist — which
+//! is what makes triggers useful *and* what makes them easy to misread.
+//!
+//! What this example demonstrates that the others don't:
+//!
+//! - **`add_trigger` / `TriggerConfig`** with a real interval.
+//! - **Observing a trigger** via a wire inspector, which is the only way
+//!   to see one today — there is no event on the agent's own stream.
+//! - **The discard boundary**: a `chat` after a trigger returns an answer
+//!   to *your* message, never the trigger's.
+//! - **Idle-only delivery**: a firing due mid-turn is deferred, and missed
+//!   intervals collapse rather than queueing a backlog.
+//! - **Why the opening turn is mandatory**: on harness 0.1.10 a trigger
+//!   that fires into a conversation with no history crashes the harness
+//!   outright. See the comment on the opening `chat` below.
+//!
+//! ## Requirements
+//!
+//! ```bash
+//! pip install google-antigravity==0.1.10   # or set ANTIGRAVITY_HARNESS_PATH
+//! export GEMINI_API_KEY=...
+//! cargo run --example proactive_agent --features antigravity
+//! LOUD_WIRE=automatedTrigger,summary cargo run --example proactive_agent --features antigravity
+//! ```
+//!
+//! ## Expected output
+//!
+//! ```text
+//! === Proactive Agent ===
+//!
+//! Opening turn: "Ready."
+//!
+//! Trigger registered: every 2s, "Check the sensor log..."
+//! Waiting for the first firing (fires after one interval, not immediately)...
+//! ✓ Trigger delivered after 0.1s
+//!
+//! --- A user turn now interrupts the trigger's turn ---
+//! Agent: The sensor log is a stand-in; nothing was actually read.
+//! ✓ The answer addresses the user's message, not the trigger's.
+//!
+//! Triggers delivered during this run: 2
+//! ```
+
+use genai_rs::antigravity::{AntigravityAgent, Capabilities, TriggerConfig};
+use genai_rs::wire::{WireEvent, WireInspector};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// The trigger's message. Distinct from anything the user says, so the
+/// two turns can be told apart in the transcript.
+const TRIGGER_MESSAGE: &str = "Check the sensor log for anomalies and note anything unusual.";
+
+/// How often the trigger fires. Short so the example finishes quickly; a
+/// real watcher would use minutes, not seconds.
+const TRIGGER_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Records every `automatedTrigger` the crate sends to the harness.
+///
+/// A trigger's turn produces no event on the agent's own stream, so a wire
+/// inspector is the supported way to confirm one fired at all. This is
+/// also the shape you'd use to export trigger deliveries to metrics.
+#[derive(Debug, Default)]
+struct TriggerWatcher {
+    deliveries: Mutex<Vec<String>>,
+}
+
+impl WireInspector for TriggerWatcher {
+    fn on_event(&self, event: &WireEvent) {
+        if let WireEvent::WsSend { payload, .. } = event
+            && let Some(message) = payload.get("automatedTrigger").and_then(|v| v.as_str())
+        {
+            self.deliveries.lock().unwrap().push(message.to_string());
+        }
+    }
+}
+
+impl TriggerWatcher {
+    fn count(&self) -> usize {
+        self.deliveries.lock().unwrap().len()
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = match std::env::var("GEMINI_API_KEY") {
+        Ok(key) if !key.trim().is_empty() => key,
+        _ => {
+            // Empty counts as absent: a fork push gets the secret as ""
+            // rather than unset, and spawning with it fails mid-turn
+            // instead of skipping.
+            println!("Skipping: GEMINI_API_KEY not set");
+            return Ok(());
+        }
+    };
+
+    println!("=== Proactive Agent ===\n");
+
+    let watcher = Arc::new(TriggerWatcher::default());
+
+    let mut agent = AntigravityAgent::builder()
+        // The builder default is *unlimited*; always set a budget.
+        .with_turn_timeout(Duration::from_secs(120))
+        .with_api_key(api_key)
+        .with_model("gemini-3.6-flash")
+        .with_system_instructions(
+            "You are a terse monitoring assistant. There is no real sensor \
+             log — say so plainly rather than inventing readings.",
+        )
+        .with_capabilities(Capabilities::none())
+        .add_trigger(TriggerConfig::new(TRIGGER_MESSAGE, TRIGGER_INTERVAL))
+        .add_wire_inspector(Arc::clone(&watcher) as Arc<dyn WireInspector>)
+        .spawn()
+        .await?;
+
+    // An opening turn BEFORE any trigger can fire — this is required, not
+    // stylistic. Harness 0.1.10 crashes if a trigger is the first activity
+    // in a conversation: its pre-invocation hook asks for "tokens since
+    // the last checkpoint", finds no steps, and dies with
+    //
+    //     hook_utils.go:94] error getting tokens since last checkpoint:
+    //       earliest step index is out of bounds: 0 vs 0
+    //     Agent run failed: executor run failed
+    //
+    // which kills the harness process and takes the session with it (the
+    // next send fails with a closed socket or a broken pipe). One real
+    // turn first is enough to give the hook something to measure.
+    let opening = agent
+        .chat("You are now monitoring. Reply with just: ready.")
+        .await?;
+    println!("Opening turn: {:?}\n", opening.text().trim());
+
+    println!(
+        "Trigger registered: every {}s, {:?}",
+        TRIGGER_INTERVAL.as_secs(),
+        TRIGGER_MESSAGE
+    );
+    println!("Waiting for the first firing (fires after one interval, not immediately)...");
+
+    // Poll rather than sleeping a fixed amount: delivery is "after the
+    // interval, once idle", which is a lower bound and not a promise.
+    let started = Instant::now();
+    let deadline = started + Duration::from_secs(30);
+    while watcher.count() == 0 && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    if watcher.count() == 0 {
+        agent.shutdown().await?;
+        return Err("no trigger delivered within 30s — check the interval and \
+                    that the agent stayed idle"
+            .into());
+    }
+    println!(
+        "✓ Trigger delivered after {:.1}s",
+        started.elapsed().as_secs_f64()
+    );
+
+    // ---------------------------------------------------------------
+    // The discard boundary. The trigger's turn may still be running; this
+    // `chat` halts it and throws its events away before sending. The
+    // answer below is to *this* message — a trigger's output can never
+    // arrive here.
+    // ---------------------------------------------------------------
+    println!("\n--- A user turn now interrupts the trigger's turn ---");
+    let response = agent
+        .chat("Ignore the sensor log. In one sentence: what are you for?")
+        .await?;
+    let answer = response.text().trim().to_string();
+    println!("Agent: {answer}");
+
+    if answer.is_empty() {
+        agent.shutdown().await?;
+        return Err("the user turn returned no text — a trigger turn may have desynced it".into());
+    }
+    println!("✓ The answer addresses the user's message, not the trigger's.");
+
+    println!("\nTriggers delivered during this run: {}", watcher.count());
+
+    // shutdown() stops the trigger tasks; so does dropping the agent. No
+    // timer outlives the session either way.
+    agent.shutdown().await?;
+
+    println!("\n=== Example Complete ===\n");
+
+    println!("--- What You'll See with LOUD_WIRE=1 ---");
+    println!("  WS Send: {{\"automatedTrigger\": \"Check the sensor log...\"}}");
+    println!("    - one per firing, sent by the crate, not by a user turn");
+    println!("  WS Receive: {{\"stepUpdate\": ...}} - the trigger's turn, unobserved");
+    println!("  WS Send: {{\"haltRequest\": true}} then {{\"userInput\": ...}}");
+    println!("    - the next chat() halting the trigger's turn before sending");
+    println!("  Try LOUD_WIRE=automatedTrigger,summary to see only deliveries\n");
+
+    println!("--- Production Considerations ---");
+    println!("• Give the conversation one real turn before any trigger can");
+    println!("  fire. On harness 0.1.10 a trigger into an empty conversation");
+    println!("  crashes the harness process, not just the turn");
+    println!("• A trigger's turn is NOT surfaced: its text never reaches your");
+    println!("  stream. Use triggers for side effects (tool calls, history), and");
+    println!("  read the results with a normal turn afterwards");
+    println!("• Delivery is idle-only. A firing due mid-turn is deferred, and");
+    println!("  missed intervals collapse into one — there is no backlog");
+    println!("• The first firing is after one interval, not at spawn. Do the");
+    println!("  first pass yourself if you need work done immediately");
+    println!("• Intervals must be non-zero; spawn() validates this");
+    println!("• A wire inspector is the only way to observe deliveries today —");
+    println!("  worth wiring to metrics if a silent trigger would matter");
+    println!("• Trigger tasks stop on shutdown() and on drop, so no timer leaks");
+
+    Ok(())
+}

--- a/examples/real_world/rag_system/main.rs
+++ b/examples/real_world/rag_system/main.rs
@@ -268,7 +268,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         // Step 4: Send to model with system instruction for RAG behavior
         let response = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are a helpful assistant answering questions about company policies and \
                  technical documentation. Always cite your sources when referencing the \

--- a/examples/real_world/repo_auditor/README.md
+++ b/examples/real_world/repo_auditor/README.md
@@ -41,7 +41,7 @@ denied by Rust code.
 ## Running
 
 ```bash
-pip install google-antigravity==0.1.5   # ships the localharness binary
+pip install google-antigravity==0.1.10   # ships the localharness binary
 # ...or point at an existing binary:
 export ANTIGRAVITY_HARNESS_PATH=/path/to/localharness
 
@@ -132,5 +132,5 @@ Notes from real runs:
   can be verified mechanically
 - Bound turns with `with_turn_timeout`; use `with_save_dir` +
   `conversation_id()` to resume long audits
-- Pin the harness wheel (`google-antigravity==0.1.5`, see
+- Pin the harness wheel (`google-antigravity==0.1.10`, see
   `antigravity::SUPPORTED_HARNESS_VERSION`)

--- a/examples/real_world/repo_auditor/main.rs
+++ b/examples/real_world/repo_auditor/main.rs
@@ -20,7 +20,7 @@
 //! ## Running
 //!
 //! ```bash
-//! pip install google-antigravity==0.1.5   # or set ANTIGRAVITY_HARNESS_PATH
+//! pip install google-antigravity==0.1.10   # or set ANTIGRAVITY_HARNESS_PATH
 //! export GEMINI_API_KEY=your_api_key
 //! cargo run --example repo_auditor --features antigravity
 //! LOUD_WIRE=1 cargo run --example repo_auditor --features antigravity  # wire trace
@@ -314,7 +314,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!(
         "• Bound runaway turns with with_turn_timeout; add with_save_dir to resume long audits"
     );
-    println!("• Pin the harness wheel (google-antigravity==0.1.5, SUPPORTED_HARNESS_VERSION)");
+    println!("• Pin the harness wheel (google-antigravity==0.1.10, SUPPORTED_HARNESS_VERSION)");
 
     if mismatches > 0 {
         return Err(format!("{mismatches} finding(s) contradict the severity classifier").into());

--- a/examples/real_world/repo_auditor/main.rs
+++ b/examples/real_world/repo_auditor/main.rs
@@ -160,7 +160,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let mut agent = AntigravityAgent::builder()
         .with_api_key(api_key)
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_system_instructions(AUDITOR_INSTRUCTIONS)
         .add_workspace(&workspace)
         // Read-only built-ins plus subagent delegation. start_subagent is

--- a/examples/real_world/session_resume/README.md
+++ b/examples/real_world/session_resume/README.md
@@ -1,0 +1,61 @@
+# Session Resume Example
+
+An agent that remembers across process restarts, using the harness's
+trajectory persistence — the shape a CLI assistant actually needs.
+
+## Overview
+
+Runs two *separate* agent lifecycles against one persisted conversation:
+
+1. **Run 1** starts fresh with `with_save_dir`, plants a fact, captures
+   `conversation_id()`, writes it to disk, and `shutdown()`s.
+2. **Run 2** spawns a brand-new agent with the same save dir plus
+   `with_conversation_id`, inspects `initial_history()` to prove the
+   history came back, and answers a question that can only be answered
+   from run 1's turn.
+
+Nothing is carried between the two in memory — only what the harness wrote
+to disk.
+
+## What it covers that the other examples don't
+
+| Surface | Why it matters |
+|---------|----------------|
+| `with_save_dir` + `conversation_id()` | The two halves you must persist together |
+| `with_conversation_id` | Selecting *which* trajectory to restore |
+| `initial_history()` | The only programmatic evidence a resume resumed |
+| `shutdown()` vs drop | Only `shutdown()` makes the trajectory durable |
+
+## The failure mode this exists to make visible
+
+**Resuming an unknown id is not an error.** It comes back empty and the
+agent carries on with a fresh conversation — which looks identical to a
+working resume until someone notices the agent has amnesia. That is why
+run 2 checks `initial_history()` and fails loudly rather than assuming.
+
+The same check is asserted in
+`tests/antigravity_harness.rs::test_antigravity_session_resume_restores_history`.
+
+## Running
+
+```bash
+pip install google-antigravity==0.1.10   # ships the localharness binary
+export GEMINI_API_KEY=...
+
+cargo run --example session_resume --features antigravity
+LOUD_WIRE=1 cargo run --example session_resume --features antigravity
+```
+
+With `LOUD_WIRE=1` the resume is visible on the wire: run 1 sends an empty
+`cascadeId` and gets one back; run 2 sends that id and the
+`initializeConversationResponse` comes back carrying `history`.
+
+## Production notes
+
+- Persist **both** the save directory and the conversation id. Either alone
+  silently starts fresh.
+- Always `shutdown()`. Dropping the agent kills the harness without writing
+  the trajectory.
+- The save directory grows per conversation — prune on your own schedule.
+- Restored history counts toward the context window like any other history,
+  so long-lived conversations still compact.

--- a/examples/real_world/session_resume/main.rs
+++ b/examples/real_world/session_resume/main.rs
@@ -64,7 +64,16 @@ const PLANTED_FACT: &str = "the deploy key rotates on the first Monday of each q
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not set");
+    let api_key = match std::env::var("GEMINI_API_KEY") {
+        Ok(key) if !key.trim().is_empty() => key,
+        _ => {
+            // Empty counts as absent: a fork push gets the secret as ""
+            // rather than unset, and spawning with it fails mid-turn
+            // instead of skipping.
+            println!("Skipping: GEMINI_API_KEY not set");
+            return Ok(());
+        }
+    };
 
     // A real CLI would use a stable location (e.g. ~/.config/my-agent).
     // A temp dir keeps the example self-contained and re-runnable.

--- a/examples/real_world/session_resume/main.rs
+++ b/examples/real_world/session_resume/main.rs
@@ -136,6 +136,11 @@ async fn run_one(
     id_file: &Path,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let mut agent = AntigravityAgent::builder()
+        // The builder default is *unlimited*. Always set a budget: the
+        // failure mode without one is a turn that never ends (a harness
+        // that renames its terminal state does exactly this), which hangs
+        // rather than errors.
+        .with_turn_timeout(std::time::Duration::from_secs(120))
         .with_api_key(api_key.to_string())
         .with_model("gemini-3.6-flash")
         .with_system_instructions(
@@ -186,6 +191,7 @@ async fn run_two(
     println!("Resuming conversation: {conversation_id}");
 
     let mut agent = AntigravityAgent::builder()
+        .with_turn_timeout(std::time::Duration::from_secs(120))
         .with_api_key(api_key.to_string())
         .with_model("gemini-3.6-flash")
         .with_system_instructions(

--- a/examples/real_world/session_resume/main.rs
+++ b/examples/real_world/session_resume/main.rs
@@ -1,0 +1,232 @@
+//! # Session Resume — an agent that remembers across process restarts
+//!
+//! Two *separate* agent lifecycles against one persisted conversation,
+//! which is what a CLI assistant actually does: you run it, it exits, you
+//! run it again tomorrow and it still knows what you told it.
+//!
+//! The harness owns the persistence. Point it at a save directory with
+//! [`with_save_dir`], and on shutdown it writes the trajectory there under
+//! the conversation id. Hand that same directory *and* id back via
+//! [`with_conversation_id`] and the next `spawn()` restores the history —
+//! [`initial_history`] returns the restored steps, and the model answers
+//! from them without you replaying anything.
+//!
+//! What this example demonstrates that the others don't:
+//!
+//! - **`with_save_dir` + `conversation_id()` + `with_conversation_id`** —
+//!   the full round trip, including persisting the id the way a real CLI
+//!   would (a dotfile next to the save dir).
+//! - **`initial_history()`** — inspecting what was restored, which is the
+//!   only programmatic evidence that a resume actually resumed rather
+//!   than silently starting fresh.
+//! - **Recall across the boundary** — run 2 answers a question that can
+//!   only be answered from run 1's turn.
+//! - **The distinction that matters**: `shutdown()` persists,
+//!   dropping does not.
+//!
+//! ## Requirements
+//!
+//! ```bash
+//! pip install google-antigravity==0.1.10   # or set ANTIGRAVITY_HARNESS_PATH
+//! export GEMINI_API_KEY=...
+//! cargo run --example session_resume --features antigravity
+//! LOUD_WIRE=1 cargo run --example session_resume --features antigravity
+//! ```
+//!
+//! ## Expected output
+//!
+//! ```text
+//! === Session Resume ===
+//!
+//! --- Run 1: fresh session ---
+//! Started conversation: 01JD...
+//! Restored steps: 0 (fresh conversation)
+//! Agent: Noted — the deploy key rotates on the first Monday of each quarter.
+//! Persisted id to /tmp/.../conversation-id
+//! Shut down cleanly (trajectory saved).
+//!
+//! --- Run 2: resuming the same conversation ---
+//! Resuming conversation: 01JD...
+//! Restored steps: 4
+//!   [1] user     -> "Remember this: the deploy key rotates ..."
+//!   [2] model    -> "Noted — the deploy key rotates ..."
+//! Agent: The deploy key rotates on the first Monday of each quarter.
+//! ✓ The agent recalled the fact from run 1.
+//! ```
+
+use genai_rs::antigravity::{AntigravityAgent, AntigravityError, Capabilities};
+use std::path::Path;
+
+/// The fact planted in run 1 and recalled in run 2. Deliberately arbitrary
+/// — nothing in the model's training could supply it, so a correct answer
+/// in run 2 can *only* have come from restored history.
+const PLANTED_FACT: &str = "the deploy key rotates on the first Monday of each quarter";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not set");
+
+    // A real CLI would use a stable location (e.g. ~/.config/my-agent).
+    // A temp dir keeps the example self-contained and re-runnable.
+    let save_dir = tempfile::Builder::new()
+        .prefix("session-resume-")
+        .tempdir()?;
+    let save_path = save_dir.path().to_string_lossy().to_string();
+    let id_file = save_dir.path().join("conversation-id");
+
+    println!("=== Session Resume ===\n");
+    println!("Save directory: {save_path}\n");
+
+    // ---------------------------------------------------------------
+    // Run 1 — a fresh conversation. Stands in for the first invocation.
+    // ---------------------------------------------------------------
+    println!("--- Run 1: fresh session ---");
+    let conversation_id = run_one(&api_key, &save_path, &id_file).await?;
+
+    // ---------------------------------------------------------------
+    // Run 2 — same save dir, same id. Stands in for a later invocation
+    // in a brand-new process: nothing is carried over in memory, only
+    // what the harness wrote to disk.
+    // ---------------------------------------------------------------
+    println!("\n--- Run 2: resuming the same conversation ---");
+    run_two(&api_key, &save_path, &conversation_id).await?;
+
+    println!("\n=== Example Complete ===\n");
+
+    println!("--- What You'll See with LOUD_WIRE=1 ---");
+    println!("  HARNESS /path/to/localharness (pid N) - spawned once per run");
+    println!("  WS Send: {{\"config\": {{... \"cascadeId\": \"\"}}}} - run 1, no id to resume");
+    println!(
+        "  WS Receive: {{\"initializeConversationResponse\": {{\"cascadeId\": \"01JD...\"}}}}"
+    );
+    println!("    - run 1: history absent/empty (fresh conversation)");
+    println!(
+        "  WS Send: {{\"config\": {{... \"cascadeId\": \"01JD...\"}}}} - run 2 asks to resume"
+    );
+    println!("  WS Receive: {{\"initializeConversationResponse\": {{\"history\": [...]}}}}");
+    println!("    - run 2: the restored steps, which initial_history() exposes\n");
+
+    println!("--- Production Considerations ---");
+    println!("• Persist BOTH halves: the save dir and the conversation id. Either");
+    println!("  one alone silently starts a fresh conversation rather than failing");
+    println!("• Always shutdown() — dropping the agent kills the harness without");
+    println!("  writing the trajectory, so the next run has nothing to resume");
+    println!("• Check initial_history() rather than assuming: a resume with an");
+    println!("  unknown id is not an error, it just comes back empty");
+    println!("• The save dir grows per conversation; prune it on your own schedule");
+    println!("• Restored history counts toward the context window like any other");
+    println!("  history — long-lived conversations still compact");
+
+    Ok(())
+}
+
+/// First invocation: start fresh, plant a fact, persist the id.
+async fn run_one(
+    api_key: &str,
+    save_path: &str,
+    id_file: &Path,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let mut agent = AntigravityAgent::builder()
+        .with_api_key(api_key.to_string())
+        .with_model("gemini-3.6-flash")
+        .with_system_instructions(
+            "You are a terse note-keeping assistant. Acknowledge facts the user \
+             gives you, and recall them verbatim when asked.",
+        )
+        // No builtin tools needed — this example is about persistence, and
+        // the read-only set is the safe default anyway.
+        .with_capabilities(Capabilities::none())
+        .with_save_dir(save_path.to_string())
+        .spawn()
+        .await?;
+
+    let conversation_id = agent
+        .conversation_id()
+        .ok_or("harness did not assign a conversation id")?
+        .to_string();
+    println!("Started conversation: {conversation_id}");
+    println!(
+        "Restored steps: {} (fresh conversation)",
+        agent.initial_history().len()
+    );
+
+    let response = agent
+        .chat(&format!("Remember this: {PLANTED_FACT}."))
+        .await?;
+    println!("Agent: {}", response.text().trim());
+
+    // A real CLI persists the id next to (or alongside) the save dir —
+    // without it, run 2 has a trajectory on disk it cannot address.
+    std::fs::write(id_file, &conversation_id)?;
+    println!("Persisted id to {}", id_file.display());
+
+    // shutdown() is what makes the trajectory durable. Dropping here
+    // would leave run 2 with nothing to restore.
+    agent.shutdown().await?;
+    println!("Shut down cleanly (trajectory saved).");
+
+    Ok(conversation_id)
+}
+
+/// Second invocation: resume, prove the history came back, prove recall.
+async fn run_two(
+    api_key: &str,
+    save_path: &str,
+    conversation_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("Resuming conversation: {conversation_id}");
+
+    let mut agent = AntigravityAgent::builder()
+        .with_api_key(api_key.to_string())
+        .with_model("gemini-3.6-flash")
+        .with_system_instructions(
+            "You are a terse note-keeping assistant. Acknowledge facts the user \
+             gives you, and recall them verbatim when asked.",
+        )
+        .with_capabilities(Capabilities::none())
+        // Both halves are required: the directory holds the trajectory,
+        // the id selects which one.
+        .with_save_dir(save_path.to_string())
+        .with_conversation_id(conversation_id.to_string())
+        .spawn()
+        .await?;
+
+    let history = agent.initial_history();
+    println!("Restored steps: {}", history.len());
+    for (i, step) in history.iter().take(4).enumerate() {
+        // StepSource is a wire enum (no Display); Debug is fine for a
+        // human-readable audit line.
+        let source = step
+            .source
+            .as_ref()
+            .map_or_else(|| "?".to_string(), |s| format!("{s:?}"));
+        let text = step.text.as_deref().unwrap_or("").replace('\n', " ");
+        let preview: String = text.chars().take(60).collect();
+        println!("  [{}] {source:<8} -> {preview:?}", i + 1);
+    }
+
+    // An empty history here is the failure this example exists to make
+    // visible: resume is not an error path, so without this check a
+    // silently-fresh conversation looks exactly like a working one.
+    if history.is_empty() {
+        agent.shutdown().await?;
+        return Err(Box::new(AntigravityError::Config(
+            "resume restored no history — the save dir or conversation id did not match".into(),
+        )));
+    }
+
+    let response = agent.chat("What did I ask you to remember?").await?;
+    let answer = response.text().trim().to_string();
+    println!("Agent: {answer}");
+
+    // Structural check, not a phrasing check: the model is free to
+    // rephrase, but "deploy key" can only have come from run 1.
+    if answer.to_lowercase().contains("deploy key") {
+        println!("✓ The agent recalled the fact from run 1.");
+    } else {
+        println!("⚠ Recall unclear — the answer did not mention the planted fact.");
+    }
+
+    agent.shutdown().await?;
+    Ok(())
+}

--- a/examples/real_world/testing_assistant/main.rs
+++ b/examples/real_world/testing_assistant/main.rs
@@ -132,7 +132,7 @@ impl TestingAssistant {
         let response = self
             .client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are an expert test engineer. Generate thorough, maintainable tests \
                  that cover normal cases, edge cases, and error conditions. Use descriptive \
@@ -177,7 +177,7 @@ impl TestingAssistant {
         let response = self
             .client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are a test coverage analyst. Evaluate test completeness, \
                  identify gaps, and suggest specific improvements. Be thorough \
@@ -233,7 +233,7 @@ impl TestingAssistant {
         let response = self
             .client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are a property-based testing expert. Identify mathematical \
                  properties and invariants that should hold for any valid input. \
@@ -267,7 +267,7 @@ impl TestingAssistant {
         let response = self
             .client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are a test engineer. Write a focused, well-named test \
                  for the specific scenario. Include setup if needed and \

--- a/examples/real_world/web_scraper_agent/README.md
+++ b/examples/real_world/web_scraper_agent/README.md
@@ -19,7 +19,7 @@ Uses Gemini's built-in search capability:
 
 ```rust
 client.interaction()
-    .with_model("gemini-3-flash-preview")
+    .with_model("gemini-3.6-flash")
     .with_text(query)
     .with_google_search()  // Enable real-time web search
     .create()

--- a/examples/real_world/web_scraper_agent/main.rs
+++ b/examples/real_world/web_scraper_agent/main.rs
@@ -115,7 +115,7 @@ impl WebResearchAgent {
         let response = self
             .client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are a professional research analyst. Synthesize information from \
                  multiple sources, verify facts when possible, and clearly indicate \
@@ -191,7 +191,7 @@ impl WebResearchAgent {
         let response = self
             .client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are a market research analyst. Provide accurate, up-to-date \
                  competitive intelligence. Focus on verifiable facts and recent \
@@ -221,7 +221,7 @@ impl WebResearchAgent {
         let mut stream = self
             .client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are a research assistant. Provide well-sourced, accurate information. \
                  Organize your response with clear sections and cite sources inline.",
@@ -273,7 +273,7 @@ impl WebResearchAgent {
         let response = self
             .client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instruction(
                 "You are a fact-checker. Verify claims using reliable sources. \
                  Be objective and cite your sources. If evidence is inconclusive, \

--- a/examples/real_world/workspace_explorer/README.md
+++ b/examples/real_world/workspace_explorer/README.md
@@ -1,0 +1,73 @@
+# Workspace Explorer Example
+
+Points the harness's read-only builtins at a real directory and observes
+every move the agent makes — the **control and observability** surface
+underneath an agent run.
+
+Where [`repo_auditor`](../repo_auditor/) shows an agent producing a
+structured verdict, this one is about what you can *see* and what you can
+*stop*.
+
+## Overview
+
+1. Seeds a small workspace (a README, two source files, and a planted
+   `secrets.env`).
+2. Runs the agent with `Capabilities::read_only()` and a name-based policy.
+3. Streams the turn, matching `AgentEvent::ToolAction` to build an audit
+   trail of every harness-executed file tool, with its allow/deny decision.
+4. Gates custom tool calls with an `on_pre_tool` hook that refuses **by
+   content** — the thing a name-based policy cannot express.
+5. Records what each call returned via `on_post_tool`.
+
+## What it covers that the other examples don't
+
+| Surface | Why it matters |
+|---------|----------------|
+| `add_workspace` with real content | Builtins actually run against real files, not merely enabled |
+| `AgentEvent::ToolAction` | The typed action stream — what the agent touched, in order |
+| `ToolDecision` on each action | Allowed or denied, per action |
+| `on_pre_tool` returning `Deny` | Content-based refusal, live |
+| `on_post_tool` | What each call actually returned |
+
+## Policies gate by name; hooks gate by content
+
+This distinction is the point of the example. `policy::allow("record_finding")`
+permits the *tool*; it cannot tell a benign argument from a credential. The
+`on_pre_tool` hook inspects the arguments and refuses the specific call,
+and the model sees the refusal reason as a tool response — so a good reason
+string steers the next attempt rather than stalling it.
+
+## A bug this example found
+
+Running it surfaced a real defect: the harness sends `"error": ""`
+(protobuf's default for an unset string) on tool calls that **succeeded**,
+and the bridge passed that through as `Some("")`. Every successful
+harness-executed builtin was therefore reported to `on_post_tool` as a
+failure — with `error.is_some()` being exactly the check the field's docs
+invite.
+
+Fixed, and pinned by
+`tests/antigravity_harness.rs::test_antigravity_workspace_actions_and_post_tool_success`
+plus a unit test on the normalization itself. Worth noting that it was
+invisible to every existing test and only appeared when someone actually
+watched an agent work.
+
+## Running
+
+```bash
+pip install google-antigravity==0.1.10   # ships the localharness binary
+export GEMINI_API_KEY=...
+
+cargo run --example workspace_explorer --features antigravity
+LOUD_WIRE=1 cargo run --example workspace_explorer --features antigravity
+```
+
+## Production notes
+
+- Use policies **and** hooks: names for shape, content for judgement.
+- Hooks run inline on the event pump — keep them non-blocking, and never
+  await a human decision inside one.
+- `ToolAction` carries `trajectory_id`; with subagents running, that is what
+  distinguishes the parent's actions from a subagent's.
+- Workspace announcement is on by default so the model knows the root path;
+  disable it only if you ground the model yourself.

--- a/examples/real_world/workspace_explorer/main.rs
+++ b/examples/real_world/workspace_explorer/main.rs
@@ -116,6 +116,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let post_audit = Arc::clone(&audit);
 
     let mut agent = AntigravityAgent::builder()
+        // The builder default is *unlimited*. Always set a budget: the
+        // failure mode without one is a turn that never ends (a harness
+        // that renames its terminal state does exactly this), which hangs
+        // rather than errors.
+        .with_turn_timeout(std::time::Duration::from_secs(120))
         .with_api_key(api_key)
         .with_model("gemini-3.6-flash")
         .with_system_instructions(

--- a/examples/real_world/workspace_explorer/main.rs
+++ b/examples/real_world/workspace_explorer/main.rs
@@ -43,10 +43,14 @@
 //! [action] list_directory      (allowed)  .
 //! [action] view_file           (allowed)  README.md
 //! [tool]   record_finding      -> ok
-//! [DENIED] record_finding: refusing to record a secret value
 //!
-//! --- Audit trail (4 harness actions, 2 custom calls, 1 denied) ---
+//! --- Audit trail (6 streamed actions, 12 post-tool callbacks, 0 denied) ---
 //! ```
+//!
+//! The deny path is prompt-dependent: the system instruction tells the
+//! agent not to touch credentials, so a well-behaved run never trips the
+//! hook. Seeding `secrets.env` and gating on content means the refusal is
+//! there when it is needed rather than relied upon for the demo.
 
 use futures_util::StreamExt;
 use genai_rs::CallableFunction;
@@ -65,7 +69,11 @@ use std::sync::{Arc, Mutex};
     note(description = "One sentence describing the finding")
 )]
 fn record_finding(file: String, note: String) -> String {
-    format!(r#"{{"recorded": true, "file": "{file}", "note": "{note}"}}"#)
+    // Build it with `json!` rather than interpolating into a string
+    // literal: `note` is free-form model output about code, so a quoted
+    // identifier or a backslash is likely rather than contrived, and
+    // hand-built JSON breaks on both.
+    serde_json::json!({ "recorded": true, "file": file, "note": note }).to_string()
 }
 
 /// One observed event, for the end-of-run audit trail.
@@ -73,8 +81,10 @@ fn record_finding(file: String, note: String) -> String {
 enum Audit {
     /// A harness-executed builtin (file tools, etc.).
     HarnessAction { name: String, allowed: bool },
-    /// A client-executed custom tool call that ran.
-    CustomCall { name: String, ok: bool },
+    /// A completed tool call as seen by `on_post_tool`. Note this fires
+    /// for harness-executed builtins as well as custom tools — the hook is
+    /// "a tool finished", not "your code ran".
+    PostTool { name: String, ok: bool },
     /// A custom tool call the pre-tool hook refused.
     Denied { name: String, reason: String },
 }
@@ -123,16 +133,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Dynamic gate: policies match on *names*, so they cannot express
         // "this particular call is bad". Content-based refusal lives here.
         .on_pre_tool(move |call| {
-            let looks_secret = call.args["note"]
-                .as_str()
-                .into_iter()
-                .chain(call.args["file"].as_str())
+            // The hook is consulted for harness builtins too, and they use
+            // their own argument names — `view_file` sends `file_path`, not
+            // `file`. Reading only the custom tool's keys would silently
+            // allow every builtin (a missing key indexes to Null), so the
+            // gate would cover recording a secret but not *reading* one.
+            const ARG_KEYS: [&str; 5] = ["note", "file", "file_path", "directory_path", "query"];
+            let looks_secret = ARG_KEYS
+                .iter()
+                .filter_map(|k| call.args[*k].as_str())
                 .any(|s| {
                     let s = s.to_lowercase();
                     s.contains("secret") || s.contains("api_key") || s.contains("password")
                 });
             if looks_secret {
-                let reason = "refusing to record a secret value".to_string();
+                let reason = format!("refusing to touch a secret value via {}", call.name);
                 println!("[DENIED] {}: {reason}", call.name);
                 hook_audit.lock().unwrap().push(Audit::Denied {
                     name: call.name.clone(),
@@ -155,7 +170,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     "ok"
                 }
             );
-            post_audit.lock().unwrap().push(Audit::CustomCall {
+            post_audit.lock().unwrap().push(Audit::PostTool {
                 name: outcome.name.clone(),
                 ok: outcome.error.is_none(),
             });
@@ -217,7 +232,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .count();
     let calls = trail
         .iter()
-        .filter(|a| matches!(a, Audit::CustomCall { .. }))
+        .filter(|a| matches!(a, Audit::PostTool { .. }))
         .count();
     let denied = trail
         .iter()
@@ -225,7 +240,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .count();
 
     println!(
-        "\n--- Audit trail ({actions} harness actions, {calls} custom calls, {denied} denied) ---"
+        "\n--- Audit trail ({actions} streamed actions, {calls} post-tool callbacks, {denied} denied) ---"
     );
     for entry in trail.iter() {
         match entry {
@@ -235,8 +250,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     if *allowed { "ok" } else { "denied" }
                 );
             }
-            Audit::CustomCall { name, ok } => {
-                println!("  call    {name:<20} {}", if *ok { "ok" } else { "error" });
+            Audit::PostTool { name, ok } => {
+                println!("  posttool{name:<20} {}", if *ok { "ok" } else { "error" });
             }
             Audit::Denied { name, reason } => println!("  DENIED  {name:<20} {reason}"),
         }

--- a/examples/real_world/workspace_explorer/main.rs
+++ b/examples/real_world/workspace_explorer/main.rs
@@ -260,7 +260,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         match entry {
             Audit::HarnessAction { name, allowed } => {
                 println!(
-                    "  action  {name:<20} {}",
+                    // Three spaces, not two: "action" is 6 chars against
+                    // "posttool"/"DENIED" at 8/6+pad, so the name column
+                    // only lines up at width 11.
+                    "  action   {name:<20} {}",
                     if *allowed { "ok" } else { "denied" }
                 );
             }

--- a/examples/real_world/workspace_explorer/main.rs
+++ b/examples/real_world/workspace_explorer/main.rs
@@ -251,9 +251,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 );
             }
             Audit::PostTool { name, ok } => {
-                println!("  posttool{name:<20} {}", if *ok { "ok" } else { "error" });
+                println!("  posttool {name:<20} {}", if *ok { "ok" } else { "error" });
             }
-            Audit::Denied { name, reason } => println!("  DENIED  {name:<20} {reason}"),
+            Audit::Denied { name, reason } => println!("  DENIED   {name:<20} {reason}"),
         }
     }
     agent.shutdown().await?;

--- a/examples/real_world/workspace_explorer/main.rs
+++ b/examples/real_world/workspace_explorer/main.rs
@@ -1,0 +1,305 @@
+//! # Workspace Explorer — watching an agent work, and gating it live
+//!
+//! Points the harness's read-only builtins at a real directory and then
+//! *observes every move it makes*: each `list_directory` / `view_file` /
+//! `search_directory` surfaces as a typed [`ToolAction`] on the stream,
+//! and a pre-tool hook adjudicates custom tool calls before they run.
+//!
+//! Where `repo_auditor` shows the agent producing a structured verdict,
+//! this one is about the **control and observability surface** underneath:
+//! what the agent touched, in what order, and what you were able to stop.
+//!
+//! What this example demonstrates that the others don't:
+//!
+//! - **Workspaces end to end** — `add_workspace` on a directory with real
+//!   content, so the builtin file tools actually run against real files
+//!   (rather than being merely enabled).
+//! - **Typed [`ToolAction`] observation** — matching the streamed action
+//!   variants to build an audit trail, including `decision` (was it
+//!   allowed or denied?) and `trajectory_id` (whose action was it?).
+//! - **A live `on_pre_tool` gate** — a hook that denies by *content*, not
+//!   just by tool name, which is the thing a static policy cannot express.
+//! - **`on_post_tool`** — recording what each custom call actually
+//!   returned.
+//!
+//! ## Requirements
+//!
+//! ```bash
+//! pip install google-antigravity==0.1.10   # or set ANTIGRAVITY_HARNESS_PATH
+//! export GEMINI_API_KEY=...
+//! cargo run --example workspace_explorer --features antigravity
+//! LOUD_WIRE=1 cargo run --example workspace_explorer --features antigravity
+//! ```
+//!
+//! ## Expected output
+//!
+//! ```text
+//! === Workspace Explorer ===
+//!
+//! Workspace: /tmp/workspace-explorer-.../
+//!   src/config.rs, src/main.rs, README.md, secrets.env
+//!
+//! --- Exploring ---
+//! [action] list_directory      (allowed)  .
+//! [action] view_file           (allowed)  README.md
+//! [tool]   record_finding      -> ok
+//! [DENIED] record_finding: refusing to record a secret value
+//!
+//! --- Audit trail (4 harness actions, 2 custom calls, 1 denied) ---
+//! ```
+
+use futures_util::StreamExt;
+use genai_rs::CallableFunction;
+use genai_rs::antigravity::{
+    AgentEvent, AntigravityAgent, Capabilities, PreToolDecision, ToolAction, policy,
+};
+use genai_rs_macros::tool;
+use std::sync::{Arc, Mutex};
+
+/// Records a finding about the workspace.
+///
+/// A deliberately trivial custom tool — the interesting part is that the
+/// pre-tool hook inspects its *arguments* and can refuse the call.
+#[tool(
+    file(description = "The file the finding is about"),
+    note(description = "One sentence describing the finding")
+)]
+fn record_finding(file: String, note: String) -> String {
+    format!(r#"{{"recorded": true, "file": "{file}", "note": "{note}"}}"#)
+}
+
+/// One observed event, for the end-of-run audit trail.
+#[derive(Debug)]
+enum Audit {
+    /// A harness-executed builtin (file tools, etc.).
+    HarnessAction { name: String, allowed: bool },
+    /// A client-executed custom tool call that ran.
+    CustomCall { name: String, ok: bool },
+    /// A custom tool call the pre-tool hook refused.
+    Denied { name: String, reason: String },
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not set");
+
+    let workspace = seed_workspace()?;
+    let workspace_path = workspace.path().to_string_lossy().to_string();
+
+    println!("=== Workspace Explorer ===\n");
+    println!("Workspace: {workspace_path}");
+    println!("  src/config.rs, src/main.rs, README.md, secrets.env\n");
+
+    // The audit trail is shared between the hooks (which run inline on the
+    // event pump) and the stream loop, so it needs interior mutability.
+    let audit: Arc<Mutex<Vec<Audit>>> = Arc::new(Mutex::new(Vec::new()));
+    let hook_audit = Arc::clone(&audit);
+    let post_audit = Arc::clone(&audit);
+
+    let mut agent = AntigravityAgent::builder()
+        .with_api_key(api_key)
+        .with_model("gemini-3.6-flash")
+        .with_system_instructions(
+            "You are exploring a small codebase. List the directory, read the files \
+             that look interesting, and call record_finding once for each notable \
+             thing you find. Do not read or record credentials. Finish when done.",
+        )
+        // Real content for the builtins to work against. The crate
+        // announces the root to the model by default, so it does not have
+        // to guess paths.
+        .add_workspace(workspace_path.clone())
+        // Read-only builtins are exactly what an explorer needs; the file
+        // tools below are all in this set.
+        .with_capabilities(Capabilities::read_only())
+        .add_tool(RecordFindingCallable.declaration())
+        // Static policy: the shape of what may run.
+        .add_policy(policy::deny_all())
+        .add_policy(policy::allow("record_finding"))
+        .add_policy(policy::allow("list_directory"))
+        .add_policy(policy::allow("view_file"))
+        .add_policy(policy::allow("search_directory"))
+        .add_policy(policy::allow("find_file"))
+        .add_policy(policy::allow("finish"))
+        // Dynamic gate: policies match on *names*, so they cannot express
+        // "this particular call is bad". Content-based refusal lives here.
+        .on_pre_tool(move |call| {
+            let looks_secret = call.args["note"]
+                .as_str()
+                .into_iter()
+                .chain(call.args["file"].as_str())
+                .any(|s| {
+                    let s = s.to_lowercase();
+                    s.contains("secret") || s.contains("api_key") || s.contains("password")
+                });
+            if looks_secret {
+                let reason = "refusing to record a secret value".to_string();
+                println!("[DENIED] {}: {reason}", call.name);
+                hook_audit.lock().unwrap().push(Audit::Denied {
+                    name: call.name.clone(),
+                    reason: reason.clone(),
+                });
+                PreToolDecision::deny(reason)
+            } else {
+                PreToolDecision::Allow
+            }
+        })
+        // Post-tool: what the call actually returned. Denied calls never
+        // execute, so they never reach this hook.
+        .on_post_tool(move |outcome| {
+            println!(
+                "[tool]   {:<20} -> {}",
+                outcome.name,
+                if outcome.error.is_some() {
+                    "error"
+                } else {
+                    "ok"
+                }
+            );
+            post_audit.lock().unwrap().push(Audit::CustomCall {
+                name: outcome.name.clone(),
+                ok: outcome.error.is_none(),
+            });
+        })
+        .spawn()
+        .await?;
+
+    println!("--- Exploring ---");
+    {
+        let mut stream = agent
+            .send_streaming("Explore this workspace and record what you find.")
+            .await?;
+
+        while let Some(event) = stream.next().await {
+            match event? {
+                // The typed action surface: every harness-executed builtin
+                // arrives here with its decision and originating trajectory.
+                AgentEvent::ToolAction {
+                    action, decision, ..
+                } => {
+                    let name = action.tool_name();
+                    let allowed = decision.is_allowed();
+                    // A few variants carry a path worth showing; the rest
+                    // are summarized by name alone.
+                    // `action` is boxed on the event, so match through it.
+                    let detail = match action.as_ref() {
+                        ToolAction::ViewFile(v) => v.file_path.clone().unwrap_or_default(),
+                        ToolAction::ListDirectory(l) => {
+                            l.directory_path.clone().unwrap_or_default()
+                        }
+                        ToolAction::SearchDirectory(s) => s.query.clone().unwrap_or_default(),
+                        _ => String::new(),
+                    };
+                    println!(
+                        "[action] {name:<20} ({})  {detail}",
+                        if allowed { "allowed" } else { "denied" }
+                    );
+                    audit
+                        .lock()
+                        .unwrap()
+                        .push(Audit::HarnessAction { name, allowed });
+                }
+                AgentEvent::Finished(_) => break,
+                AgentEvent::Error { message, severity } => {
+                    eprintln!("[error ({severity:?})] {message}");
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // ---- Audit trail -------------------------------------------------
+    // Snapshot and release: the guard must not be alive across the
+    // shutdown await below.
+    let trail: Vec<Audit> = std::mem::take(&mut *audit.lock().unwrap());
+    let actions = trail
+        .iter()
+        .filter(|a| matches!(a, Audit::HarnessAction { .. }))
+        .count();
+    let calls = trail
+        .iter()
+        .filter(|a| matches!(a, Audit::CustomCall { .. }))
+        .count();
+    let denied = trail
+        .iter()
+        .filter(|a| matches!(a, Audit::Denied { .. }))
+        .count();
+
+    println!(
+        "\n--- Audit trail ({actions} harness actions, {calls} custom calls, {denied} denied) ---"
+    );
+    for entry in trail.iter() {
+        match entry {
+            Audit::HarnessAction { name, allowed } => {
+                println!(
+                    "  action  {name:<20} {}",
+                    if *allowed { "ok" } else { "denied" }
+                );
+            }
+            Audit::CustomCall { name, ok } => {
+                println!("  call    {name:<20} {}", if *ok { "ok" } else { "error" });
+            }
+            Audit::Denied { name, reason } => println!("  DENIED  {name:<20} {reason}"),
+        }
+    }
+    agent.shutdown().await?;
+
+    println!("\n=== Example Complete ===\n");
+
+    println!("--- What You'll See with LOUD_WIRE=1 ---");
+    println!("  WS Send: {{\"config\": {{\"workspaces\": [{{\"filesystemWorkspace\": ...}}]}}}}");
+    println!("    - the workspace root the builtins are pointed at");
+    println!("  WS Receive: {{\"stepUpdate\": {{\"listDirectory\": ...}}}} - a harness action");
+    println!("  WS Receive: {{\"stepUpdate\": {{\"viewFile\": ...}}}} - each file read");
+    println!("  WS Receive: {{\"toolCall\": ...}} / WS Send: {{\"toolResponse\": ...}}");
+    println!("    - record_finding, dispatched through the crate's registry");
+    println!("  (a denied call sends a toolResponse carrying the refusal reason,");
+    println!("   so the model sees why and can adapt)\n");
+
+    println!("--- Production Considerations ---");
+    println!("• Policies gate by NAME; on_pre_tool gates by CONTENT. Use both —");
+    println!("  a name-based allow cannot tell a safe argument from a dangerous one");
+    println!("• Hooks run inline on the event pump: keep them non-blocking, and");
+    println!("  never await a human decision inside one");
+    println!("• ToolAction carries trajectory_id — with subagents running, that is");
+    println!("  what tells the parent's actions apart from a subagent's");
+    println!("• Denials are visible to the model as tool responses, so a good");
+    println!("  reason string steers the next attempt instead of stalling it");
+    println!("• Workspace announcement is on by default; disable it only if you");
+    println!("  ground the model on paths yourself");
+
+    Ok(())
+}
+
+/// Creates a small workspace with a planted credential, so the
+/// content-based deny path has something real to refuse.
+fn seed_workspace() -> Result<tempfile::TempDir, Box<dyn std::error::Error>> {
+    let dir = tempfile::Builder::new()
+        .prefix("workspace-explorer-")
+        .tempdir()?;
+    let src = dir.path().join("src");
+    std::fs::create_dir_all(&src)?;
+
+    std::fs::write(
+        dir.path().join("README.md"),
+        "# Widget Service\n\nA tiny service that widgets the widgets.\n\
+         Configuration lives in `src/config.rs`.\n",
+    )?;
+    std::fs::write(
+        src.join("main.rs"),
+        "fn main() {\n    // TODO: handle the empty-input case\n    \
+         println!(\"widgets\");\n}\n",
+    )?;
+    std::fs::write(
+        src.join("config.rs"),
+        "pub const RETRIES: u32 = 3;\n\
+         // FIXME: timeout is not configurable\n\
+         pub const TIMEOUT_SECS: u64 = 30;\n",
+    )?;
+    // The bait: present so the agent can find it, and the pre-tool hook
+    // refuses to let its contents be recorded.
+    std::fs::write(
+        dir.path().join("secrets.env"),
+        "API_KEY=sk-do-not-record-this\nPASSWORD=hunter2\n",
+    )?;
+    Ok(dir)
+}

--- a/examples/real_world/workspace_explorer/main.rs
+++ b/examples/real_world/workspace_explorer/main.rs
@@ -91,7 +91,16 @@ enum Audit {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not set");
+    let api_key = match std::env::var("GEMINI_API_KEY") {
+        Ok(key) if !key.trim().is_empty() => key,
+        _ => {
+            // Empty counts as absent: a fork push gets the secret as ""
+            // rather than unset, and spawning with it fails mid-turn
+            // instead of skipping.
+            println!("Skipping: GEMINI_API_KEY not set");
+            return Ok(());
+        }
+    };
 
     let workspace = seed_workspace()?;
     let workspace_path = workspace.path().to_string_lossy().to_string();
@@ -257,6 +266,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
     agent.shutdown().await?;
+
+    // Give the CI smoke run teeth. Printing an empty audit trail and
+    // exiting 0 would pass the very check meant to catch "the agent did
+    // nothing" — the same reason `session_resume` errors on an empty
+    // restored history rather than reporting it.
+    if actions == 0 && calls == 0 {
+        return Err(
+            "the agent took no actions and made no tool calls — nothing was exercised".into(),
+        );
+    }
 
     println!("\n=== Example Complete ===\n");
 

--- a/examples/response_passthrough.rs
+++ b/examples/response_passthrough.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response1 = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("What is 15 * 7? Just give me the number.")
         .create()
         .await?;
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response2 = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(history.clone())
         .create()
         .await?;
@@ -86,7 +86,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response3 = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(history2)
         .create()
         .await?;
@@ -106,7 +106,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let resp = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(history.clone())
         .create()
         .await?;
@@ -121,7 +121,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let resp2 = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(history.clone())
         .create()
         .await?;

--- a/examples/retrieval_grounding.rs
+++ b/examples/retrieval_grounding.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // -------------------------------------------------------------------
     let vertex_request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("What does our handbook say about vacation policy?")
         .add_tool(
             RetrievalConfig::new().with_vertex_ai_search(
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // -------------------------------------------------------------------
     let rag_request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Summarize the design documents about caching")
         .add_tool(
             RetrievalConfig::new().with_rag_store(
@@ -88,7 +88,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // -------------------------------------------------------------------
     let exa_request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Find recent papers on speculative decoding")
         .add_tool(
             RetrievalConfig::new().with_exa_ai_search(

--- a/examples/retry_with_backoff.rs
+++ b/examples/retry_with_backoff.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let client = Client::builder(api_key).build()?;
 
-    let model = "gemini-3-flash-preview";
+    let model = "gemini-3.6-flash";
     let prompt = "What is the Rust programming language known for? Answer in one sentence.";
 
     println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");

--- a/examples/simple_interaction.rs
+++ b/examples/simple_interaction.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let client = Client::builder(api_key).build()?;
 
     // 2. Create an interaction using the builder pattern
-    let model_name = "gemini-3-flash-preview";
+    let model_name = "gemini-3.6-flash";
     let prompt = "Explain the concept of recursion in programming in one paragraph.";
 
     println!("Creating interaction with model: {model_name}");

--- a/examples/stateful_interaction.rs
+++ b/examples/stateful_interaction.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Create the client
     let client = Client::builder(api_key).build()?;
 
-    let model_name = "gemini-3-flash-preview";
+    let model_name = "gemini-3.6-flash";
 
     // === First interaction ===
     println!("=== FIRST INTERACTION ===\n");

--- a/examples/streaming.rs
+++ b/examples/streaming.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a streaming request
     let mut stream = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(prompt)
         .with_store_enabled()
         .create_stream();

--- a/examples/streaming_auto_functions.rs
+++ b/examples/streaming_auto_functions.rs
@@ -103,7 +103,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Returns AutoFunctionStreamEvent which wraps chunk + event_id for resume support
     let mut stream = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(prompt)
         .add_functions(vec![weather_func, time_func, convert_func])
         .create_stream_with_auto_functions();

--- a/examples/structured_output.rs
+++ b/examples/structured_output.rs
@@ -109,7 +109,7 @@ async fn basic_structured_output(client: &Client) -> Result<(), Box<dyn Error>> 
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Write a review for the movie 'Inception' (2010). Be concise.")
         .with_response_format(schema)
         .create()
@@ -175,7 +175,7 @@ async fn complex_nested_schema(client: &Client) -> Result<(), Box<dyn Error>> {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Give me a simple pasta recipe with 5 ingredients and 4 steps.")
         .with_response_format(schema)
         .create()
@@ -229,7 +229,7 @@ async fn structured_with_search(client: &Client) -> Result<(), Box<dyn Error>> {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("What's the current status of Apple Inc (AAPL) stock? Include any recent news.")
         .with_google_search() // Enable real-time web search
         .with_response_format(schema)
@@ -279,7 +279,7 @@ async fn streaming_structured_output(client: &Client) -> Result<(), Box<dyn Erro
 
     let mut stream = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Write a brief review for a wireless mouse. Be concise.")
         .with_response_format(schema)
         .create_stream();

--- a/examples/system_instructions.rs
+++ b/examples/system_instructions.rs
@@ -18,7 +18,7 @@ use std::io::{Write, stdout};
 async fn main() -> Result<(), Box<dyn Error>> {
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not found in environment");
     let client = Client::builder(api_key).build()?;
-    let model_name = "gemini-3-flash-preview";
+    let model_name = "gemini-3.6-flash";
 
     // =========================================================================
     // Example 1: Setting a Persona

--- a/examples/text_input.rs
+++ b/examples/text_input.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::text("Analyze this JSON data. How many users are there and what roles exist?"),
             // Note: Use text/plain for JSON - API doesn't support application/json as document type
@@ -107,7 +107,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::text("Parse this CSV and calculate the average age of all employees."),
             // Note: Use text/plain for CSV - API doesn't support text/csv as document type
@@ -127,7 +127,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::text("Summarize this markdown document in one sentence."),
             // text/markdown is supported for markdown content
@@ -150,7 +150,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::text("What is the main purpose of this project based on the README?"),
             readme_content,
@@ -170,7 +170,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let doc = document_from_file("CHANGELOG.md").await?;
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::text("List the main sections in this markdown file."),
             doc,

--- a/examples/thinking.rs
+++ b/examples/thinking.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(prompt)
         .with_thinking_level(ThinkingLevel::Medium)
         .with_store_enabled()
@@ -94,7 +94,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(summary_prompt)
         .with_thinking_level(ThinkingLevel::Medium)
         .with_thinking_summaries(ThinkingSummaries::Auto)
@@ -145,7 +145,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let response = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text(complex_prompt)
             .with_thinking_level(level)
             .with_store_enabled()
@@ -193,7 +193,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut stream = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(stream_prompt)
         .with_thinking_level(ThinkingLevel::Medium)
         .create_stream();

--- a/examples/thought_echo.rs
+++ b/examples/thought_echo.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // First interaction - must enable store for multi-turn
     let response1 = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(initial_prompt)
         .with_thinking_level(ThinkingLevel::Medium)
         .with_store_enabled()
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response2 = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(followup)
         .with_previous_interaction(interaction_id)
         .with_thinking_level(ThinkingLevel::Medium)
@@ -110,7 +110,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let resp_manual = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(prompt)
         .with_thinking_level(ThinkingLevel::Low)
         .create()
@@ -135,7 +135,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let resp_followup = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(history)
         .with_thinking_level(ThinkingLevel::Low)
         .create()

--- a/examples/tool_service.rs
+++ b/examples/tool_service.rs
@@ -161,7 +161,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let result1 = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(prompt1)
         .with_tool_service(service.clone()) // Clone the Arc, not the service
         .create_with_auto_functions()
@@ -189,7 +189,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let result2 = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text(prompt2)
         .with_tool_service(service.clone()) // Same service instance
         .create_with_auto_functions()

--- a/examples/url_context.rs
+++ b/examples/url_context.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let client = Client::builder(api_key).build()?;
 
     // 2. Create an interaction with URL context enabled
-    let model_name = "gemini-3-flash-preview";
+    let model_name = "gemini-3.6-flash";
     let prompt = "Please fetch and summarize the main content from https://example.com. \
                   What is the purpose of this domain?";
 

--- a/examples/video_input.rs
+++ b/examples/video_input.rs
@@ -20,7 +20,13 @@ const DEMO_MP4_BASE64: &str = "AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAMWb
 async fn main() -> Result<(), Box<dyn Error>> {
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not found in environment");
     let client = Client::builder(api_key).build()?;
-    let model_name = "gemini-3.6-flash";
+    // This example is about **inline** (base64) video bytes, and the
+    // default `gemini-3.6-flash` rejects those with a 400 while accepting
+    // video by URI (verified live 2026-08-10). So it pins a model that
+    // accepts the inline form — the same reason `tests/common`'s
+    // VIDEO_INLINE_MODEL exists. If you only need video by URI, the
+    // default model is fine; see the Files API section below.
+    let model_name = "gemini-3-flash-preview";
 
     // =========================================================================
     // Example 1: Basic Video Analysis (Fluent Builder Pattern)
@@ -67,7 +73,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // Using with_content() for multimodal input
    let response = client
        .interaction()
-       .with_model("gemini-3.6-flash")
+       .with_model("gemini-3-flash-preview")
        .with_content(vec![
            Content::text("Describe the key scenes in this video. What's happening?"),
            Content::video_data(&base64_video, "video/mp4"),
@@ -80,7 +86,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    let video = video_from_file("video.mp4").await?;
    let response = client
        .interaction()
-       .with_model("gemini-3.6-flash")
+       .with_model("gemini-3-flash-preview")
        .with_content(vec![
            Content::text("Describe the key scenes in this video."),
            video,
@@ -95,7 +101,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         r#"
    let response = client
        .interaction()
-       .with_model("gemini-3.6-flash")
+       .with_model("gemini-3-flash-preview")
        .with_content(vec![
            Content::text("List all the objects and people visible in this video.
                For each, note when they first appear (approximate timestamp)."),
@@ -111,7 +117,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         r#"
    let response = client
        .interaction()
-       .with_model("gemini-3.6-flash")
+       .with_model("gemini-3-flash-preview")
        .with_content(vec![
            Content::text("What actions or activities are being performed in this video?
                Describe the sequence of events."),
@@ -127,7 +133,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         r#"
    let response = client
        .interaction()
-       .with_model("gemini-3.6-flash")
+       .with_model("gemini-3-flash-preview")
        .with_content(vec![
            Content::text("How many people are in this video? What are they wearing?"),
            Content::video_data(&base64_video, "video/mp4"),
@@ -148,7 +154,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // First turn: Send video and get initial analysis
    let first = client
        .interaction()
-       .with_model("gemini-3.6-flash")
+       .with_model("gemini-3-flash-preview")
        .with_content(vec![
            Content::text("Describe what's happening in this video."),
            Content::video_data(&base64_video, "video/mp4"),
@@ -160,7 +166,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // Second turn: Ask follow-up (video is remembered)
    let second = client
        .interaction()
-       .with_model("gemini-3.6-flash")
+       .with_model("gemini-3-flash-preview")
        .with_text("What happens at the 30-second mark?")
        .with_previous_interaction(&first.id)
        .create()
@@ -169,7 +175,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // Third turn: More specific questions
    let third = client
        .interaction()
-       .with_model("gemini-3.6-flash")
+       .with_model("gemini-3-flash-preview")
        .with_text("What color is the car in the background?")
        .with_previous_interaction(&second.id)
        .create()
@@ -187,7 +193,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         r#"
    let response = client
        .interaction()
-       .with_model("gemini-3.6-flash")
+       .with_model("gemini-3-flash-preview")
        .with_content(vec![
            Content::text("Analyze this video:
                1. What is shown visually?
@@ -271,7 +277,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // Build the request using with_content
    let response = client
        .interaction()
-       .with_model("gemini-3.6-flash")
+       .with_model("gemini-3-flash-preview")
        .with_content(vec![
            Content::text("Describe what's happening in this video."),
            video_content,
@@ -294,7 +300,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // Send with with_content
    let response = client
        .interaction()
-       .with_model("gemini-3.6-flash")
+       .with_model("gemini-3-flash-preview")
        .with_content(vec![
            Content::text("Describe what's happening in this video."),
            Content::video_data(&base64_video, "video/mp4"),

--- a/examples/video_input.rs
+++ b/examples/video_input.rs
@@ -20,7 +20,7 @@ const DEMO_MP4_BASE64: &str = "AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAMWb
 async fn main() -> Result<(), Box<dyn Error>> {
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not found in environment");
     let client = Client::builder(api_key).build()?;
-    let model_name = "gemini-3-flash-preview";
+    let model_name = "gemini-3.6-flash";
 
     // =========================================================================
     // Example 1: Basic Video Analysis (Fluent Builder Pattern)
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // Using with_content() for multimodal input
    let response = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("Describe the key scenes in this video. What's happening?"),
            Content::video_data(&base64_video, "video/mp4"),
@@ -80,7 +80,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    let video = video_from_file("video.mp4").await?;
    let response = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("Describe the key scenes in this video."),
            video,
@@ -95,7 +95,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         r#"
    let response = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("List all the objects and people visible in this video.
                For each, note when they first appear (approximate timestamp)."),
@@ -111,7 +111,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         r#"
    let response = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("What actions or activities are being performed in this video?
                Describe the sequence of events."),
@@ -127,7 +127,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         r#"
    let response = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("How many people are in this video? What are they wearing?"),
            Content::video_data(&base64_video, "video/mp4"),
@@ -148,7 +148,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // First turn: Send video and get initial analysis
    let first = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("Describe what's happening in this video."),
            Content::video_data(&base64_video, "video/mp4"),
@@ -160,7 +160,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // Second turn: Ask follow-up (video is remembered)
    let second = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_text("What happens at the 30-second mark?")
        .with_previous_interaction(&first.id)
        .create()
@@ -169,7 +169,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // Third turn: More specific questions
    let third = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_text("What color is the car in the background?")
        .with_previous_interaction(&second.id)
        .create()
@@ -187,7 +187,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         r#"
    let response = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("Analyze this video:
                1. What is shown visually?
@@ -271,7 +271,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // Build the request using with_content
    let response = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("Describe what's happening in this video."),
            video_content,
@@ -294,7 +294,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
    // Send with with_content
    let response = client
        .interaction()
-       .with_model("gemini-3-flash-preview")
+       .with_model("gemini-3.6-flash")
        .with_content(vec![
            Content::text("Describe what's happening in this video."),
            Content::video_data(&base64_video, "video/mp4"),

--- a/src/antigravity/config.rs
+++ b/src/antigravity/config.rs
@@ -16,9 +16,17 @@ use super::protocol;
 /// with:
 ///
 /// ```bash
-/// pip install google-antigravity==0.1.5
+/// pip install google-antigravity==0.1.10
 /// ```
-pub const SUPPORTED_HARNESS_VERSION: &str = "0.1.5";
+///
+/// The 0.1.5 → 0.1.10 move renamed two wire spellings that the bridge
+/// depends on (`STATE_IDLE` → `STATE_FULLY_IDLE`, `usageMetadata` →
+/// `usageUpdate`); both old spellings are still accepted, so a single
+/// build drives either revision. "Degrades gracefully" is doing real
+/// work in that sentence above, though — a renamed value an
+/// `Unknown` variant absorbs is invisible until behavior that
+/// *matched* on it silently stops firing.
+pub const SUPPORTED_HARNESS_VERSION: &str = "0.1.10";
 
 /// Harness-executed built-in tools.
 ///

--- a/src/antigravity/mod.rs
+++ b/src/antigravity/mod.rs
@@ -963,6 +963,20 @@ impl AntigravityAgent {
     /// its trajectory), closes stdin (EOF triggers the harness's clean
     /// exit), then escalates to SIGTERM and SIGKILL if it lingers.
     pub async fn shutdown(mut self) -> Result<(), AntigravityError> {
+        // Summarize protocol drift once, at the natural end of a session.
+        // Individual `warn!`s scroll past mid-run; the aggregate is what
+        // tells you the harness spoke a dialect this build only partly
+        // understands — the failure mode that otherwise presents as
+        // "it just didn't do anything".
+        let drift = protocol::drift_report();
+        if !drift.is_empty() {
+            tracing::warn!(
+                "Antigravity session saw {} unrecognized wire value(s) — this build may not \
+                 fully understand this harness (see SUPPORTED_HARNESS_VERSION): {:?}",
+                drift.values().sum::<usize>(),
+                drift
+            );
+        }
         // Stop trigger timers first so nothing writes to the closing socket.
         self.trigger_tasks.abort_all();
         self.session.close().await;

--- a/src/antigravity/mod.rs
+++ b/src/antigravity/mod.rs
@@ -51,7 +51,7 @@ pub use hooks::{
 pub use streaming::{AgentEvent, AgentEventStream, ErrorSeverity, ToolAction, ToolDecision};
 pub use triggers::TriggerConfig;
 
-use crate::wire::{LoudWirePrinter, WireInspector};
+use crate::wire::WireInspector;
 use crate::{FunctionDeclaration, ToolService};
 use serde_json::Value;
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
@@ -629,8 +629,8 @@ impl AgentBuilder {
         let binary = process::discover_harness(self.harness_path.as_deref())?;
 
         let mut inspectors = self.inspectors.clone();
-        if std::env::var("LOUD_WIRE").is_ok() {
-            inspectors.push(Arc::new(LoudWirePrinter::new()));
+        if let Some(printer) = crate::wire::env_inspector() {
+            inspectors.push(Arc::new(printer));
         }
         let wire = WireContext::new(inspectors);
 
@@ -852,8 +852,20 @@ impl std::fmt::Debug for AntigravityAgent {
 /// while consuming an [`AgentEventStream`]). Obtain via
 /// [`AntigravityAgent::cancel_handle`]; cheap to clone.
 ///
-/// Cancellation makes the in-flight `chat`/stream fail with
-/// [`AntigravityError::Turn`] once the harness confirms.
+/// # What a cancelled turn returns
+///
+/// Harness 0.1.10 answers a halt by taking the trajectory to
+/// `STATE_FULLY_IDLE` — the same terminal state as a natural completion,
+/// not `STATE_CANCELLED`. So the in-flight `chat`/stream **resolves
+/// normally**, returning whatever partial output the turn had produced;
+/// it does not fail with [`AntigravityError::Turn`]. Treat `cancel` as
+/// "stop early and keep what you have", and track the cancellation on
+/// your side if you need to tell a halted turn from a completed one.
+///
+/// [`AntigravityError::Turn`] remains the outcome when the *harness*
+/// cancels a turn itself (`STATE_CANCELLED`), which is a different event
+/// from this handle's halt request. Pinned by
+/// `test_antigravity_cancel_handle_halts_an_in_flight_turn`.
 #[derive(Debug, Clone)]
 pub struct CancelHandle {
     sink: SinkHandle,

--- a/src/antigravity/mod.rs
+++ b/src/antigravity/mod.rs
@@ -1501,10 +1501,12 @@ impl AntigravityAgent {
                     // wire envelope the harness expects (Item: unwrap
                     // ToolOutcome.result). The error branch keeps the
                     // envelope's error string.
-                    let error = result
-                        .get("error")
-                        .and_then(Value::as_str)
-                        .map(ToString::to_string);
+                    let error = normalize_tool_error(
+                        result
+                            .get("error")
+                            .and_then(Value::as_str)
+                            .map(str::to_owned),
+                    );
                     let outcome = ToolOutcome {
                         name: name.clone(),
                         result: error.is_none().then(|| unwrap_result_value(&result)),
@@ -1570,7 +1572,7 @@ impl AntigravityAgent {
                     // Unwrap the `{"result": ...}` envelope for consistency
                     // with the custom-tool dispatch path.
                     result: post_tool_args.result.as_deref().map(unwrap_result_string),
-                    error: post_tool_args.error.clone(),
+                    error: normalize_tool_error(post_tool_args.error.clone()),
                 });
             }
             response.empty_result = Some(protocol::EmptyResult {});
@@ -1772,6 +1774,19 @@ fn unwrap_result_value(value: &Value) -> String {
         };
     }
     value.to_string()
+}
+
+/// Normalizes a tool error into "errored or not".
+///
+/// The harness populates `PostToolArgs.error` with `""` — protobuf's
+/// default for an unset string — on calls that **succeeded**. Passing that
+/// through verbatim makes `ToolOutcome::error.is_some()` true for every
+/// successful harness-executed builtin, which is precisely the check the
+/// field's own docs invite ("the error, if it failed"). Treating blank as
+/// absent keeps `is_some()` meaning what it says, on both the custom-tool
+/// dispatch path and the harness post-tool path.
+fn normalize_tool_error(error: Option<String>) -> Option<String> {
+    error.filter(|e| !e.trim().is_empty())
 }
 
 /// Like [`unwrap_result_value`], for a harness-supplied result *string*
@@ -2346,6 +2361,66 @@ mod agent_tests {
             turn.queue.pop_front(),
             Some(AgentEvent::Finished(_))
         ));
+    }
+
+    #[test]
+    fn stall_diagnosis_names_unrecognized_main_trajectory_states() {
+        // The scenario nobody reproduces on purpose: the harness renames
+        // the terminal state, the Evergreen path absorbs it as Unknown,
+        // and the turn runs to its timeout. Pin that the timeout message
+        // names the culprit instead of reporting a bare stall.
+        let unknown: TrajectoryState =
+            serde_json::from_value(serde_json::json!("STATE_SUPER_IDLE")).unwrap();
+        assert!(unknown.is_unknown(), "fixture must be an Unknown variant");
+
+        let mut turn = TurnState::new(None, None);
+        turn.main_trajectory = Some("main".to_string());
+        let update = trajectory_update(Some("main"), unknown, None);
+        AntigravityAgent::process_trajectory_update(&update, &mut turn).unwrap();
+
+        assert!(!turn.finished, "an unknown state must not end the turn");
+        let diagnosis = turn.stall_diagnosis();
+        assert!(
+            diagnosis.contains("STATE_SUPER_IDLE"),
+            "diagnosis must name the state, got: {diagnosis}"
+        );
+        assert!(
+            diagnosis.contains("version mismatch"),
+            "diagnosis must point at the likely cause, got: {diagnosis}"
+        );
+    }
+
+    #[test]
+    fn stall_diagnosis_ignores_subagent_states_and_clean_turns() {
+        // A clean turn keeps the plain operation name...
+        let turn = TurnState::new(None, None);
+        assert_eq!(turn.stall_diagnosis(), "agent turn");
+
+        // ...and a *subagent* trajectory going somewhere unrecognized is
+        // not the parent's problem, so it must not pollute the parent's
+        // diagnosis (the `is_main` half of the condition).
+        let unknown: TrajectoryState =
+            serde_json::from_value(serde_json::json!("STATE_SUPER_IDLE")).unwrap();
+        let mut turn = TurnState::new(None, None);
+        turn.main_trajectory = Some("main".to_string());
+        let update = trajectory_update(Some("subagent-1"), unknown, None);
+        AntigravityAgent::process_trajectory_update(&update, &mut turn).unwrap();
+        assert_eq!(turn.stall_diagnosis(), "agent turn");
+    }
+
+    #[test]
+    fn tool_error_normalization_treats_blank_as_success() {
+        // The harness sends `"error": ""` (protobuf's default for an unset
+        // string) on calls that SUCCEEDED, so passing it through verbatim
+        // reported every successful builtin as a failure to the
+        // `is_some()` check the field's docs invite.
+        assert_eq!(normalize_tool_error(Some(String::new())), None);
+        assert_eq!(normalize_tool_error(Some("   ".to_string())), None);
+        assert_eq!(normalize_tool_error(None), None);
+        assert_eq!(
+            normalize_tool_error(Some("boom".to_string())),
+            Some("boom".to_string())
+        );
     }
 
     #[test]

--- a/src/antigravity/mod.rs
+++ b/src/antigravity/mod.rs
@@ -20,7 +20,7 @@
 //!
 //! let mut agent = AntigravityAgent::builder()
 //!     .with_api_key(std::env::var("GEMINI_API_KEY")?)
-//!     .with_model("gemini-3-flash-preview")
+//!     .with_model("gemini-3.6-flash")
 //!     .with_system_instructions("You are a code-review assistant.")
 //!     .add_workspace("/path/to/repo")
 //!     .add_policy(policy::deny_all())
@@ -285,7 +285,7 @@ impl AgentBuilder {
         self
     }
 
-    /// Sets the text model (default: `gemini-3-flash-preview`).
+    /// Sets the text model (default: `gemini-3.6-flash`).
     #[must_use]
     pub fn with_model(mut self, model: impl Into<String>) -> Self {
         self.model = Some(model.into());
@@ -744,7 +744,7 @@ impl AgentBuilder {
                     name: Some(
                         self.model
                             .clone()
-                            .unwrap_or_else(|| "gemini-3-flash-preview".to_string()),
+                            .unwrap_or_else(|| "gemini-3.6-flash".to_string()),
                     ),
                     types: vec![protocol::ModelType::Text],
                     gemini_api_endpoint: Some(protocol::GeminiApiEndpoint {
@@ -2463,7 +2463,7 @@ mod agent_tests {
     #[tokio::test]
     async fn test_spawn_model_without_api_key_is_config_error() {
         let err = AntigravityAgent::builder()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .spawn()
             .await
             .unwrap_err();
@@ -2477,7 +2477,7 @@ mod agent_tests {
     fn test_builder_harness_config_assembly() {
         let builder = AntigravityAgent::builder()
             .with_api_key("test-key")
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_system_instructions("Be brief.")
             .add_workspace("/w1")
             .add_workspace("/w2")
@@ -2494,7 +2494,7 @@ mod agent_tests {
         assert_eq!(config.cascade_id.as_deref(), Some("resume-me"));
         assert_eq!(config.models.len(), 1);
         let model = &config.models[0];
-        assert_eq!(model.name.as_deref(), Some("gemini-3-flash-preview"));
+        assert_eq!(model.name.as_deref(), Some("gemini-3.6-flash"));
         assert_eq!(model.types, vec![protocol::ModelType::Text]);
         assert_eq!(
             model

--- a/src/antigravity/mod.rs
+++ b/src/antigravity/mod.rs
@@ -54,7 +54,7 @@ pub use triggers::TriggerConfig;
 use crate::wire::{LoudWirePrinter, WireInspector};
 use crate::{FunctionDeclaration, ToolService};
 use serde_json::Value;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -1049,7 +1049,7 @@ impl AntigravityAgent {
                         // turn and desync every turn after it.
                         self.halt_and_drain("recovering from a turn timeout").await;
                         return Err(AntigravityError::Timeout {
-                            operation: "agent turn".to_string(),
+                            operation: turn.stall_diagnosis(),
                             timeout: turn.timeout.unwrap_or_default(),
                         });
                     }
@@ -1433,8 +1433,22 @@ impl AntigravityAgent {
                 return Err(AntigravityError::Turn(message));
             }
             _ => {
-                // Running / subagent idle or cancelled / unknown states:
-                // nothing to do for the parent turn.
+                // Running / waiting-for-tasks / subagent idle or
+                // cancelled: nothing to do for the parent turn.
+                //
+                // An *unrecognized* main-trajectory state is different in
+                // kind, though it lands here too: only `Idle` ends a
+                // turn, so if the harness renamed the terminal state (as
+                // 0.1.10 did — `STATE_IDLE` -> `STATE_FULLY_IDLE`) the
+                // turn runs to its timeout with nothing else to show for
+                // it. Record the value so the timeout can name the cause
+                // instead of reporting a bare stall.
+                if is_main
+                    && let Some(state) = &update.state
+                    && let Some(unknown) = state.unknown_state_type()
+                {
+                    turn.unknown_trajectory_states.insert(unknown.to_string());
+                }
             }
         }
         Ok(())
@@ -1805,6 +1819,10 @@ impl Drop for TurnGuard {
 struct TurnState {
     queue: VecDeque<AgentEvent>,
     finished: bool,
+    /// Unrecognized *main-trajectory* states seen this turn. Populated
+    /// only on the Evergreen `Unknown` path; drives the stall diagnostic
+    /// when a turn times out without ever reaching a terminal state.
+    unknown_trajectory_states: BTreeSet<String>,
     main_trajectory: Option<String>,
     handled_waits: HashMap<(String, u32), HashSet<&'static str>>,
     announced_actions: HashSet<(String, u32)>,
@@ -1829,6 +1847,7 @@ impl TurnState {
         Self {
             queue: VecDeque::new(),
             finished: false,
+            unknown_trajectory_states: BTreeSet::new(),
             main_trajectory: None,
             handled_waits: HashMap::new(),
             announced_actions: HashSet::new(),
@@ -1843,6 +1862,35 @@ impl TurnState {
             deadline: timeout.map(|t| tokio::time::Instant::now() + t),
             _turn_guard: turn_guard,
         }
+    }
+
+    /// Describes *why* a turn stalled, for the timeout error's
+    /// `operation` field.
+    ///
+    /// A bare "agent turn timed out" is the least actionable error the
+    /// bridge can raise: it looks identical whether the model is slow,
+    /// the harness died quietly, or — the case this exists for — the
+    /// harness renamed the terminal trajectory state and the bridge
+    /// stopped recognizing the end of a turn. When unknown
+    /// main-trajectory states were seen, name them and the likely cause,
+    /// so the failure points at the version mismatch instead of looking
+    /// like latency.
+    fn stall_diagnosis(&self) -> String {
+        if self.unknown_trajectory_states.is_empty() {
+            return "agent turn".to_string();
+        }
+        let states: Vec<_> = self
+            .unknown_trajectory_states
+            .iter()
+            .map(String::as_str)
+            .collect();
+        format!(
+            "agent turn (never saw a terminal trajectory state; the harness \
+             sent unrecognized state(s) [{}] that this build does not treat \
+             as terminal — most likely a harness/bridge version mismatch, \
+             see antigravity::SUPPORTED_HARNESS_VERSION)",
+            states.join(", ")
+        )
     }
 
     /// Marks a waiting-state request as handled for the step; returns

--- a/src/antigravity/mod.rs
+++ b/src/antigravity/mod.rs
@@ -971,8 +971,9 @@ impl AntigravityAgent {
         let drift = protocol::drift_report();
         if !drift.is_empty() {
             tracing::warn!(
-                "Antigravity session saw {} unrecognized wire value(s) — this build may not \
-                 fully understand this harness (see SUPPORTED_HARNESS_VERSION): {:?}",
+                "This process has seen {} unrecognized antigravity wire value(s) — this \
+                 build may not fully understand this harness (see \
+                 SUPPORTED_HARNESS_VERSION). Cumulative across agents in this process: {:?}",
                 drift.values().sum::<usize>(),
                 drift
             );

--- a/src/antigravity/protocol.rs
+++ b/src/antigravity/protocol.rs
@@ -569,7 +569,7 @@ pub struct FilesystemWorkspace {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ModelConfig {
-    /// Model name, e.g. `gemini-3-flash-preview`.
+    /// Model name, e.g. `gemini-3.6-flash`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// Roles this model serves ([`ModelType::Text`] is required for chat).
@@ -2003,7 +2003,7 @@ mod tests {
                     ..Default::default()
                 }],
                 models: vec![ModelConfig {
-                    name: Some("gemini-3-flash-preview".to_string()),
+                    name: Some("gemini-3.6-flash".to_string()),
                     types: vec![ModelType::Text],
                     gemini_api_endpoint: Some(GeminiApiEndpoint {
                         api_key: Some("k".to_string()),
@@ -2023,7 +2023,7 @@ mod tests {
             "harnessSideTools": {"runCommand": {"enabled": false}, "viewFile": {"enabled": true}},
             "workspaces": [{"filesystemWorkspace": {"directory": "/w"}}],
             "mcpServers": [{"name": "git", "stdio": {"command": "uvx", "args": ["x"], "env": {"K": "V"}}}],
-            "models": [{"name": "gemini-3-flash-preview", "types": ["MODEL_TYPE_TEXT"], "geminiApiEndpoint": {"httpHeaders": {"a": "b"}, "apiKey": "k"}}],
+            "models": [{"name": "gemini-3.6-flash", "types": ["MODEL_TYPE_TEXT"], "geminiApiEndpoint": {"httpHeaders": {"a": "b"}, "apiKey": "k"}}],
             "enabledHooks": ["LIFECYCLE_HOOK_PRE_TOOL"],
         }});
         assert_eq!(serde_json::to_value(&event).unwrap(), expected);

--- a/src/antigravity/protocol.rs
+++ b/src/antigravity/protocol.rs
@@ -24,6 +24,52 @@ use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 
 // =============================================================================
+// Protocol drift telemetry
+// =============================================================================
+
+/// Every unrecognized wire value seen this process, and how often.
+static DRIFT: std::sync::Mutex<Option<BTreeMap<String, usize>>> = std::sync::Mutex::new(None);
+
+/// Records an unrecognized wire value for [`drift_report`].
+///
+/// The Evergreen posture preserves what it does not recognize, which
+/// prevents a crash but produces no *signal*: a `warn!` nobody reads is
+/// the only trace, and behavior keyed on a renamed variant stops firing
+/// silently. Accumulating them makes the degradation inspectable —
+/// programmatically, not by grepping logs.
+pub(crate) fn record_drift(enum_name: &str, value: &str) {
+    if let Ok(mut guard) = DRIFT.lock() {
+        *guard
+            .get_or_insert_with(BTreeMap::new)
+            .entry(format!("{enum_name}={value}"))
+            .or_insert(0) += 1;
+    }
+}
+
+/// Unrecognized wire values seen so far, as `"EnumName=WIRE_VALUE" -> count`.
+///
+/// Empty is the healthy state. A non-empty report means the harness sent
+/// something this build does not model — which, for a value the crate
+/// *matches on*, is the difference between working and silently doing
+/// nothing (see `SUPPORTED_HARNESS_VERSION`). Process-wide and cumulative;
+/// [`clear_drift_report`] resets it.
+#[must_use]
+pub fn drift_report() -> BTreeMap<String, usize> {
+    DRIFT
+        .lock()
+        .ok()
+        .and_then(|g| g.clone())
+        .unwrap_or_default()
+}
+
+/// Clears [`drift_report`] (useful between test cases).
+pub fn clear_drift_report() {
+    if let Ok(mut guard) = DRIFT.lock() {
+        *guard = None;
+    }
+}
+
+// =============================================================================
 // Flexible numeric deserialization (proto-JSON int64/uint64 arrive as strings)
 // =============================================================================
 
@@ -125,6 +171,20 @@ macro_rules! wire_string_enum {
                 }
             }
 
+            /// Every wire spelling this enum recognizes, canonical and
+            /// alias alike.
+            ///
+            /// Exists for the protocol-drift guard in
+            /// `tests/antigravity_harness.rs`, which diffs these against
+            /// the enum values in the installed harness wheel's protobuf
+            /// descriptor. A value the harness gained (or renamed) is
+            /// otherwise invisible: it deserializes to `Unknown` and any
+            /// behavior keyed on the old variant silently stops firing.
+            #[must_use]
+            pub const fn all_wire_values() -> &'static [&'static str] {
+                &[$( $wire $(, $alias)* ),+]
+            }
+
             /// Check if this is an unknown value.
             #[must_use]
             pub const fn is_unknown(&self) -> bool {
@@ -177,6 +237,11 @@ macro_rules! wire_string_enum {
                      Preserving in Unknown variant."),
                     $ctx
                 );
+                // Also accumulate it: a warn is only seen by whoever is
+                // reading logs at the time, and this is the signal that
+                // distinguishes "preserved harmlessly" from "the bridge
+                // stopped recognizing something it acts on".
+                record_drift(stringify!($name), &$ctx);
                 Ok(Self::Unknown { $ctx, data: value })
             }
         }

--- a/src/antigravity/protocol.rs
+++ b/src/antigravity/protocol.rs
@@ -1869,12 +1869,14 @@ pub struct ActionCompaction {
 /// `ActionInvokeSubagent` — subagent invocation marker.
 ///
 /// The invoked subagent's `name` is modeled as an optional typed field, but
-/// **harness 0.1.5 does not populate it**: the `invokeSubagent` step action
-/// is an empty message on the wire (verified with `LOUD_WIRE=1` — the step
-/// only carries the generic text `"Invoke subagent"`). The field is here so
-/// that a future harness emitting the name surfaces it without an API break;
-/// until then it stays `None`, and any unexpected field is preserved in
-/// `extra` (Evergreen).
+/// **the harness does not populate it** (verified live on 0.1.5 and again
+/// on 0.1.10 by `test_antigravity_subagent_is_actually_invoked`, which
+/// delegates for real and reports the answer rather than asserting the old
+/// one): the `invokeSubagent` step action is an empty message on the wire,
+/// and the step only carries the generic text `"Invoke subagent"`. The
+/// field is here so that a future harness emitting the name surfaces it
+/// without an API break; until then it stays `None`, and any unexpected
+/// field is preserved in `extra` (Evergreen).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionInvokeSubagent {

--- a/src/antigravity/protocol.rs
+++ b/src/antigravity/protocol.rs
@@ -1198,8 +1198,15 @@ impl<'de> Deserialize<'de> for OutputEvent {
         // modeled yet, and either key must be consumed here or it falls
         // through to the leftover-key arm below and is misreported as an
         // unknown oneof variant.
+        // Consume `usageUpdate` unconditionally, before choosing between
+        // the two spellings: if a transitional harness ever sent *both*,
+        // leaving it in `map` would hand it to the leftover-key arm below
+        // and surface a bogus `Unknown` payload — the exact misreport this
+        // branch exists to prevent, in the one shape a nested match
+        // wouldn't cover.
+        let usage_update = map.remove("usageUpdate");
         let usage_metadata = match map.remove("usageMetadata") {
-            None | Some(Value::Null) => match map.remove("usageUpdate") {
+            Some(Value::Null) | None => match usage_update {
                 None | Some(Value::Null) => None,
                 Some(Value::Object(mut update)) => match update.remove("total") {
                     None | Some(Value::Null) => None,

--- a/src/antigravity/protocol.rs
+++ b/src/antigravity/protocol.rs
@@ -98,7 +98,7 @@ macro_rules! wire_string_enum {
     (
         $(#[$meta:meta])*
         $name:ident, $ctx:ident, $unknown_type_fn:ident {
-            $( $(#[$vmeta:meta])* $variant:ident => $wire:literal ),+ $(,)?
+            $( $(#[$vmeta:meta])* $variant:ident => $wire:literal $(| $alias:literal)* ),+ $(,)?
         }
     ) => {
         $(#[$meta])*
@@ -161,7 +161,10 @@ macro_rules! wire_string_enum {
                 let value = Value::deserialize(deserializer)?;
                 if let Value::String(s) = &value {
                     match s.as_str() {
-                        $( $wire => return Ok(Self::$variant), )+
+                        // Aliases accept spellings from other harness
+                        // revisions; `as_wire_str` always emits the
+                        // canonical (current-harness) form.
+                        $( $wire $(| $alias)* => return Ok(Self::$variant), )+
                         _ => {}
                     }
                 }
@@ -231,8 +234,19 @@ wire_string_enum!(
         Unspecified => "STATE_UNSPECIFIED",
         /// The trajectory is processing a turn.
         Running => "STATE_RUNNING",
-        /// The trajectory finished the turn and is awaiting input.
-        Idle => "STATE_IDLE",
+        /// The trajectory finished the turn and is awaiting input — the
+        /// signal that ends a turn.
+        ///
+        /// Harness 0.1.10 renamed this from `STATE_IDLE` to
+        /// `STATE_FULLY_IDLE`; the old spelling is accepted as an alias
+        /// so one build drives either harness revision. Without the
+        /// alias the value degrades to `Unknown` and, because only
+        /// `Idle` ends a turn, every turn silently runs to its timeout.
+        Idle => "STATE_FULLY_IDLE" | "STATE_IDLE",
+        /// The trajectory is blocked on subordinate tasks (e.g. running
+        /// subagents) and will return to `Running`. Explicitly **not**
+        /// terminal — new in harness 0.1.10.
+        WaitingForTasks => "STATE_WAITING_FOR_TASKS",
         /// The turn was cancelled (halt request or pre-turn hook denial).
         Cancelled => "STATE_CANCELLED",
     }
@@ -1177,8 +1191,25 @@ impl<'de> Deserialize<'de> for OutputEvent {
 
         let seq_num = take_i64(&mut map, "seqNum")?;
         let timestamp_micros = take_i64(&mut map, "timestampMicros")?;
+        // Harness 0.1.10 replaced the flat `usageMetadata` with
+        // `usageUpdate: {agents: [...], total: UsageMetadata}`. Read the
+        // aggregate from either spelling so one build drives both
+        // revisions; the per-trajectory `agents` breakdown is not
+        // modeled yet, and either key must be consumed here or it falls
+        // through to the leftover-key arm below and is misreported as an
+        // unknown oneof variant.
         let usage_metadata = match map.remove("usageMetadata") {
-            None | Some(Value::Null) => None,
+            None | Some(Value::Null) => match map.remove("usageUpdate") {
+                None | Some(Value::Null) => None,
+                Some(Value::Object(mut update)) => match update.remove("total") {
+                    None | Some(Value::Null) => None,
+                    Some(total) => Some(serde_json::from_value(total).map_err(D::Error::custom)?),
+                },
+                Some(other) => {
+                    tracing::warn!("Unexpected JSON type for usageUpdate, dropping usage: {other}");
+                    None
+                }
+            },
             Some(v) => Some(serde_json::from_value(v).map_err(D::Error::custom)?),
         };
 
@@ -1996,6 +2027,63 @@ mod tests {
             "enabledHooks": ["LIFECYCLE_HOOK_PRE_TOOL"],
         }});
         assert_eq!(serde_json::to_value(&event).unwrap(), expected);
+    }
+
+    #[test]
+    fn trajectory_terminal_state_accepts_both_harness_spellings() {
+        // Harness 0.1.10 renamed the terminal state. Both spellings must
+        // land on `Idle`, because only `Idle` ends a turn: when this
+        // regressed, every turn ran to its timeout with no parse error
+        // and no failed assertion anywhere — the value was simply
+        // absorbed as `Unknown` and never matched.
+        for wire in ["STATE_FULLY_IDLE", "STATE_IDLE"] {
+            let state: TrajectoryState = serde_json::from_value(json!(wire)).unwrap();
+            assert_eq!(
+                state,
+                TrajectoryState::Idle,
+                "{wire} must deserialize to the terminal Idle state"
+            );
+            assert!(!state.is_unknown(), "{wire} must not degrade to Unknown");
+        }
+        // The canonical (current-harness) spelling is what we re-emit.
+        assert_eq!(TrajectoryState::Idle.as_wire_str(), "STATE_FULLY_IDLE");
+
+        // New in 0.1.10, and deliberately *not* terminal — it means the
+        // trajectory is blocked on subtasks and will return to Running.
+        let waiting: TrajectoryState =
+            serde_json::from_value(json!("STATE_WAITING_FOR_TASKS")).unwrap();
+        assert_eq!(waiting, TrajectoryState::WaitingForTasks);
+        assert!(!waiting.is_unknown());
+
+        // A genuinely unrecognized state still degrades (Evergreen).
+        let bogus: TrajectoryState = serde_json::from_value(json!("STATE_FUTURE")).unwrap();
+        assert!(bogus.is_unknown());
+        assert_eq!(bogus.unknown_state_type(), Some("STATE_FUTURE"));
+    }
+
+    #[test]
+    fn output_event_reads_usage_from_both_harness_shapes() {
+        // 0.1.5 flat form.
+        let flat = r#"{"seqNum": "1", "usageMetadata": {"promptTokenCount": "10", "totalTokenCount": "20"}}"#;
+        let event: OutputEvent = serde_json::from_str(flat).unwrap();
+        let usage = event.usage_metadata.as_ref().expect("flat usage");
+        assert_eq!(usage.prompt_token_count, Some(10));
+        assert_eq!(usage.total_token_count, Some(20));
+
+        // 0.1.10 nested form: the aggregate lives under `total`, with a
+        // per-trajectory breakdown alongside it that we do not model.
+        let nested = r#"{"seqNum": "1", "usageUpdate": {"agents": [{"trajectoryId": "t1", "usage": {"totalTokenCount": "5"}}], "total": {"promptTokenCount": "10", "totalTokenCount": "20"}}}"#;
+        let event: OutputEvent = serde_json::from_str(nested).unwrap();
+        let usage = event.usage_metadata.as_ref().expect("nested usage");
+        assert_eq!(usage.prompt_token_count, Some(10));
+        assert_eq!(usage.total_token_count, Some(20));
+        // Consumed as envelope metadata, not misreported as an unknown
+        // oneof payload (the leftover-key arm would otherwise claim it).
+        assert!(
+            event.payload.is_none(),
+            "usageUpdate must not be read as a payload variant, got {:?}",
+            event.payload
+        );
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -242,14 +242,14 @@ impl Client {
     ///
     /// // Simple interaction
     /// let response = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Hello, world!")
     ///     .create()
     ///     .await?;
     ///
     /// // Stateful conversation (requires stored interaction)
     /// let response2 = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("What did I just say?")
     ///     .with_previous_interaction(response.id.as_ref().expect("stored interaction has id"))
     ///     .create()
@@ -289,7 +289,7 @@ impl Client {
     /// // Build a reusable request with the builder, then execute it.
     /// let request = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Hello, world!")
     ///     .build()?;
     ///
@@ -309,7 +309,7 @@ impl Client {
     /// let client = Client::builder("api_key".to_string()).build()?;
     /// let mut request = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Count to 5")
     ///     .build()?;
     /// request.stream = Some(true);
@@ -344,7 +344,7 @@ impl Client {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new("api_key".to_string());
     /// let request = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Hello!")
     ///     .build()?;
     ///
@@ -398,7 +398,7 @@ impl Client {
     /// let client = Client::new("api_key".to_string());
     ///
     /// let request = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Count to 5")
     ///     .build()?;
     ///
@@ -1299,7 +1299,7 @@ impl Client {
     ///
     /// // Use in interaction
     /// let response = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_content(vec![
     ///         Content::text("Describe this video"),
     ///         Content::from_file(&file),
@@ -1580,7 +1580,7 @@ impl Client {
     ///
     /// // Use in interaction
     /// let response = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_content(vec![
     ///         Content::text("Describe this video"),
     ///         Content::from_file(&file),

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use crate::GenaiError;
 use crate::http::context::HttpContext;
-use crate::wire::{LoudWirePrinter, WireInspector};
+use crate::wire::WireInspector;
 use reqwest::Client as ReqwestClient;
 use std::sync::Arc;
 use std::time::Duration;
@@ -40,14 +40,14 @@ impl std::fmt::Debug for Client {
     }
 }
 
-/// Appends a [`LoudWirePrinter`] when the `LOUD_WIRE` environment variable is
-/// set. Checked once at `Client` construction time.
+/// Appends a [`crate::wire::LoudWirePrinter`] when the `LOUD_WIRE`
+/// environment variable is set, filtered by its value. Checked once at
+/// `Client` construction time; shares
+/// [`crate::wire::env_inspector`] with the antigravity agent builder so
+/// the variable means the same thing on both paths.
 fn with_env_inspectors(mut inspectors: Vec<Arc<dyn WireInspector>>) -> Vec<Arc<dyn WireInspector>> {
-    if let Ok(raw) = std::env::var("LOUD_WIRE") {
-        // The value selects what to print — `1` keeps the historical
-        // firehose, anything else filters. See `wire::WireFilter`.
-        let filter = crate::wire::WireFilter::parse(&raw);
-        inspectors.push(Arc::new(LoudWirePrinter::with_filter(filter)));
+    if let Some(printer) = crate::wire::env_inspector() {
+        inspectors.push(Arc::new(printer));
     }
     inspectors
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -43,8 +43,11 @@ impl std::fmt::Debug for Client {
 /// Appends a [`LoudWirePrinter`] when the `LOUD_WIRE` environment variable is
 /// set. Checked once at `Client` construction time.
 fn with_env_inspectors(mut inspectors: Vec<Arc<dyn WireInspector>>) -> Vec<Arc<dyn WireInspector>> {
-    if std::env::var("LOUD_WIRE").is_ok() {
-        inspectors.push(Arc::new(LoudWirePrinter::new()));
+    if let Ok(raw) = std::env::var("LOUD_WIRE") {
+        // The value selects what to print — `1` keeps the historical
+        // firehose, anything else filters. See `wire::WireFilter`.
+        let filter = crate::wire::WireFilter::parse(&raw);
+        inspectors.push(Arc::new(LoudWirePrinter::with_filter(filter)));
     }
     inspectors
 }

--- a/src/content.rs
+++ b/src/content.rs
@@ -1676,7 +1676,7 @@ impl Content {
     /// let content = Content::from_file(&file);
     ///
     /// let response = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_content(vec![
     ///         Content::text("Describe this video"),
     ///         content,

--- a/src/content_tests.rs
+++ b/src/content_tests.rs
@@ -1281,7 +1281,7 @@ fn test_deserialize_response_with_built_in_tool_steps() {
     // Test deserializing a full response whose steps include built-in tools
     let response_json = r#"{
         "id": "interaction_789",
-        "model": "gemini-3-flash-preview",
+        "model": "gemini-3.6-flash",
         "steps": [
             {"type": "model_output", "content": [{"type": "text", "text": "Here's the result:"}]},
             {"type": "code_execution_call", "id": "call_abc", "arguments": {"code": "print(42)", "language": "python"}},
@@ -1314,7 +1314,7 @@ fn test_deserialize_response_with_unknown_steps() {
     // Test deserializing a full response that contains truly unknown steps
     let response_json = r#"{
         "id": "interaction_789",
-        "model": "gemini-3-flash-preview",
+        "model": "gemini-3.6-flash",
         "steps": [
             {"type": "model_output", "content": [{"type": "text", "text": "Result:"}]},
             {"type": "future_tool_result", "data": "some_data"},

--- a/src/http/files.rs
+++ b/src/http/files.rs
@@ -37,7 +37,7 @@
 //!
 //! // Use in interaction
 //! let response = client.interaction()
-//!     .with_model("gemini-3-flash-preview")
+//!     .with_model("gemini-3.6-flash")
 //!     .add_file(&file)
 //!     .with_text("Describe this video")
 //!     .create()

--- a/src/http/interactions.rs
+++ b/src/http/interactions.rs
@@ -578,7 +578,7 @@ mod tests {
     fn test_create_interaction_request_serialization() {
         // Verify request serialization works correctly
         let request = InteractionRequest {
-            model: Some("gemini-3-flash-preview".to_string()),
+            model: Some("gemini-3.6-flash".to_string()),
             agent: None,
             agent_config: None,
             input: InteractionInput::Text("Hello".to_string()),
@@ -600,7 +600,7 @@ mod tests {
         };
 
         let json = serde_json::to_string(&request).expect("Serialization should work");
-        assert!(json.contains("gemini-3-flash-preview"));
+        assert!(json.contains("gemini-3.6-flash"));
         assert!(json.contains("Hello"));
     }
 
@@ -609,7 +609,7 @@ mod tests {
         // Verify we can deserialize a typical revision 2026-05-20 response
         let response_json = r#"{
             "id": "test_interaction_123",
-            "model": "gemini-3-flash-preview",
+            "model": "gemini-3.6-flash",
             "steps": [{"type": "model_output", "content": [{"type": "text", "text": "Hi there!"}]}],
             "status": "completed"
         }"#;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //!     let response = client
 //!         .interaction()
-//!         .with_model("gemini-3-flash-preview")
+//!         .with_model("gemini-3.6-flash")
 //!         .with_text("Hello, Gemini!")
 //!         .create()
 //!         .await?;

--- a/src/multimodal.rs
+++ b/src/multimodal.rs
@@ -29,7 +29,7 @@
 //!    # let client = Client::new("key".to_string());
 //!    let response = client
 //!        .interaction()
-//!        .with_model("gemini-3-flash-preview")
+//!        .with_model("gemini-3.6-flash")
 //!        .with_content(vec![
 //!            Content::text("Describe this video"),
 //!            Content::from_uri_and_mime("gs://bucket/large-video.mp4", "video/mp4"),
@@ -50,7 +50,7 @@
 //!    let file = client.upload_file("large-video.mp4").await?;
 //!    let response = client
 //!        .interaction()
-//!        .with_model("gemini-3-flash-preview")
+//!        .with_model("gemini-3.6-flash")
 //!        .with_content(vec![
 //!            Content::text("Describe this video"),
 //!            Content::from_file(&file),
@@ -74,7 +74,7 @@
 //!
 //! let response = client
 //!     .interaction()
-//!     .with_model("gemini-3-flash-preview")
+//!     .with_model("gemini-3.6-flash")
 //!     .with_content(vec![
 //!         Content::text("What's in this image?"),
 //!         image,

--- a/src/request.rs
+++ b/src/request.rs
@@ -1212,7 +1212,7 @@ impl VideoConfig {
 /// let client = Client::new("api_key".to_string());
 ///
 /// let request = client.interaction()
-///     .with_model("gemini-3-flash-preview")
+///     .with_model("gemini-3.6-flash")
 ///     .with_text("Hello!")
 ///     .build()?;
 ///
@@ -1230,7 +1230,7 @@ impl VideoConfig {
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let client = Client::new("api_key".to_string());
 /// # let request = client.interaction()
-/// #     .with_model("gemini-3-flash-preview")
+/// #     .with_model("gemini-3.6-flash")
 /// #     .with_text("Hello!")
 /// #     .build()?;
 /// let response = client.execute(request).await?;
@@ -1247,7 +1247,7 @@ impl VideoConfig {
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let client = Client::new("api_key".to_string());
 /// # let request = client.interaction()
-/// #     .with_model("gemini-3-flash-preview")
+/// #     .with_model("gemini-3.6-flash")
 /// #     .with_text("Hello!")
 /// #     .build()?;
 /// let response = loop {
@@ -1262,7 +1262,7 @@ impl VideoConfig {
 /// ```
 #[derive(Clone, Serialize, Deserialize, Debug, Default, PartialEq)]
 pub struct InteractionRequest {
-    /// Model name (e.g., "gemini-3-flash-preview") - mutually exclusive with agent
+    /// Model name (e.g., "gemini-3.6-flash") - mutually exclusive with agent
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
 
@@ -1557,20 +1557,26 @@ impl ThinkingSummaries {
         }
     }
 
-    /// Convert to the agent_config wire format (THINKING_SUMMARIES_*).
+    /// Convert to the `agent_config` wire format (`"auto"` / `"none"`).
     ///
-    /// AgentConfig uses a different wire format than GenerationConfig:
-    /// - GenerationConfig: lowercase ("auto", "none")
-    /// - AgentConfig: SCREAMING_CASE ("THINKING_SUMMARIES_AUTO", "THINKING_SUMMARIES_NONE")
+    /// This used to emit the SCREAMING_CASE `THINKING_SUMMARIES_*` form,
+    /// which the API accepted when `DeepResearchConfig` was written.
+    /// Verified live 2026-08-10, it no longer does:
+    ///
+    /// ```text
+    /// The value 'THINKING_SUMMARIES_AUTO' is not supported for
+    /// 'agent_config.thinking_summaries'. Supported values: 'auto', 'none'.
+    /// ```
+    ///
+    /// So both contexts now take the lowercase spelling and this agrees
+    /// with [`Serialize`]. The seam is kept rather than inlined because
+    /// the two spellings diverged once and could again; deserialization
+    /// still accepts either form (Evergreen).
     #[must_use]
     pub fn to_agent_config_value(&self) -> serde_json::Value {
         match self {
-            ThinkingSummaries::Auto => {
-                serde_json::Value::String("THINKING_SUMMARIES_AUTO".to_string())
-            }
-            ThinkingSummaries::None => {
-                serde_json::Value::String("THINKING_SUMMARIES_NONE".to_string())
-            }
+            ThinkingSummaries::Auto => serde_json::Value::String("auto".to_string()),
+            ThinkingSummaries::None => serde_json::Value::String("none".to_string()),
             ThinkingSummaries::Unknown { summaries_type, .. } => {
                 // For unknown values, preserve the original format
                 serde_json::Value::String(summaries_type.clone())
@@ -1986,7 +1992,7 @@ impl From<DynamicConfig> for AgentConfig {
 /// error enumerates the supported config types as `dynamic`,
 /// `deep-research`, `code-mender`, `antigravity`). Setting `model` to a
 /// value the agent doesn't offer returns 404 `not_found` — including
-/// `gemini-3-flash-preview`, this crate's default model elsewhere. The
+/// `gemini-3.6-flash`, this crate's default model elsewhere. The
 /// agent's model catalog is not enumerable on a standard key, so leave
 /// `model` unset unless you know an accepted value.
 ///
@@ -2075,12 +2081,12 @@ mod tests {
         // AgentConfig uses THINKING_SUMMARIES_* format via to_agent_config_value()
         assert_eq!(
             ThinkingSummaries::Auto.to_agent_config_value(),
-            serde_json::Value::String("THINKING_SUMMARIES_AUTO".to_string())
+            serde_json::Value::String("auto".to_string())
         );
 
         assert_eq!(
             ThinkingSummaries::None.to_agent_config_value(),
-            serde_json::Value::String("THINKING_SUMMARIES_NONE".to_string())
+            serde_json::Value::String("none".to_string())
         );
     }
 
@@ -2128,7 +2134,7 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
         assert_eq!(value["type"], "deep-research");
-        assert_eq!(value["thinking_summaries"], "THINKING_SUMMARIES_AUTO");
+        assert_eq!(value["thinking_summaries"], "auto");
     }
 
     #[test]

--- a/src/request_builder/auto_functions.rs
+++ b/src/request_builder/auto_functions.rs
@@ -182,7 +182,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// // Functions are auto-discovered from registry
     /// let result = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("What's the weather in Tokyo?")
     ///     .create_with_auto_functions()
     ///     .await?;
@@ -217,7 +217,7 @@ impl<'a> InteractionBuilder<'a> {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("key".to_string());
     /// let result = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("...")
     ///     .with_max_function_call_loops(3)
     ///     .create_with_auto_functions()
@@ -249,7 +249,7 @@ impl<'a> InteractionBuilder<'a> {
     /// # let client = Client::new("key".to_string());
     /// // Per-API-call timeout (30s per model round)
     /// let result = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("What's the weather?")
     ///     .with_timeout(Duration::from_secs(30))
     ///     .create_with_auto_functions()
@@ -259,7 +259,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let result = tokio::time::timeout(
     ///     Duration::from_secs(60),
     ///     client.interaction()
-    ///         .with_model("gemini-3-flash-preview")
+    ///         .with_model("gemini-3.6-flash")
     ///         .with_text("What's the weather?")
     ///         .create_with_auto_functions()
     /// ).await??;
@@ -461,7 +461,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let client = Client::builder("api_key".to_string()).build()?;
     ///
     /// let mut stream = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("What's the weather in Tokyo?")
     ///     .create_stream_with_auto_functions();
     ///
@@ -520,7 +520,7 @@ impl<'a> InteractionBuilder<'a> {
     /// # let client = Client::new("key".to_string());
     /// // Per-chunk timeout (30s between chunks)
     /// let mut stream = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("What's the weather?")
     ///     .with_timeout(Duration::from_secs(30))
     ///     .create_stream_with_auto_functions();

--- a/src/request_builder/mod.rs
+++ b/src/request_builder/mod.rs
@@ -43,7 +43,7 @@ use futures_util::{StreamExt, stream::BoxStream};
 /// let client = Client::builder("api_key".to_string()).build()?;
 ///
 /// let response = client.interaction()
-///     .with_model("gemini-3-flash-preview")
+///     .with_model("gemini-3.6-flash")
 ///     .with_text("What is the capital of France?")
 ///     .create()
 ///     .await?;
@@ -62,7 +62,7 @@ use futures_util::{StreamExt, stream::BoxStream};
 /// # let input = "Hello";
 /// // Build common configuration, then conditionally add previous_interaction
 /// let mut builder = client.interaction()
-///     .with_model("gemini-3-flash-preview")
+///     .with_model("gemini-3.6-flash")
 ///     .with_system_instruction("You are a helpful assistant.")
 ///     .with_content(vec![Content::text(input)]);
 ///
@@ -278,7 +278,7 @@ impl<'a> InteractionBuilder<'a> {
         self
     }
 
-    /// Sets the model to use for this interaction (e.g., "gemini-3-flash-preview").
+    /// Sets the model to use for this interaction (e.g., "gemini-3.6-flash").
     ///
     /// Note: Mutually exclusive with `with_agent()`.
     #[must_use]
@@ -437,7 +437,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// // Simple single-turn message
     /// let response = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Hello!")
     ///     .create()
     ///     .await?;
@@ -448,7 +448,7 @@ impl<'a> InteractionBuilder<'a> {
     ///     Step::model_text("4"),
     /// ];
     /// let response = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_history(history)
     ///     .with_text("And times 3?")  // Appended as final user_input step
     ///     .create()
@@ -485,7 +485,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let client = Client::new("api-key".to_string());
     ///
     /// let response = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_system_instruction("You are a helpful assistant specializing in Rust")
     ///     .with_text("Hello!")
     ///     .create()
@@ -519,7 +519,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let client = Client::builder("api_key".to_string()).build()?;
     ///
     /// let response = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_content(vec![
     ///         Content::text("Describe this image"),
     ///         Content::image_uri("files/abc", "image/png"),
@@ -571,7 +571,7 @@ impl<'a> InteractionBuilder<'a> {
     ///     Step::user_text("And what's that times 3?"),
     /// ];
     /// let response = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_history(history)
     ///     .create()
     ///     .await?;
@@ -606,7 +606,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .conversation()
     ///         .user("What is 2+2?")
     ///         .model("2+2 equals 4.")
@@ -656,7 +656,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Hello")
     ///     .add_tool(ComputerUseConfig::new().excluding(vec!["download_file".to_string()]))
     ///     .add_tool(FileSearchConfig::new(vec!["docs".to_string()]).with_top_k(5))
@@ -702,7 +702,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// let builder = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("What's the temperature in Paris?")
     ///     .add_function(func);
     /// ```
@@ -730,7 +730,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// let builder = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("What's the weather and time?")
     ///     .add_functions(functions);
     /// ```
@@ -770,7 +770,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let service = Arc::new(MyService { db: Database::new() });
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_tool_service(service)
     ///     .with_text("Query the database for users")
     ///     .create_with_auto_functions()
@@ -800,7 +800,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Who won the 2024 World Series?")
     ///     .with_google_search()
     ///     .create()
@@ -840,7 +840,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Find coffee shops near Times Square")
     ///     .with_google_maps()
     ///     .create()
@@ -883,7 +883,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Calculate the factorial of 50")
     ///     .with_code_execution()
     ///     .create()
@@ -929,7 +929,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Summarize the content from https://example.com")
     ///     .with_url_context()
     ///     .create()
@@ -976,7 +976,7 @@ impl<'a> InteractionBuilder<'a> {
     /// ```
     ///
     /// Use this when you want the model to generate images. Requires a model
-    /// that supports image generation (e.g., `gemini-3-pro-image-preview`).
+    /// that supports image generation (e.g., `gemini-3.1-flash-image`).
     ///
     /// # Example
     ///
@@ -989,7 +989,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-pro-image-preview")
+    ///     .with_model("gemini-3.1-flash-image")
     ///     .with_text("A cute cat playing with yarn")
     ///     .with_image_output()
     ///     .create()
@@ -1165,7 +1165,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-pro-image-preview")
+    ///     .with_model("gemini-3.1-flash-image")
     ///     .with_text("Generate a landscape photo")
     ///     .with_image_config(config)
     ///     .create()
@@ -1243,7 +1243,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let client = Client::new("api-key".to_string());
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Transcribe the attached audio")
     ///     .with_transcription_config(
     ///         TranscriptionConfig::new().with_language_codes(["en-US"]),
@@ -1382,7 +1382,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let client = Client::new("api-key".to_string());
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Tell me about safety filters")
     ///     .with_safety_settings(vec![SafetySetting::new(
     ///         HarmCategory::Harassment,
@@ -1513,7 +1513,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Generate info for someone named Alice who is 30 and likes hiking")
     ///     .with_response_format(schema)
     ///     .create()
@@ -1540,7 +1540,7 @@ impl<'a> InteractionBuilder<'a> {
     /// # let client = Client::new("api-key".to_string());
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("What is the current weather in Tokyo?")
     ///     .with_google_search()
     ///     .with_response_format(json!({
@@ -1606,7 +1606,7 @@ impl<'a> InteractionBuilder<'a> {
     /// # let client = Client::new("api-key".to_string());
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-pro-image-preview")
+    ///     .with_model("gemini-3.1-flash-image")
     ///     .with_text("A labeled diagram of a volcano")
     ///     .with_response_formats(vec![
     ///         ResponseFormat::text_plain(),
@@ -1649,7 +1649,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let client = Client::builder("api-key".to_string()).build()?;
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Solve this step by step: 15 * 23")
     ///     .with_thinking_level(ThinkingLevel::Medium)
     ///     .create()
@@ -1685,7 +1685,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let client = Client::builder("api-key".to_string()).build()?;
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Solve this step by step: 15 * 23")
     ///     .with_thinking_level(ThinkingLevel::Medium)
     ///     .with_thinking_summaries(ThinkingSummaries::Auto)
@@ -1718,7 +1718,7 @@ impl<'a> InteractionBuilder<'a> {
     /// // Two requests with the same seed should produce the same output
     /// let response1 = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Generate a random number")
     ///     .with_seed(42)
     ///     .create()
@@ -1726,7 +1726,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// let response2 = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Generate a random number")
     ///     .with_seed(42)
     ///     .create()
@@ -1758,7 +1758,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let client = Client::builder("api-key".to_string()).build()?;
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Write a story")
     ///     .with_stop_sequences(vec!["THE END".to_string(), "---".to_string()])
     ///     .create()
@@ -1795,7 +1795,7 @@ impl<'a> InteractionBuilder<'a> {
     /// // Force the model to use a function
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Get weather in Tokyo")
     ///     .with_function_calling_mode(FunctionCallingMode::Any)
     ///     .create()
@@ -1804,7 +1804,7 @@ impl<'a> InteractionBuilder<'a> {
     /// // Use VALIDATED mode for guaranteed schema adherence
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Get weather in Tokyo")
     ///     .with_function_calling_mode(FunctionCallingMode::Validated)
     ///     .create()
@@ -1848,7 +1848,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let client = Client::builder("api-key".to_string()).build()?;
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Get weather in Tokyo")
     ///     .with_allowed_tools(vec!["get_weather".to_string()])
     ///     .create()
@@ -1879,7 +1879,7 @@ impl<'a> InteractionBuilder<'a> {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("key".to_string());
     /// let response = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Hello")
     ///     .with_service_tier(ServiceTier::Flex)
     ///     .create()
@@ -1901,7 +1901,7 @@ impl<'a> InteractionBuilder<'a> {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("key".to_string());
     /// let response = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Summarize the cached document")
     ///     .with_cached_content("cachedContents/xyz")
     ///     .create()
@@ -1974,7 +1974,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let client = Client::builder("api_key".to_string()).build()?;
     ///
     /// let response = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Complex multi-step task")
     ///     .with_max_function_call_loops(10)  // Allow up to 10 iterations
     ///     .create_with_auto_functions()
@@ -2025,7 +2025,7 @@ impl<'a> InteractionBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("What is the meaning of life?")
     ///     .with_timeout(Duration::from_secs(30))
     ///     .create()
@@ -2092,7 +2092,7 @@ impl<'a> InteractionBuilder<'a> {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("api_key".to_string());
     /// let mut stream = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Write a story")
     ///     .create_stream();
     ///
@@ -2124,7 +2124,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let client = Client::builder("api_key".to_string()).build()?;
     ///
     /// let mut stream = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Count to 5")
     ///     .create_stream();
     ///
@@ -2198,7 +2198,7 @@ impl<'a> InteractionBuilder<'a> {
     /// let client = Client::new("api_key".to_string());
     ///
     /// let request = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("Hello!")
     ///     .build()?;
     ///
@@ -2347,7 +2347,7 @@ impl<'a> InteractionBuilder<'a> {
 ///
 /// let response = client
 ///     .interaction()
-///     .with_model("gemini-3-flash-preview")
+///     .with_model("gemini-3.6-flash")
 ///     .conversation()
 ///         .user("What is the capital of France?")
 ///         .model("The capital of France is Paris.")
@@ -2381,7 +2381,7 @@ impl<'a> ConversationBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .conversation()
     ///         .user("Hello!")
     ///         .done()
@@ -2419,7 +2419,7 @@ impl<'a> ConversationBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .conversation()
     ///         .user("What is 2+2?")
     ///         .model("2+2 equals 4.")
@@ -2457,7 +2457,7 @@ impl<'a> ConversationBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .conversation()
     ///         .turn(role, "Dynamic message")
     ///         .done()
@@ -2491,7 +2491,7 @@ impl<'a> ConversationBuilder<'a> {
     ///
     /// let response = client
     ///     .interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .conversation()
     ///         .user("Hello!")
     ///         .done()  // Returns to InteractionBuilder

--- a/src/request_builder/tests.rs
+++ b/src/request_builder/tests.rs
@@ -61,10 +61,10 @@ fn test_interaction_builder_with_model() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello");
 
-    assert_eq!(builder.model.as_deref(), Some("gemini-3-flash-preview"));
+    assert_eq!(builder.model.as_deref(), Some("gemini-3.6-flash"));
     assert!(builder.agent.is_none());
     assert_eq!(builder.current_message.as_deref(), Some("Hello"));
 }
@@ -86,7 +86,7 @@ fn test_interaction_builder_with_previous_interaction() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Follow-up question")
         .with_previous_interaction("interaction_123");
 
@@ -101,7 +101,7 @@ fn test_interaction_builder_with_system_instruction() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_system_instruction("You are a helpful assistant");
 
@@ -125,7 +125,7 @@ fn test_interaction_builder_with_generation_config() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_generation_config(config.clone());
 
@@ -147,7 +147,7 @@ fn test_interaction_builder_with_function() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Call a function")
         .add_function(func);
 
@@ -160,7 +160,7 @@ fn test_interaction_builder_add_mcp_server() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Use MCP server")
         .add_tool(McpServerConfig::new(
             "my-server",
@@ -185,7 +185,7 @@ fn test_interaction_builder_with_multiple_mcp_servers() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Use multiple MCP servers")
         .add_tool(McpServerConfig::new("server-1", "https://mcp1.example.com"))
         .add_tool(McpServerConfig::new("server-2", "https://mcp2.example.com"));
@@ -204,7 +204,7 @@ fn test_interaction_builder_add_mcp_server_and_other_tools() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Use MCP and other tools")
         .add_tool(McpServerConfig::new("my-server", "https://mcp.example.com"))
         .with_google_search()
@@ -220,7 +220,7 @@ fn test_interaction_builder_with_google_maps() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Find coffee shops")
         .with_google_maps();
 
@@ -243,7 +243,7 @@ fn test_interaction_builder_add_tool_with_configs() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Test all configs")
         .add_tool(GoogleSearchConfig::new().with_search_types(vec![crate::SearchType::WebSearch]))
         .add_tool(GoogleMapsConfig::new().with_widget())
@@ -281,7 +281,7 @@ fn test_interaction_builder_with_store_disabled() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Temporary interaction")
         .with_store_disabled();
 
@@ -295,7 +295,7 @@ fn test_interaction_builder_with_store_enabled() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Stored interaction")
         .with_store_enabled();
 
@@ -307,21 +307,21 @@ fn test_interaction_builder_build_success() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello");
 
     let result = builder.build();
     assert!(result.is_ok());
 
     let request = result.unwrap();
-    assert_eq!(request.model.as_deref(), Some("gemini-3-flash-preview"));
+    assert_eq!(request.model.as_deref(), Some("gemini-3.6-flash"));
     assert!(matches!(request.input, crate::InteractionInput::Text(_)));
 }
 
 #[test]
 fn test_interaction_builder_build_missing_input() {
     let client = create_test_client();
-    let builder = client.interaction().with_model("gemini-3-flash-preview");
+    let builder = client.interaction().with_model("gemini-3.6-flash");
 
     let result = builder.build();
     assert!(result.is_err());
@@ -349,7 +349,7 @@ fn test_interaction_builder_with_response_modalities() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Generate an image")
         .with_response_modalities(vec!["IMAGE".to_string()]);
 
@@ -368,7 +368,7 @@ fn test_interaction_builder_with_max_function_call_loops() {
     // Test default value
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Test");
     assert_eq!(
         builder.max_function_call_loops,
@@ -378,7 +378,7 @@ fn test_interaction_builder_with_max_function_call_loops() {
     // Test custom value
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Test")
         .with_max_function_call_loops(10);
     assert_eq!(builder.max_function_call_loops, 10);
@@ -386,7 +386,7 @@ fn test_interaction_builder_with_max_function_call_loops() {
     // Test setting to minimum (1)
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Test")
         .with_max_function_call_loops(1);
     assert_eq!(builder.max_function_call_loops, 1);
@@ -402,7 +402,7 @@ fn test_builder_system_instruction_available() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_system_instruction("Be helpful");
 
@@ -415,12 +415,12 @@ fn test_builder_chained_preserves_fields() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_system_instruction("Be helpful")
         .with_previous_interaction("prev-123");
 
-    assert_eq!(builder.model.as_deref(), Some("gemini-3-flash-preview"));
+    assert_eq!(builder.model.as_deref(), Some("gemini-3.6-flash"));
     assert!(builder.system_instruction.is_some());
     assert_eq!(builder.previous_interaction_id.as_deref(), Some("prev-123"));
 }
@@ -430,7 +430,7 @@ fn test_builder_store_disabled_sets_store_false() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_store_disabled();
 
@@ -443,7 +443,7 @@ fn test_store_disabled_with_background_validation_error() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_background(true)
         .with_store_disabled();
@@ -466,7 +466,7 @@ fn test_store_disabled_with_previous_interaction_validation_error() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_previous_interaction("prev-123")
         .with_store_disabled();
@@ -488,7 +488,7 @@ fn test_builder_chained_can_set_background() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_previous_interaction("prev-123")
         .with_background(true);
@@ -501,7 +501,7 @@ fn test_builder_can_set_background() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_background(true);
 
@@ -526,7 +526,7 @@ async fn test_auto_functions_rejects_store_disabled() {
 
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Test")
         .add_function(func)
         .with_store_disabled() // This should be rejected
@@ -556,7 +556,7 @@ async fn test_stream_auto_functions_rejects_store_disabled() {
 
     let mut stream = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Test")
         .add_function(func)
         .with_store_disabled() // This should be rejected
@@ -587,7 +587,7 @@ async fn test_auto_functions_allows_store_true() {
 
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Test")
         .add_function(func)
         .with_store_enabled() // Explicitly true
@@ -615,7 +615,7 @@ async fn test_auto_functions_allows_store_default() {
 
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Test")
         .add_function(func)
         // No .with_store() call - uses default (None, which means true on server)
@@ -647,7 +647,7 @@ fn test_interaction_builder_with_history() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(steps);
 
     assert_eq!(builder.history.len(), 3);
@@ -666,14 +666,14 @@ fn test_interaction_builder_build_with_history() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(steps);
 
     let result = builder.build();
     assert!(result.is_ok());
 
     let request = result.unwrap();
-    assert_eq!(request.model.as_deref(), Some("gemini-3-flash-preview"));
+    assert_eq!(request.model.as_deref(), Some("gemini-3.6-flash"));
     assert!(matches!(request.input, crate::InteractionInput::Steps(_)));
 }
 
@@ -686,7 +686,7 @@ fn test_interaction_builder_with_single_step() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(steps);
 
     let result = builder.build();
@@ -704,7 +704,7 @@ fn test_with_history_then_with_text_composes_correctly() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(history)
         .with_text("How are you?");
 
@@ -733,7 +733,7 @@ fn test_with_text_then_with_history_composes_correctly() {
     // Order reversed - should produce same result
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("How are you?")
         .with_history(history);
 
@@ -761,7 +761,7 @@ fn test_history_and_text_order_independent() {
     // Build in one order
     let req1 = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(history.clone())
         .with_text("Current")
         .build()
@@ -770,7 +770,7 @@ fn test_history_and_text_order_independent() {
     // Build in reverse order
     let req2 = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Current")
         .with_history(history)
         .build()
@@ -790,7 +790,7 @@ fn test_conversation_builder_then_with_text() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .conversation()
         .user("What is 2+2?")
         .model("4")
@@ -819,7 +819,7 @@ fn test_with_text_only_produces_text_input() {
 
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello!")
         .build()
         .expect("Build should succeed");
@@ -841,7 +841,7 @@ fn test_with_history_only_produces_steps_input() {
 
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(history)
         .build()
         .expect("Build should succeed");
@@ -864,7 +864,7 @@ fn test_chained_preserves_history_and_current_message() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(history)
         .with_text("Current message")
         .with_previous_interaction("prev-123");
@@ -884,7 +884,7 @@ fn test_store_disabled_preserves_history_and_current_message() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(history)
         .with_text("Current message")
         .with_store_disabled();
@@ -908,7 +908,7 @@ fn test_with_content_cannot_combine_with_history() {
 
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_history(history)
         .with_content(content)
         .build();
@@ -937,7 +937,7 @@ fn test_with_content_and_text_merge() {
     // with_text() then with_content() - text should be prepended to content
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Describe this image")
         .with_content(vec![image_content.clone()])
         .build()
@@ -962,7 +962,7 @@ fn test_with_content_and_text_merge() {
     // with_content() then with_text() - should also work (order-independent)
     let request2 = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![image_content])
         .with_text("Describe this image")
         .build()
@@ -998,7 +998,7 @@ fn test_with_content_alone_works() {
 
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(content)
         .build();
 
@@ -1014,7 +1014,7 @@ fn test_conversation_builder_fluent_api() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .conversation()
         .user("What is 2+2?")
         .model("2+2 equals 4.")
@@ -1040,7 +1040,7 @@ fn test_conversation_builder_with_parts_content() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .conversation()
         .user(TurnContent::Parts(parts))
         .done();
@@ -1062,7 +1062,7 @@ fn test_conversation_builder_with_turn_method() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .conversation()
         .turn(Role::User, "Hello")
         .turn(Role::Model, "Hi!")
@@ -1076,7 +1076,7 @@ fn test_conversation_builder_empty() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .conversation()
         .done();
 
@@ -1089,13 +1089,13 @@ fn test_conversation_builder_preserves_model() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .conversation()
         .user("Hello")
         .done();
 
     // Model should be preserved through conversation builder
-    assert_eq!(builder.model.as_deref(), Some("gemini-3-flash-preview"));
+    assert_eq!(builder.model.as_deref(), Some("gemini-3.6-flash"));
 }
 
 #[test]
@@ -1103,7 +1103,7 @@ fn test_conversation_builder_preserves_system_instruction() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_system_instruction("Be helpful")
         .conversation()
         .user("Hello")
@@ -1120,7 +1120,7 @@ fn test_interaction_builder_with_file_search() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Search my documents")
         .add_tool(FileSearchConfig::new(vec![
             "stores/store-123".to_string(),
@@ -1150,7 +1150,7 @@ fn test_interaction_builder_with_file_search_config() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Search with config")
         .add_tool(
             FileSearchConfig::new(vec!["stores/my-docs".to_string()])
@@ -1185,7 +1185,7 @@ fn test_interaction_builder_with_file_search_and_other_tools() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Search and process")
         .add_tool(FileSearchConfig::new(vec!["stores/docs".to_string()]))
         .with_google_search()
@@ -1208,7 +1208,7 @@ fn test_interaction_builder_with_file_search_single_store() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Search single store")
         .add_tool(FileSearchConfig::new(vec!["stores/single".to_string()]));
 
@@ -1232,7 +1232,7 @@ fn test_with_image_config() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-pro-image-preview")
+        .with_model("gemini-3.1-flash-image")
         .with_text("Generate a landscape")
         .with_image_config(config);
 
@@ -1255,7 +1255,7 @@ fn test_with_image_config_merges_with_existing_generation_config() {
 
     let builder = client
         .interaction()
-        .with_model("gemini-3-pro-image-preview")
+        .with_model("gemini-3.1-flash-image")
         .with_text("Generate an image")
         .with_thinking_level(crate::ThinkingLevel::Low)
         .with_image_config(config);
@@ -1277,7 +1277,7 @@ fn test_interaction_builder_with_allowed_tools() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Get weather")
         .with_allowed_tools(vec!["get_weather".to_string(), "get_time".to_string()]);
 
@@ -1299,7 +1299,7 @@ fn test_interaction_builder_with_allowed_tools_preserves_mode() {
     let client = create_test_client();
     let builder = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Get weather")
         .with_tool_choice(ToolChoice::Mode(FunctionCallingMode::Any))
         .with_allowed_tools(vec!["get_weather".to_string()]);
@@ -1326,7 +1326,7 @@ fn test_builder_with_webhook_config() {
     let client = create_test_client();
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_webhook_config(
             WebhookConfig::new()
@@ -1349,7 +1349,7 @@ fn test_builder_with_environment_id() {
     let client = create_test_client();
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_environment("38aac1ae7f30fe9bd67afe42382ea041")
         .build()
@@ -1366,7 +1366,7 @@ fn test_builder_with_typed_remote_environment() {
     let client = create_test_client();
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_environment(
             RemoteEnvironment::new()
@@ -1394,7 +1394,7 @@ fn test_builder_with_response_format_raw_schema_maps_to_text() {
     let client = create_test_client();
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Generate data")
         .with_response_format(json!({
             "type": "object",
@@ -1444,7 +1444,7 @@ fn test_builder_with_response_formats_list() {
     let client = create_test_client();
     let request = client
         .interaction()
-        .with_model("gemini-3-pro-image-preview")
+        .with_model("gemini-3.1-flash-image")
         .with_text("A diagram")
         .with_response_formats(vec![
             ResponseFormat::text_plain(),
@@ -1563,7 +1563,7 @@ fn test_builder_retrieval_tool() {
     let client = create_test_client();
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Search internal docs")
         .add_tool(
             RetrievalConfig::new()
@@ -1603,7 +1603,7 @@ fn test_builder_deep_research_config_new_fields() {
     let value = serde_json::to_value(&request).unwrap();
     let config = &value["agent_config"];
     assert_eq!(config["type"], "deep-research");
-    assert_eq!(config["thinking_summaries"], "THINKING_SUMMARIES_AUTO");
+    assert_eq!(config["thinking_summaries"], "auto");
     assert_eq!(config["visualization"], "auto");
     assert_eq!(config["collaborative_planning"], true);
     assert_eq!(config["enable_bigquery_tool"], false);
@@ -1616,7 +1616,7 @@ fn test_builder_request_roundtrip_with_new_fields() {
     let client = create_test_client();
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_webhook_config(WebhookConfig::new().with_uris(vec!["https://x.example".into()]))
         .with_environment("env-1")
@@ -1642,7 +1642,7 @@ fn test_builder_safety_settings_replace_and_accumulate() {
     // add_* accumulates: two adds yield two entries, appended after with_*.
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .with_safety_settings(vec![SafetySetting::new(
             HarmCategory::HateSpeech,
@@ -1675,7 +1675,7 @@ fn test_builder_with_safety_settings_replaces() {
     let client = create_test_client();
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .add_safety_setting(SafetySetting::new(
             HarmCategory::HateSpeech,
@@ -1699,7 +1699,7 @@ fn test_builder_labels_merge_and_replace() {
     let client = create_test_client();
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .add_label("team", "search")
         .add_label("env", "ci")
@@ -1715,7 +1715,7 @@ fn test_builder_labels_merge_and_replace() {
     // with_labels replaces wholesale.
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .add_label("stale", "1")
         .with_labels([("fresh", "2")])
@@ -1733,7 +1733,7 @@ fn test_builder_with_transcription_config() {
     let client = create_test_client();
     let request = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Transcribe this")
         .with_generation_config(GenerationConfig {
             temperature: Some(0.5), // pre-existing generation_config must survive

--- a/src/request_tests.rs
+++ b/src/request_tests.rs
@@ -5,7 +5,7 @@ use super::*;
 #[test]
 fn test_serialize_create_interaction_request_with_model() {
     let request = InteractionRequest {
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         agent: None,
         agent_config: None,
         input: InteractionInput::Text("Hello, world!".to_string()),
@@ -29,7 +29,7 @@ fn test_serialize_create_interaction_request_with_model() {
     let json = serde_json::to_string(&request).expect("Serialization failed");
     let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
-    assert_eq!(value["model"], "gemini-3-flash-preview");
+    assert_eq!(value["model"], "gemini-3.6-flash");
     assert_eq!(value["input"], "Hello, world!");
     assert!(value.get("agent").is_none());
 }
@@ -171,7 +171,8 @@ fn test_tool_choice_allowed_tools_roundtrip() {
 #[test]
 fn test_thinking_summaries_serialization() {
     // GenerationConfig wire format uses lowercase (auto/none)
-    // Note: AgentConfig uses THINKING_SUMMARIES_* via to_agent_config_value() - see agent_config.rs tests
+    // Note: AgentConfig also uses the lowercase form via to_agent_config_value();
+    // the old THINKING_SUMMARIES_* spelling is still accepted on deserialize.
     assert_eq!(
         serde_json::to_string(&ThinkingSummaries::Auto).unwrap(),
         "\"auto\""
@@ -185,7 +186,7 @@ fn test_thinking_summaries_serialization() {
 
 #[test]
 fn test_thinking_summaries_deserialization() {
-    // Test wire format (THINKING_SUMMARIES_*)
+    // Deserialize accepts the legacy THINKING_SUMMARIES_* spelling.
     assert_eq!(
         serde_json::from_str::<ThinkingSummaries>("\"THINKING_SUMMARIES_AUTO\"").unwrap(),
         ThinkingSummaries::Auto
@@ -399,7 +400,7 @@ fn test_deep_research_config_serialization() {
     let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
     assert_eq!(value["type"], "deep-research");
-    assert_eq!(value["thinking_summaries"], "THINKING_SUMMARIES_AUTO");
+    assert_eq!(value["thinking_summaries"], "auto");
 }
 
 #[test]
@@ -527,10 +528,7 @@ fn test_agent_config_helper_methods() {
         .into();
     let value = config.as_value();
     assert_eq!(value.get("type").unwrap(), "deep-research");
-    assert_eq!(
-        value.get("thinking_summaries").unwrap(),
-        "THINKING_SUMMARIES_AUTO"
-    );
+    assert_eq!(value.get("thinking_summaries").unwrap(), "auto");
 }
 
 #[test]
@@ -566,10 +564,7 @@ fn test_create_interaction_request_with_agent_config() {
 
     assert_eq!(value["agent"], "deep-research-pro-preview-12-2025");
     assert_eq!(value["agent_config"]["type"], "deep-research");
-    assert_eq!(
-        value["agent_config"]["thinking_summaries"],
-        "THINKING_SUMMARIES_AUTO"
-    );
+    assert_eq!(value["agent_config"]["thinking_summaries"], "auto");
     assert_eq!(value["background"], true);
     assert_eq!(value["store"], true);
 }
@@ -579,7 +574,8 @@ fn test_create_interaction_request_with_agent_config() {
 /// This test explicitly documents the casing decisions:
 /// - `type` key uses kebab-case for values: "deep-research", "dynamic"
 /// - `thinking_summaries` key uses snake_case per API documentation
-/// - Values use SCREAMING_SNAKE_CASE: "THINKING_SUMMARIES_AUTO", "THINKING_SUMMARIES_NONE"
+/// - Values are lowercase: "auto", "none" (the API rejected the older
+///   SCREAMING_SNAKE_CASE spelling as of 2026-08-10)
 ///
 /// Note: The Gemini Interactions API uses snake_case for field names.
 #[test]
@@ -591,7 +587,7 @@ fn test_agent_config_field_naming_conventions() {
 
     let json = serde_json::to_string(&config).expect("Serialization failed");
 
-    // Expected: {"type":"deep-research","thinking_summaries":"THINKING_SUMMARIES_AUTO"}
+    // Expected: {"type":"deep-research","thinking_summaries":"auto"}
     assert!(
         json.contains("thinking_summaries"),
         "Field should be snake_case 'thinking_summaries', got: {}",
@@ -603,10 +599,10 @@ fn test_agent_config_field_naming_conventions() {
         json
     );
 
-    // Verify value uses wire format THINKING_SUMMARIES_*
+    // Verify value uses the lowercase wire format
     assert!(
-        json.contains(r#""THINKING_SUMMARIES_AUTO""#),
-        "ThinkingSummaries::Auto should serialize to 'THINKING_SUMMARIES_AUTO', got: {}",
+        json.contains(r#""auto""#),
+        "ThinkingSummaries::Auto should serialize to 'auto', got: {}",
         json
     );
 }
@@ -621,7 +617,7 @@ fn test_agent_config_field_naming_conventions() {
 #[test]
 fn test_interaction_request_roundtrip() {
     let original = InteractionRequest {
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         agent: None,
         agent_config: None,
         input: InteractionInput::Text("Hello, world!".to_string()),
@@ -685,7 +681,7 @@ fn test_interaction_request_roundtrip() {
 #[test]
 fn test_response_format_serializes_as_snake_case() {
     let request = InteractionRequest {
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         agent: None,
         agent_config: None,
         input: InteractionInput::Text("test".to_string()),
@@ -891,7 +887,7 @@ fn test_deep_research_config_full_wire_shape() {
 
     let value = serde_json::to_value(&config).unwrap();
     assert_eq!(value["type"], "deep-research");
-    assert_eq!(value["thinking_summaries"], "THINKING_SUMMARIES_AUTO");
+    assert_eq!(value["thinking_summaries"], "auto");
     assert_eq!(value["visualization"], "off");
     assert_eq!(value["collaborative_planning"], true);
     assert_eq!(value["enable_bigquery_tool"], true);
@@ -903,7 +899,7 @@ fn test_request_with_webhook_config_and_environment_wire_shape() {
     use crate::webhooks::WebhookConfig;
 
     let request = InteractionRequest {
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         agent: None,
         agent_config: None,
         input: InteractionInput::Text("Hello".to_string()),

--- a/src/response.rs
+++ b/src/response.rs
@@ -459,7 +459,7 @@ impl UsageMetadata {
 ///
 /// let response = client
 ///     .interaction()
-///     .with_model("gemini-3-flash-preview")
+///     .with_model("gemini-3.6-flash")
 ///     .with_text("A cat playing with yarn")
 ///     .with_image_output()
 ///     .create()
@@ -894,7 +894,7 @@ impl InteractionResponse {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("key".to_string());
     /// let first = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_text("What is 2+2?")
     ///     .create().await?;
     ///
@@ -903,7 +903,7 @@ impl InteractionResponse {
     /// history.push(Step::user_text("Now multiply that by 3"));
     ///
     /// let second = client.interaction()
-    ///     .with_model("gemini-3-flash-preview")
+    ///     .with_model("gemini-3.6-flash")
     ///     .with_history(history)
     ///     .create().await?;
     /// # Ok(())
@@ -1865,7 +1865,7 @@ mod tests {
         // possible prefix until the field is observed for real.
         let json = r#"{
             "id": "v1_abc123",
-            "model": "gemini-3-flash-preview",
+            "model": "gemini-3.6-flash",
             "status": "completed",
             "steps": [
                 {"type": "thought", "signature": "sig-1"},

--- a/src/response_tests.rs
+++ b/src/response_tests.rs
@@ -20,7 +20,7 @@ use super::*;
 fn test_deserialize_interaction_response_completed() {
     let response_json = r#"{
         "id": "interaction_123",
-        "model": "gemini-3-flash-preview",
+        "model": "gemini-3.6-flash",
         "steps": [
             {"type": "user_input", "content": [{"type": "text", "text": "Hello"}]},
             {"type": "model_output", "content": [{"type": "text", "text": "Hi there!"}]}
@@ -37,7 +37,7 @@ fn test_deserialize_interaction_response_completed() {
         serde_json::from_str(response_json).expect("Deserialization failed");
 
     assert_eq!(response.id.as_deref(), Some("interaction_123"));
-    assert_eq!(response.model.as_deref(), Some("gemini-3-flash-preview"));
+    assert_eq!(response.model.as_deref(), Some("gemini-3.6-flash"));
     assert_eq!(response.status, InteractionStatus::Completed);
     assert_eq!(response.steps.len(), 2);
     assert_eq!(response.as_text(), Some("Hi there!"));
@@ -132,7 +132,7 @@ fn test_usage_metadata_grounding_tool_count() {
 fn test_interaction_response_text() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_output(vec![
             Content::text("Hello"),
@@ -166,7 +166,7 @@ fn test_interaction_response_text_output_text_fallback() {
 fn test_interaction_response_thoughts() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::thought("sig_1"),
@@ -196,7 +196,7 @@ fn test_interaction_response_thoughts() {
 fn test_interaction_response_no_thoughts() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("Just text, no thoughts.")],
         ..Default::default()
@@ -230,7 +230,7 @@ fn test_interaction_response_thought_summaries() {
 fn test_interaction_response_function_calls() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::function_call(
@@ -272,7 +272,7 @@ fn test_function_call_step_without_id_becomes_unknown() {
     // Step::Unknown with the data preserved.
     let response_json = r#"{
         "id": "test_id",
-        "model": "gemini-3-flash-preview",
+        "model": "gemini-3.6-flash",
         "steps": [
             {"type": "function_call", "name": "get_weather", "arguments": {"location": "Tokyo"}}
         ],
@@ -294,7 +294,7 @@ fn test_function_call_step_without_id_becomes_unknown() {
 fn test_interaction_response_mixed_content() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::model_text("Let me check"),
@@ -315,7 +315,7 @@ fn test_interaction_response_mixed_content() {
 fn test_interaction_response_empty_steps() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![],
         ..Default::default()
@@ -334,7 +334,7 @@ fn test_interaction_response_empty_steps() {
 fn test_interaction_response_has_unknown() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::model_text("Here's the result:"),
@@ -363,7 +363,7 @@ fn test_interaction_response_has_unknown() {
 fn test_interaction_response_no_unknown() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("Normal response")],
         ..Default::default()
@@ -379,7 +379,7 @@ fn test_interaction_response_no_unknown() {
 fn test_step_summary() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::model_output(vec![Content::text("Text 1"), Content::text("Text 2")]),
@@ -417,7 +417,7 @@ fn test_step_summary() {
 fn test_step_summary_empty() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![],
         ..Default::default()
@@ -473,7 +473,7 @@ fn test_step_summary_display_with_unknown() {
 fn test_step_summary_with_built_in_tools() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::CodeExecutionCall {
@@ -538,7 +538,7 @@ fn test_step_summary_with_built_in_tools() {
 fn test_interaction_response_code_execution_helpers() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::model_text("Here's the code:"),
@@ -584,7 +584,7 @@ fn test_interaction_response_code_execution_helpers() {
 fn test_interaction_response_google_search_helpers() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::GoogleSearchResult {
@@ -610,7 +610,7 @@ fn test_interaction_response_google_search_helpers() {
 fn test_interaction_response_url_context_helpers() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::UrlContextResult {
             call_id: "ctx_123".to_string(),
@@ -635,7 +635,7 @@ fn test_interaction_response_url_context_helpers() {
 fn test_interaction_response_google_maps_helpers() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::GoogleMapsResult {
@@ -678,7 +678,7 @@ fn test_interaction_response_google_maps_helpers() {
 fn test_interaction_response_google_maps_helpers_empty() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("No maps here.")],
         ..Default::default()
@@ -694,7 +694,7 @@ fn test_interaction_response_google_maps_helpers_empty() {
 fn test_interaction_response_function_results() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::function_result(
@@ -744,7 +744,7 @@ fn test_interaction_response_function_results_text_payload() {
 fn test_interaction_response_no_function_results() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("Just text")],
         ..Default::default()
@@ -760,7 +760,7 @@ fn test_interaction_response_no_function_results() {
 fn test_interaction_response_google_search_call_helpers() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::GoogleSearchCall {
@@ -799,7 +799,7 @@ fn test_interaction_response_google_search_call_helpers() {
 fn test_interaction_response_no_google_search_calls() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("No search")],
         ..Default::default()
@@ -816,7 +816,7 @@ fn test_interaction_response_no_google_search_calls() {
 fn test_interaction_response_url_context_call_helpers() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::UrlContextCall {
@@ -853,7 +853,7 @@ fn test_interaction_response_url_context_call_helpers() {
 fn test_interaction_response_no_url_context_calls() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![],
         ..Default::default()
@@ -870,7 +870,7 @@ fn test_interaction_response_no_url_context_calls() {
 fn test_interaction_response_code_execution_call_singular() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::CodeExecutionCall {
@@ -902,7 +902,7 @@ fn test_interaction_response_code_execution_call_singular() {
 fn test_interaction_response_no_code_execution_call() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("No code")],
         ..Default::default()
@@ -915,7 +915,7 @@ fn test_interaction_response_no_code_execution_call() {
 fn test_interaction_response_code_execution_calls_plural() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::CodeExecutionCall {
@@ -951,7 +951,7 @@ fn test_interaction_response_code_execution_calls_plural() {
 fn test_interaction_response_code_execution_results() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::CodeExecutionResult {
@@ -990,7 +990,7 @@ fn test_interaction_response_code_execution_results() {
 fn test_interaction_response_no_code_execution_results() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("No code")],
         ..Default::default()
@@ -1005,7 +1005,7 @@ fn test_interaction_response_no_code_execution_results() {
 fn test_interaction_response_google_search_results() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::GoogleSearchResult {
@@ -1042,7 +1042,7 @@ fn test_interaction_response_google_search_results() {
 fn test_interaction_response_no_google_search_results() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![],
         ..Default::default()
@@ -1056,7 +1056,7 @@ fn test_interaction_response_no_google_search_results() {
 fn test_interaction_response_url_context_results() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::UrlContextResult {
@@ -1095,7 +1095,7 @@ fn test_interaction_response_url_context_results() {
 fn test_interaction_response_no_url_context_results() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![],
         ..Default::default()
@@ -1115,7 +1115,7 @@ fn test_interaction_response_complex_roundtrip() {
     // Build a response with many different step types
     let response = InteractionResponse {
         id: Some("complex-interaction-xyz".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             // Thought with signature (thinking models)
@@ -1205,7 +1205,7 @@ fn test_interaction_response_complex_roundtrip() {
         "Should contain ID"
     );
     assert!(
-        json_str.contains("gemini-3-flash-preview"),
+        json_str.contains("gemini-3.6-flash"),
         "Should contain model"
     );
     assert!(
@@ -1237,10 +1237,7 @@ fn test_interaction_response_complex_roundtrip() {
 
     // Verify top-level fields
     assert_eq!(deserialized.id.as_deref(), Some("complex-interaction-xyz"));
-    assert_eq!(
-        deserialized.model,
-        Some("gemini-3-flash-preview".to_string())
-    );
+    assert_eq!(deserialized.model, Some("gemini-3.6-flash".to_string()));
     assert_eq!(deserialized.status, InteractionStatus::Completed);
     assert_eq!(
         deserialized.previous_interaction_id,
@@ -1409,7 +1406,7 @@ fn test_interaction_response_deserialize_without_id() {
     // When store=false, the API response does not include an id field.
     // This test verifies that we can deserialize such responses correctly.
     let json = r#"{
-        "model": "gemini-3-flash-preview",
+        "model": "gemini-3.6-flash",
         "steps": [{"type": "model_output", "content": [{"type": "text", "text": "Hi there!"}]}],
         "status": "completed"
     }"#;
@@ -1418,7 +1415,7 @@ fn test_interaction_response_deserialize_without_id() {
         serde_json::from_str(json).expect("Deserialization should succeed without id");
 
     assert!(response.id.is_none(), "ID should be None when not present");
-    assert_eq!(response.model, Some("gemini-3-flash-preview".to_string()));
+    assert_eq!(response.model, Some("gemini-3.6-flash".to_string()));
     assert_eq!(response.status, InteractionStatus::Completed);
     assert!(!response.steps.is_empty());
 }
@@ -1429,7 +1426,7 @@ fn test_interaction_response_deserialize_with_id() {
     // This test verifies that we can still deserialize such responses correctly.
     let json = r#"{
         "id": "interaction-abc123",
-        "model": "gemini-3-flash-preview",
+        "model": "gemini-3.6-flash",
         "steps": [{"type": "model_output", "content": [{"type": "text", "text": "Hi there!"}]}],
         "status": "completed"
     }"#;
@@ -1442,7 +1439,7 @@ fn test_interaction_response_deserialize_with_id() {
         Some("interaction-abc123"),
         "ID should be present when included"
     );
-    assert_eq!(response.model, Some("gemini-3-flash-preview".to_string()));
+    assert_eq!(response.model, Some("gemini-3.6-flash".to_string()));
     assert_eq!(response.status, InteractionStatus::Completed);
 }
 
@@ -1452,7 +1449,7 @@ fn test_interaction_response_serialize_without_id() {
     // This uses skip_serializing_if to avoid "id": null in the output.
     let response = InteractionResponse {
         id: None,
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("Hello")],
         ..Default::default()
@@ -1472,7 +1469,7 @@ fn test_interaction_response_roundtrip_without_id() {
     // Verify roundtrip serialization works correctly when id is None.
     let original = InteractionResponse {
         id: None,
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("Test response")],
         ..Default::default()
@@ -1493,7 +1490,7 @@ fn test_interaction_response_roundtrip_without_id() {
 fn test_function_call_info_to_owned() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::function_call(
             "call_123",
@@ -1522,7 +1519,7 @@ fn test_owned_function_call_info_outlives_response() {
     let owned_calls: Vec<OwnedFunctionCallInfo> = {
         let response = InteractionResponse {
             id: Some("test_id".to_string()),
-            model: Some("gemini-3-flash-preview".to_string()),
+            model: Some("gemini-3.6-flash".to_string()),
             status: InteractionStatus::RequiresAction,
             steps: vec![
                 Step::function_call("call_1", "func_a", serde_json::json!({"x": 1})),
@@ -1618,7 +1615,7 @@ fn test_interaction_response_has_annotations() {
     // Response with annotations
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_output(vec![Content::Text {
             text: Some("According to the source, climate change is accelerating.".to_string()),
@@ -1640,7 +1637,7 @@ fn test_interaction_response_no_annotations() {
     // Response without annotations
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("Plain text without citations.")],
         ..Default::default()
@@ -1654,7 +1651,7 @@ fn test_interaction_response_empty_annotations_not_counted() {
     // Response with empty annotations array (should not count as having annotations)
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_output(vec![Content::Text {
             text: Some("Text with empty annotations.".to_string()),
@@ -1671,7 +1668,7 @@ fn test_interaction_response_all_annotations() {
     // Response with multiple text blocks, each with annotations
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::model_output(vec![Content::Text {
@@ -1715,7 +1712,7 @@ fn test_interaction_response_all_annotations_empty() {
     // Response with no annotations at all
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::model_text("No annotations here."),
@@ -1733,7 +1730,7 @@ fn test_interaction_response_all_annotations_skips_non_text() {
     // Verify all_annotations only looks at Text content, not other types
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::model_output(vec![
@@ -1771,7 +1768,7 @@ fn test_interaction_response_all_annotations_skips_non_text() {
 fn test_interaction_response_has_file_search_results() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::FileSearchResult {
             call_id: "call_123".to_string(),
@@ -1792,7 +1789,7 @@ fn test_interaction_response_has_file_search_results() {
 fn test_interaction_response_no_file_search_results() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("No file search here")],
         ..Default::default()
@@ -1805,7 +1802,7 @@ fn test_interaction_response_no_file_search_results() {
 fn test_interaction_response_file_search_results_extraction() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::FileSearchResult {
@@ -1854,7 +1851,7 @@ fn test_interaction_response_file_search_results_extraction() {
 fn test_interaction_response_file_search_results_empty_results() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::FileSearchResult {
             call_id: "call_empty".to_string(),
@@ -1880,7 +1877,7 @@ fn test_interaction_response_file_search_results_empty_results() {
 fn model_output_response(content: Vec<Content>) -> InteractionResponse {
     InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_output(content)],
         ..Default::default()
@@ -1994,7 +1991,7 @@ fn test_image_info_extension_none_mime_type_defaults_to_png() {
 fn test_images_iterator_returns_only_images_with_data() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::model_output(vec![
@@ -2019,7 +2016,7 @@ fn test_images_iterator_returns_only_images_with_data() {
 fn test_images_iterator_empty_when_no_images() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("Just text"), Step::thought("sig_thought")],
         ..Default::default()
@@ -2033,7 +2030,7 @@ fn test_images_iterator_empty_when_no_images() {
 fn test_images_iterator_empty_steps() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![],
         ..Default::default()
@@ -2079,7 +2076,7 @@ fn test_audios_iterator_returns_only_audios_with_data() {
 fn test_audios_iterator_empty_when_no_audios() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("Just text"), Step::thought("sig_thought")],
         ..Default::default()
@@ -2180,7 +2177,7 @@ fn test_has_audio_false_when_uri_only() {
 fn test_output_steps_returns_owned_steps() {
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![Step::model_text("Response text")],
         ..Default::default()
@@ -2200,7 +2197,7 @@ fn test_output_steps_extends_history() {
     // The documented multi-turn pattern: history.extend(response.output_steps())
     let response = InteractionResponse {
         id: Some("test_id".to_string()),
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         status: InteractionStatus::Completed,
         steps: vec![
             Step::thought("sig"),
@@ -2250,7 +2247,7 @@ fn test_deserialize_response_object_and_service_tier() {
     let wire = serde_json::json!({
         "id": "interaction_123",
         "object": "interaction",
-        "model": "gemini-3-flash-preview",
+        "model": "gemini-3.6-flash",
         "service_tier": "standard",
         "status": "completed",
         "steps": [
@@ -2290,7 +2287,7 @@ fn test_deserialize_response_webhook_config_echo() {
     let wire = serde_json::json!({
         "id": "interaction_123",
         "object": "interaction",
-        "model": "gemini-3-flash-preview",
+        "model": "gemini-3.6-flash",
         "status": "in_progress",
         "steps": [],
         "webhook_config": {

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -16,7 +16,7 @@
 //!
 //! let mut stream = client
 //!     .interaction()
-//!     .with_model("gemini-3-flash-preview")
+//!     .with_model("gemini-3.6-flash")
 //!     .with_text("What's the weather in London?")
 //!     .create_stream_with_auto_functions();
 //!
@@ -440,7 +440,7 @@ impl<'de> Deserialize<'de> for AutoFunctionStreamChunk {
 ///
 /// let mut stream = client
 ///     .interaction()
-///     .with_model("gemini-3-flash-preview")
+///     .with_model("gemini-3.6-flash")
 ///     .with_text("What's the weather in London?")
 ///     .create_stream_with_auto_functions();
 ///
@@ -706,7 +706,7 @@ mod duration_millis {
 /// # let client = Client::new("key".to_string());
 /// let result = client
 ///     .interaction()
-///     .with_model("gemini-3-flash-preview")
+///     .with_model("gemini-3.6-flash")
 ///     .with_text("What's the weather in London?")
 ///     .create_with_auto_functions()
 ///     .await?;
@@ -793,7 +793,7 @@ impl AutoFunctionResult {
 ///
 /// let mut stream = client
 ///     .interaction()
-///     .with_model("gemini-3-flash-preview")
+///     .with_model("gemini-3.6-flash")
 ///     .with_text("What's the weather in London?")
 ///     .create_stream_with_auto_functions();
 ///
@@ -1046,7 +1046,7 @@ mod tests {
         let result = AutoFunctionResult {
             response: crate::InteractionResponse {
                 id: Some("interaction-abc123".to_string()),
-                model: Some("gemini-3-flash-preview".to_string()),
+                model: Some("gemini-3.6-flash".to_string()),
                 steps: vec![
                     crate::Step::model_text("Based on the weather data:"),
                     crate::Step::model_text("Paris is 18°C and London is 15°C."),
@@ -1089,7 +1089,7 @@ mod tests {
             "Should contain interaction ID"
         );
         assert!(
-            json_str.contains("gemini-3-flash-preview"),
+            json_str.contains("gemini-3.6-flash"),
             "Should contain model name"
         );
         assert!(
@@ -1122,7 +1122,7 @@ mod tests {
         );
         assert_eq!(
             deserialized.response.model,
-            Some("gemini-3-flash-preview".to_string())
+            Some("gemini-3.6-flash".to_string())
         );
         assert_eq!(deserialized.response.status, InteractionStatus::Completed);
         assert_eq!(
@@ -1157,7 +1157,7 @@ mod tests {
         let result = AutoFunctionResult {
             response: crate::InteractionResponse {
                 id: Some("interaction-stuck".to_string()),
-                model: Some("gemini-3-flash-preview".to_string()),
+                model: Some("gemini-3.6-flash".to_string()),
                 steps: vec![crate::Step::function_call(
                     "call-stuck",
                     "get_weather",
@@ -1197,7 +1197,7 @@ mod tests {
         let legacy_json = r#"{
             "response": {
                 "id": "interaction-old",
-                "model": "gemini-3-flash-preview",
+                "model": "gemini-3.6-flash",
                 "steps": [],
                 "status": "completed"
             },
@@ -1221,7 +1221,7 @@ mod tests {
         // Create a MaxLoopsReached chunk
         let response = crate::InteractionResponse {
             id: Some("interaction-max-loops".to_string()),
-            model: Some("gemini-3-flash-preview".to_string()),
+            model: Some("gemini-3.6-flash".to_string()),
             steps: vec![crate::Step::function_call(
                 "call-pending",
                 "stuck_function",
@@ -1282,7 +1282,7 @@ mod tests {
         // Simulate MaxLoopsReached being yielded
         let response = crate::InteractionResponse {
             id: Some("max-loops-response".to_string()),
-            model: Some("gemini-3-flash-preview".to_string()),
+            model: Some("gemini-3.6-flash".to_string()),
             status: InteractionStatus::Completed,
             ..Default::default()
         };
@@ -1404,7 +1404,7 @@ mod tests {
         let chunk = AutoFunctionStreamChunk::ExecutingFunctions {
             response: crate::InteractionResponse {
                 id: Some("interaction-new".to_string()),
-                model: Some("gemini-3-flash-preview".to_string()),
+                model: Some("gemini-3.6-flash".to_string()),
                 status: InteractionStatus::Completed,
                 ..Default::default()
             },

--- a/src/streaming_tests.rs
+++ b/src/streaming_tests.rs
@@ -132,7 +132,7 @@ fn test_deserialize_interaction_completed_event() {
         "event_type": "interaction.completed",
         "interaction": {
             "id": "interaction_456",
-            "model": "gemini-3-flash-preview",
+            "model": "gemini-3.6-flash",
             "steps": [
                 {"type": "user_input", "content": [{"type": "text", "text": "Count to 3"}]},
                 {"type": "model_output", "content": [{"type": "text", "text": "1, 2, 3"}]}

--- a/src/triggers.rs
+++ b/src/triggers.rs
@@ -1055,7 +1055,7 @@ mod tests {
         // and that an agent-targeting interaction stays quiet.
         let messages = crate::test_subscriber::capture_messages(|| {
             let interaction = crate::request::InteractionRequest {
-                model: Some("gemini-3-flash-preview".to_string()),
+                model: Some("gemini-3.6-flash".to_string()),
                 input: InteractionInput::Text("Daily audit".to_string()),
                 ..Default::default()
             };

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -406,6 +406,13 @@ mod paint {
 /// | *anything else* | A WebSocket payload whose top-level key matches (e.g. `stepUpdate`, `toolCall`) |
 /// | `summary` | Modifier: one line per event instead of full bodies |
 ///
+/// A value that matches no category and no payload key selects **nothing**,
+/// so `LOUD_WIRE=0`, `false`, `off` and `verbose` all print silence. Note
+/// that this is a behavior change: the gate used to be "is the variable set
+/// at all", so those values previously produced the full firehose. If
+/// output has gone missing, an unrecognized selector is the first thing to
+/// check.
+///
 /// # Examples
 ///
 /// ```bash
@@ -505,12 +512,37 @@ impl WireFilter {
     }
 }
 
-/// Envelope bookkeeping present on every harness message, and therefore
-/// useless as a selector: matching on `seqNum` would keep the whole stream.
-/// Excluded from both selector matching and summary rendering so the two
-/// agree on what a message "is".
+/// The printer the `LOUD_WIRE` environment variable asks for, or `None`
+/// when the variable is unset.
+///
+/// Single source of truth for the env gate: both `Client` and the
+/// antigravity `AgentBuilder` install their zero-config inspector through
+/// this, so a filter means the same thing on either path. (They diverged
+/// once — the harness path re-implemented the gate as a bare `is_ok()` and
+/// silently ignored the filter, which is exactly the surface where
+/// filtering matters most.)
+pub(crate) fn env_inspector() -> Option<LoudWirePrinter> {
+    let raw = std::env::var("LOUD_WIRE").ok()?;
+    // The value selects what to print — `1` keeps the historical
+    // firehose, anything else filters. See `WireFilter`.
+    Some(LoudWirePrinter::with_filter(WireFilter::parse(&raw)))
+}
+
+/// Envelope bookkeeping that rides alongside a harness message rather
+/// than being one, and is therefore useless as a selector: matching on
+/// `seqNum` would keep the whole stream, and `usageUpdate` would keep
+/// every message that happens to carry usage.
+///
+/// Deliberately the same set the protocol deserializer strips before it
+/// picks the oneof arm (`OutputEvent::deserialize` removes `seqNum`,
+/// `timestampMicros` and the usage keys) — selection, summary rendering
+/// and deserialization should agree on what a message *is*. Excluded from
+/// both selector matching and summary rendering for that reason.
 fn is_envelope_key(key: &str) -> bool {
-    matches!(key, "seqNum" | "timestampMicros")
+    matches!(
+        key,
+        "seqNum" | "timestampMicros" | "usageMetadata" | "usageUpdate"
+    )
 }
 
 /// Pretty-prints wire events to stderr.
@@ -1069,6 +1101,20 @@ mod filter_tests {
         assert!(f.allows(&ws(json!({"stepUpdate": {}}))));
         let f = WireFilter::parse("seqNum");
         assert!(!f.allows(&ws(json!({"seqNum": "1", "toolCall": {}}))));
+
+        // Usage rides along with a message rather than being one, and the
+        // deserializer strips it before picking the oneof arm — so it must
+        // not select either, or it would keep every message carrying usage.
+        for envelope in ["usageUpdate", "usageMetadata"] {
+            let f = WireFilter::parse(envelope);
+            assert!(
+                !f.allows(&ws(json!({"stepUpdate": {}, envelope: {"total": {}}}))),
+                "{envelope:?} must not act as a selector"
+            );
+        }
+        // ...and the message it rides on still selects normally.
+        let f = WireFilter::parse("stepUpdate");
+        assert!(f.allows(&ws(json!({"stepUpdate": {}, "usageMetadata": {}}))));
     }
 
     #[test]
@@ -1089,7 +1135,34 @@ mod filter_tests {
         assert!(f.is_summary());
         assert!(f.allows(&ws(json!({"toolCall": {}}))));
         assert!(!f.allows(&request()));
+    }
 
+    #[test]
+    fn env_inspector_applies_the_filter_from_the_variable() {
+        use super::env_inspector;
+
+        // SAFETY: nextest runs each test in its own process, so this
+        // mutation is not visible to any other test.
+        unsafe { std::env::set_var("LOUD_WIRE", "toolCall,summary") };
+        let printer = env_inspector().expect("LOUD_WIRE set should yield a printer");
+        assert!(printer.filter.is_summary());
+        assert!(printer.filter.allows(&ws(json!({"toolCall": {}}))));
+        assert!(!printer.filter.allows(&request()));
+
+        // The historical spelling still means everything.
+        unsafe { std::env::set_var("LOUD_WIRE", "1") };
+        let printer = env_inspector().expect("printer");
+        assert_eq!(printer.filter, WireFilter::all());
+
+        unsafe { std::env::remove_var("LOUD_WIRE") };
+        assert!(
+            env_inspector().is_none(),
+            "an unset LOUD_WIRE must install nothing"
+        );
+    }
+
+    #[test]
+    fn summary_survives_an_on_value_in_either_order() {
         // Even alongside an "on" value, summary survives — in either order.
         // `summary` is a modifier, so token position must not change what
         // the value means.

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -403,7 +403,7 @@ mod paint {
 /// | `ws` | Every WebSocket message |
 /// | `harness` | Harness spawn and stderr lines |
 /// | `upload` | File-upload start/complete |
-/// | *anything else* | A WebSocket payload whose top-level key matches (e.g. `stepUpdate`, `toolCall`) |
+/// | *anything else* | A WebSocket payload whose top-level key matches (e.g. `stepUpdate`, `toolCall`), or whose *nested* key one level in matches (e.g. `mcpTool`, `runCommand` — the step actions that all live under `stepUpdate`) |
 /// | `summary` | Modifier: one line per event instead of full bodies |
 ///
 /// A value that matches no category and no payload key selects **nothing**,
@@ -505,9 +505,29 @@ impl WireFilter {
             _ => return false,
         };
         payload.as_object().is_some_and(|map| {
-            map.keys()
-                .filter(|k| !is_envelope_key(k))
-                .any(|key| self.selectors.contains(&key.to_ascii_lowercase()))
+            map.iter()
+                .filter(|(k, _)| !is_envelope_key(k))
+                .any(|(key, value)| {
+                    if self.selectors.contains(&key.to_ascii_lowercase()) {
+                        return true;
+                    }
+                    // ...and one level deeper, because the granularity a
+                    // reader usually wants is *which action* a step carried,
+                    // and every builtin action (`mcpTool`, `runCommand`,
+                    // `viewFile`, …) hides under the single `stepUpdate` key.
+                    // Without this, `LOUD_WIRE=mcpTool` silently matches
+                    // nothing — which is exactly what it did until an example
+                    // advertised it and printed silence.
+                    //
+                    // Deliberately only one level: deeper would start matching
+                    // leaf field names across unrelated messages, and the
+                    // selector list is not scoped by message type.
+                    value.as_object().is_some_and(|inner| {
+                        inner
+                            .keys()
+                            .any(|nested| self.selectors.contains(&nested.to_ascii_lowercase()))
+                    })
+                })
         })
     }
 }
@@ -630,10 +650,30 @@ impl LoudWirePrinter {
         payload.as_object().map_or_else(
             || "(non-object)".to_string(),
             |m| {
-                let keys: Vec<&str> = m
-                    .keys()
-                    .filter(|k| !is_envelope_key(k))
-                    .map(String::as_str)
+                let keys: Vec<String> = m
+                    .iter()
+                    .filter(|(k, _)| !is_envelope_key(k))
+                    .map(|(key, value)| {
+                        // Qualify with the nested object-valued key when
+                        // there is one: a bare "stepUpdate" says almost
+                        // nothing, while "stepUpdate/mcpTool" says which
+                        // action the step carried — and matches what a
+                        // nested selector selects on, so asking for
+                        // `mcpTool` no longer prints lines labelled
+                        // `stepUpdate`. Scalar fields (stepIndex, text,
+                        // state) are skipped, so message types without a
+                        // nested object render exactly as before.
+                        let action = value.as_object().and_then(|inner| {
+                            inner
+                                .iter()
+                                .find(|(_, v)| v.is_object())
+                                .map(|(k, _)| k.as_str())
+                        });
+                        match action {
+                            Some(action) => format!("{key}/{action}"),
+                            None => key.clone(),
+                        }
+                    })
                     .collect();
                 if keys.is_empty() {
                     "(no payload keys)".to_string()
@@ -1151,6 +1191,40 @@ mod filter_tests {
     }
 
     #[test]
+    fn nested_selectors_reach_step_actions() {
+        // The case this exists for: every builtin action lives one level
+        // under `stepUpdate`, so a top-level-only match made the most
+        // useful selector ("show me the MCP calls") match nothing.
+        let step_with_mcp = ws(json!({
+            "seqNum": "3",
+            "stepUpdate": {
+                "stepIndex": 2,
+                "mcpTool": {"serverName": "widgets", "toolName": "list_widgets"},
+            },
+        }));
+        let step_with_view = ws(json!({
+            "stepUpdate": {"stepIndex": 4, "viewFile": {"path": "/tmp/x"}},
+        }));
+
+        let f = WireFilter::parse("mcpTool");
+        assert!(f.allows(&step_with_mcp));
+        assert!(
+            !f.allows(&step_with_view),
+            "a nested selector must still discriminate between actions"
+        );
+
+        // The enclosing key keeps working, and still matches both.
+        let f = WireFilter::parse("stepUpdate");
+        assert!(f.allows(&step_with_mcp));
+        assert!(f.allows(&step_with_view));
+
+        // Only one level deep: a leaf inside the action is not a selector,
+        // or selectors would start colliding across unrelated messages.
+        let f = WireFilter::parse("serverName");
+        assert!(!f.allows(&step_with_mcp));
+    }
+
+    #[test]
     fn payload_keys_names_the_message_and_labels_the_empty_case() {
         use super::LoudWirePrinter;
 
@@ -1179,6 +1253,28 @@ mod filter_tests {
         assert_eq!(
             LoudWirePrinter::payload_keys(&json!("not an object")),
             "(non-object)"
+        );
+
+        // A step carrying an action is qualified with it, so summary lines
+        // say which action ran and agree with what a nested selector
+        // matched on.
+        assert_eq!(
+            LoudWirePrinter::payload_keys(&json!({
+                "seqNum": "3",
+                "stepUpdate": {
+                    "stepIndex": 2,
+                    "text": "List widgets",
+                    "mcpTool": {"serverName": "widgets"},
+                },
+            })),
+            "stepUpdate/mcpTool"
+        );
+        // Scalar-only payloads are unqualified, exactly as before.
+        assert_eq!(
+            LoudWirePrinter::payload_keys(&json!({
+                "trajectoryStateUpdate": {"state": "STATE_FULLY_IDLE", "trajectoryId": "t-0"},
+            })),
+            "trajectoryStateUpdate"
         );
     }
 

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -15,6 +15,16 @@
 //! LOUD_WIRE=1 cargo run --example simple_interaction
 //! ```
 //!
+//! `LOUD_WIRE` also accepts a comma-separated filter — see [`WireFilter`]
+//! for the syntax. `1` (and the other "on" spellings) keeps the historical
+//! everything-pretty-printed behavior; anything else narrows it:
+//!
+//! ```bash
+//! LOUD_WIRE=summary                # one line per event
+//! LOUD_WIRE=request,response       # HTTP only, no WebSocket noise
+//! LOUD_WIRE=toolCall,summary       # one harness message type, one line each
+//! ```
+//!
 //! For programmatic access, register inspectors on the client builder:
 //!
 //! ```no_run
@@ -368,6 +378,141 @@ mod paint {
 // LoudWirePrinter
 // =============================================================================
 
+// =============================================================================
+// WireFilter
+// =============================================================================
+
+/// Which events [`LoudWirePrinter`] should print, and how loudly.
+///
+/// Parsed from the `LOUD_WIRE` environment variable. The firehose is the
+/// right default for a single request, and the wrong one the moment a
+/// harness session is involved: a few turns produce thousands of
+/// pretty-printed lines, and finding the one message that matters means
+/// grepping raw JSON out of the scrollback.
+///
+/// # Syntax
+///
+/// `LOUD_WIRE` takes a comma-separated list. `1`, `true`, or any empty
+/// value means "everything, pretty-printed" — the historical behavior.
+///
+/// | Selector | Keeps |
+/// |----------|-------|
+/// | `request` | HTTP requests |
+/// | `response` | HTTP responses (status, body, error bodies) |
+/// | `sse` | SSE frames |
+/// | `ws` | Every WebSocket message |
+/// | `harness` | Harness spawn and stderr lines |
+/// | `upload` | File-upload start/complete |
+/// | *anything else* | A WebSocket payload whose top-level key matches (e.g. `stepUpdate`, `toolCall`) |
+/// | `summary` | Modifier: one line per event instead of full bodies |
+///
+/// # Examples
+///
+/// ```bash
+/// LOUD_WIRE=1                      # everything (unchanged)
+/// LOUD_WIRE=summary                # everything, one line each
+/// LOUD_WIRE=stepUpdate             # only stepUpdate WS payloads
+/// LOUD_WIRE=toolCall,summary       # tool calls, one line each
+/// LOUD_WIRE=request,response       # HTTP only, no WebSocket noise
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WireFilter {
+    /// Lowercased selectors. Empty means "keep everything".
+    selectors: Vec<String>,
+    /// One line per event instead of pretty-printed bodies.
+    summary: bool,
+}
+
+impl WireFilter {
+    /// A filter that keeps every event, pretty-printed.
+    #[must_use]
+    pub const fn all() -> Self {
+        Self {
+            selectors: Vec::new(),
+            summary: false,
+        }
+    }
+
+    /// Parses a `LOUD_WIRE` value. See the type docs for the syntax.
+    #[must_use]
+    pub fn parse(raw: &str) -> Self {
+        let mut selectors = Vec::new();
+        let mut summary = false;
+        for token in raw.split(',') {
+            let token = token.trim();
+            if token.is_empty() {
+                continue;
+            }
+            match token.to_ascii_lowercase().as_str() {
+                // The historical "on" values select everything.
+                "1" | "true" | "yes" | "on" | "all" => return Self::all_with_summary(summary),
+                "summary" => summary = true,
+                other => selectors.push(other.to_string()),
+            }
+        }
+        Self { selectors, summary }
+    }
+
+    fn all_with_summary(summary: bool) -> Self {
+        Self {
+            selectors: Vec::new(),
+            summary,
+        }
+    }
+
+    /// True when bodies should be collapsed to one line per event.
+    #[must_use]
+    pub const fn is_summary(&self) -> bool {
+        self.summary
+    }
+
+    /// The category name an event belongs to, for selector matching.
+    const fn category(event: &WireEvent) -> &'static str {
+        match event {
+            WireEvent::Request { .. } => "request",
+            WireEvent::ResponseStatus { .. }
+            | WireEvent::ResponseBody { .. }
+            | WireEvent::ErrorBody { .. } => "response",
+            WireEvent::SseFrame { .. } => "sse",
+            WireEvent::UploadStart { .. } | WireEvent::UploadComplete { .. } => "upload",
+            WireEvent::HarnessSpawn { .. } | WireEvent::HarnessStderr { .. } => "harness",
+            WireEvent::WsSend { .. } | WireEvent::WsReceive { .. } => "ws",
+        }
+    }
+
+    /// Whether this event should be printed.
+    #[must_use]
+    pub fn allows(&self, event: &WireEvent) -> bool {
+        if self.selectors.is_empty() {
+            return true;
+        }
+        let category = Self::category(event);
+        if self.selectors.iter().any(|s| s == category) {
+            return true;
+        }
+        // Otherwise a selector may name a WebSocket payload's oneof key,
+        // which is the granularity that actually matters when reading a
+        // harness session (`stepUpdate` vs `toolCall` vs `userInput`).
+        let payload = match event {
+            WireEvent::WsSend { payload, .. } | WireEvent::WsReceive { payload, .. } => payload,
+            _ => return false,
+        };
+        payload.as_object().is_some_and(|map| {
+            map.keys()
+                .filter(|k| !is_envelope_key(k))
+                .any(|key| self.selectors.contains(&key.to_ascii_lowercase()))
+        })
+    }
+}
+
+/// Envelope bookkeeping present on every harness message, and therefore
+/// useless as a selector: matching on `seqNum` would keep the whole stream.
+/// Excluded from both selector matching and summary rendering so the two
+/// agree on what a message "is".
+fn is_envelope_key(key: &str) -> bool {
+    matches!(key, "seqNum" | "timestampMicros")
+}
+
 /// Pretty-prints wire events to stderr.
 ///
 /// This is the inspector installed automatically when the `LOUD_WIRE`
@@ -382,14 +527,76 @@ mod paint {
 /// - Pretty-printed (and, with the `wire-color` feature, colored) JSON
 /// - Base64-heavy `data`/`signature` fields truncated to keep output readable
 /// - Secret fields (e.g. third-party retrieval `api_key`s) fully redacted
-#[derive(Debug, Clone, Copy, Default)]
-pub struct LoudWirePrinter;
+#[derive(Debug, Clone, Default)]
+pub struct LoudWirePrinter {
+    filter: WireFilter,
+}
 
 impl LoudWirePrinter {
-    /// Creates a new printer.
+    /// Creates a printer that prints every event, pretty-printed.
     #[must_use]
     pub const fn new() -> Self {
-        Self
+        Self {
+            filter: WireFilter::all(),
+        }
+    }
+
+    /// Creates a printer restricted by `filter` (see [`WireFilter`]).
+    #[must_use]
+    pub const fn with_filter(filter: WireFilter) -> Self {
+        Self { filter }
+    }
+
+    /// One-line rendering, for `LOUD_WIRE=summary`. Enough to see the
+    /// shape and order of a session without the bodies that make a
+    /// harness run unreadable.
+    fn print_summary(&self, event: &WireEvent) {
+        let (id, label, detail) = match event {
+            WireEvent::Request {
+                id, method, url, ..
+            } => (*id, "REQ", format!("{method} {url}")),
+            WireEvent::ResponseStatus { id, status } => (*id, "RES", format!("status {status}")),
+            WireEvent::ResponseBody { id, body } => (*id, "RES", Self::payload_keys(body)),
+            WireEvent::ErrorBody { id, status, body } => {
+                (*id, "ERR", format!("status {status}, {} bytes", body.len()))
+            }
+            WireEvent::SseFrame { id, event_type, .. } => {
+                (*id, "SSE", event_type.clone().unwrap_or_else(|| "-".into()))
+            }
+            WireEvent::UploadStart {
+                id,
+                file_name,
+                size_bytes,
+                ..
+            } => (*id, "UP", format!("{file_name} ({size_bytes} bytes)")),
+            WireEvent::UploadComplete { id, uri } => (*id, "UP", format!("done {uri}")),
+            WireEvent::HarnessSpawn { id, path, pid } => {
+                (*id, "HARNESS", format!("{path} (pid {pid:?})"))
+            }
+            WireEvent::HarnessStderr { id, line } => (*id, "STDERR", line.clone()),
+            WireEvent::WsSend { id, payload } => (*id, "WS>", Self::payload_keys(payload)),
+            WireEvent::WsReceive { id, payload } => (*id, "WS<", Self::payload_keys(payload)),
+        };
+        eprintln!(
+            "{} {} [#{id}] {label:<7} {detail}",
+            paint::bold("[LOUD_WIRE]"),
+            Self::timestamp()
+        );
+    }
+
+    /// The oneof key(s) of a WebSocket payload — the part that says what
+    /// the message *is*.
+    fn payload_keys(payload: &serde_json::Value) -> String {
+        payload.as_object().map_or_else(
+            || "(non-object)".to_string(),
+            |m| {
+                m.keys()
+                    .filter(|k| !is_envelope_key(k))
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            },
+        )
     }
 
     /// Format the current timestamp for log output (ISO 8601 UTC).
@@ -570,6 +777,13 @@ impl LoudWirePrinter {
 
 impl WireInspector for LoudWirePrinter {
     fn on_event(&self, event: &WireEvent) {
+        if !self.filter.allows(event) {
+            return;
+        }
+        if self.filter.is_summary() {
+            self.print_summary(event);
+            return;
+        }
         match event {
             WireEvent::Request {
                 id,
@@ -788,6 +1002,98 @@ impl WireInspector for TracingForwarder {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod filter_tests {
+    use super::{WireEvent, WireFilter};
+    use serde_json::json;
+
+    fn ws(payload: serde_json::Value) -> WireEvent {
+        WireEvent::WsReceive { id: 1, payload }
+    }
+
+    fn request() -> WireEvent {
+        WireEvent::Request {
+            id: 1,
+            method: "POST".into(),
+            url: "https://x/y".into(),
+            body: None,
+        }
+    }
+
+    #[test]
+    fn on_values_keep_everything() {
+        // The historical spellings must not start filtering anything out.
+        for raw in ["1", "true", "yes", "on", "all", "", "  "] {
+            let f = WireFilter::parse(raw);
+            assert!(f.allows(&request()), "{raw:?} should keep requests");
+            assert!(
+                f.allows(&ws(json!({"stepUpdate": {}}))),
+                "{raw:?} should keep ws"
+            );
+            assert!(!f.is_summary(), "{raw:?} should not imply summary");
+        }
+    }
+
+    #[test]
+    fn category_selectors_filter_by_event_kind() {
+        let f = WireFilter::parse("request");
+        assert!(f.allows(&request()));
+        assert!(!f.allows(&ws(json!({"stepUpdate": {}}))));
+        assert!(!f.allows(&WireEvent::ResponseStatus { id: 1, status: 200 }));
+
+        let f = WireFilter::parse("response");
+        assert!(f.allows(&WireEvent::ResponseStatus { id: 1, status: 200 }));
+        assert!(!f.allows(&request()));
+
+        // `ws` keeps every WebSocket message regardless of payload key.
+        let f = WireFilter::parse("ws");
+        assert!(f.allows(&ws(json!({"toolCall": {}}))));
+        assert!(f.allows(&ws(json!({"anythingElse": {}}))));
+        assert!(!f.allows(&request()));
+    }
+
+    #[test]
+    fn payload_key_selectors_pick_out_one_message_type() {
+        // The granularity that actually matters when reading a harness
+        // session: which oneof arm, not which transport.
+        let f = WireFilter::parse("stepUpdate");
+        assert!(f.allows(&ws(json!({"stepUpdate": {"text": "hi"}}))));
+        assert!(!f.allows(&ws(json!({"toolCall": {}}))));
+        assert!(!f.allows(&request()));
+
+        // Case-insensitive, and envelope metadata does not count as a match.
+        let f = WireFilter::parse("STEPUPDATE");
+        assert!(f.allows(&ws(json!({"stepUpdate": {}}))));
+        let f = WireFilter::parse("seqNum");
+        assert!(!f.allows(&ws(json!({"seqNum": "1", "toolCall": {}}))));
+    }
+
+    #[test]
+    fn selectors_compose_and_summary_is_a_modifier() {
+        let f = WireFilter::parse("stepUpdate,toolCall");
+        assert!(f.allows(&ws(json!({"stepUpdate": {}}))));
+        assert!(f.allows(&ws(json!({"toolCall": {}}))));
+        assert!(!f.allows(&ws(json!({"userInput": "x"}))));
+
+        // `summary` alone changes rendering, not selection.
+        let f = WireFilter::parse("summary");
+        assert!(f.is_summary());
+        assert!(f.allows(&request()));
+        assert!(f.allows(&ws(json!({"anything": {}}))));
+
+        // ...and combines with selectors.
+        let f = WireFilter::parse("toolCall,summary");
+        assert!(f.is_summary());
+        assert!(f.allows(&ws(json!({"toolCall": {}}))));
+        assert!(!f.allows(&request()));
+
+        // Even alongside an "on" value, summary survives.
+        let f = WireFilter::parse("summary,1");
+        assert!(f.is_summary());
+        assert!(f.allows(&request()));
     }
 }
 

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -1151,6 +1151,38 @@ mod filter_tests {
     }
 
     #[test]
+    fn payload_keys_names_the_message_and_labels_the_empty_case() {
+        use super::LoudWirePrinter;
+
+        // The case that matters: envelope and payload keys together must
+        // render as the payload alone, using the same `is_envelope_key`
+        // filter selection uses. A divergence between what a summary shows
+        // and what a selector matches would surface here first.
+        assert_eq!(
+            LoudWirePrinter::payload_keys(&json!({
+                "seqNum": "7",
+                "timestampMicros": "1",
+                "stepUpdate": {"text": "hi"},
+            })),
+            "stepUpdate"
+        );
+
+        // A real message whose only content is usage — not a bug, so it
+        // gets a label rather than a blank detail column. Neutral wording
+        // because this renders HTTP bodies too.
+        assert_eq!(
+            LoudWirePrinter::payload_keys(&json!({"seqNum": "7", "usageUpdate": {"total": {}}})),
+            "(no payload keys)"
+        );
+
+        // Non-JSON frames arrive as a bare string.
+        assert_eq!(
+            LoudWirePrinter::payload_keys(&json!("not an object")),
+            "(non-object)"
+        );
+    }
+
+    #[test]
     fn env_inspector_applies_the_filter_from_the_variable() {
         use super::env_inspector;
 

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -623,19 +623,22 @@ impl LoudWirePrinter {
     /// usage (a bare `seqNum` + `usageUpdate` deserializes with no payload
     /// at all), so an empty key list is a real message and not a bug.
     /// Label it rather than printing a blank detail column, which in the
-    /// one format meant for skimming would read as a rendering fault.
+    /// one format meant for skimming would read as a rendering fault. The
+    /// label stays neutral because this also renders HTTP response bodies,
+    /// where there is no envelope to speak of.
     fn payload_keys(payload: &serde_json::Value) -> String {
         payload.as_object().map_or_else(
             || "(non-object)".to_string(),
             |m| {
-                let keys: Vec<&String> = m.keys().filter(|k| !is_envelope_key(k)).collect();
+                let keys: Vec<&str> = m
+                    .keys()
+                    .filter(|k| !is_envelope_key(k))
+                    .map(String::as_str)
+                    .collect();
                 if keys.is_empty() {
-                    "(envelope only)".to_string()
+                    "(no payload keys)".to_string()
                 } else {
-                    keys.iter()
-                        .map(|k| k.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
+                    keys.join(", ")
                 }
             },
         )

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -519,14 +519,16 @@ impl WireFilter {
                     // nothing — which is exactly what it did until an example
                     // advertised it and printed silence.
                     //
-                    // Deliberately only one level: deeper would start matching
-                    // leaf field names across unrelated messages, and the
-                    // selector list is not scoped by message type.
-                    value.as_object().is_some_and(|inner| {
-                        inner
-                            .keys()
-                            .any(|nested| self.selectors.contains(&nested.to_ascii_lowercase()))
-                    })
+                    // Restricted to *object-valued* nested keys, which is
+                    // what an action is — matching a scalar like `text`
+                    // would print a line labelled with some unrelated
+                    // action rather than the key that matched. And only one
+                    // level: deeper would match leaf field names across
+                    // unrelated messages, since selectors are not scoped by
+                    // message type.
+                    nested_action_keys(value)
+                        .iter()
+                        .any(|nested| self.selectors.contains(&nested.to_ascii_lowercase()))
                 })
         })
     }
@@ -546,6 +548,23 @@ pub(crate) fn env_inspector() -> Option<LoudWirePrinter> {
     // The value selects what to print — `1` keeps the historical
     // firehose, anything else filters. See `WireFilter`.
     Some(LoudWirePrinter::with_filter(WireFilter::parse(&raw)))
+}
+
+/// The object-valued keys one level inside a payload value — the step
+/// *actions* (`mcpTool`, `runCommand`, `viewFile`, …), as opposed to a
+/// step's scalar fields (`text`, `stepIndex`, `state`).
+///
+/// Shared by selection and summary rendering so the two cannot disagree
+/// about what a line is "about": a nested selector matches exactly the
+/// keys the label can name.
+fn nested_action_keys(value: &serde_json::Value) -> Vec<&str> {
+    value.as_object().map_or_else(Vec::new, |inner| {
+        inner
+            .iter()
+            .filter(|(_, v)| v.is_object())
+            .map(|(k, _)| k.as_str())
+            .collect()
+    })
 }
 
 /// Envelope bookkeeping that rides alongside a harness message rather
@@ -626,8 +645,8 @@ impl LoudWirePrinter {
                 (*id, "HARNESS", format!("{path} (pid {pid:?})"))
             }
             WireEvent::HarnessStderr { id, line } => (*id, "STDERR", line.clone()),
-            WireEvent::WsSend { id, payload } => (*id, "WS>", Self::payload_keys(payload)),
-            WireEvent::WsReceive { id, payload } => (*id, "WS<", Self::payload_keys(payload)),
+            WireEvent::WsSend { id, payload } => (*id, "WS>", Self::ws_payload_keys(payload)),
+            WireEvent::WsReceive { id, payload } => (*id, "WS<", Self::ws_payload_keys(payload)),
         };
         eprintln!(
             "{} {} [#{id}] {label:<7} {detail}",
@@ -645,8 +664,19 @@ impl LoudWirePrinter {
     /// Label it rather than printing a blank detail column, which in the
     /// one format meant for skimming would read as a rendering fault. The
     /// label stays neutral because this also renders HTTP response bodies,
-    /// where there is no envelope to speak of.
+    /// where there is no envelope to speak of — and those stay unqualified
+    /// for the same reason (see `ws_payload_keys`).
     fn payload_keys(payload: &serde_json::Value) -> String {
+        Self::payload_keys_inner(payload, false)
+    }
+
+    /// `payload_keys` for harness WebSocket messages, qualifying a step
+    /// with the action it carried.
+    fn ws_payload_keys(payload: &serde_json::Value) -> String {
+        Self::payload_keys_inner(payload, true)
+    }
+
+    fn payload_keys_inner(payload: &serde_json::Value, qualify: bool) -> String {
         payload.as_object().map_or_else(
             || "(non-object)".to_string(),
             |m| {
@@ -654,24 +684,29 @@ impl LoudWirePrinter {
                     .iter()
                     .filter(|(k, _)| !is_envelope_key(k))
                     .map(|(key, value)| {
-                        // Qualify with the nested object-valued key when
-                        // there is one: a bare "stepUpdate" says almost
-                        // nothing, while "stepUpdate/mcpTool" says which
-                        // action the step carried — and matches what a
-                        // nested selector selects on, so asking for
-                        // `mcpTool` no longer prints lines labelled
-                        // `stepUpdate`. Scalar fields (stepIndex, text,
-                        // state) are skipped, so message types without a
-                        // nested object render exactly as before.
-                        let action = value.as_object().and_then(|inner| {
-                            inner
-                                .iter()
-                                .find(|(_, v)| v.is_object())
-                                .map(|(k, _)| k.as_str())
-                        });
-                        match action {
-                            Some(action) => format!("{key}/{action}"),
-                            None => key.clone(),
+                        // Qualify a harness message with the action it
+                        // carried: a bare "stepUpdate" says almost nothing,
+                        // while "stepUpdate/mcpTool" says which action ran
+                        // — and names exactly what a nested selector can
+                        // match, so asking for `mcpTool` cannot produce a
+                        // line labelled with a different key.
+                        //
+                        // WebSocket only. HTTP response bodies share this
+                        // renderer and have no actions, so qualifying them
+                        // would invent structure that isn't there
+                        // (`interaction/outputs`).
+                        if !qualify {
+                            return key.clone();
+                        }
+                        let actions = nested_action_keys(value);
+                        if actions.is_empty() {
+                            key.clone()
+                        } else {
+                            // Every action, not just the first: a step
+                            // carries one in practice, but naming only the
+                            // lowest-sorting of several would reintroduce
+                            // the label/selector mismatch in a rarer shape.
+                            format!("{key}/{}", actions.join("+"))
                         }
                     })
                     .collect();
@@ -1222,6 +1257,12 @@ mod filter_tests {
         // or selectors would start colliding across unrelated messages.
         let f = WireFilter::parse("serverName");
         assert!(!f.allows(&step_with_mcp));
+
+        // Scalar fields are not selectors either: `allows` and the summary
+        // qualifier share `nested_action_keys`, so a selector can only
+        // match something the label is able to name.
+        let f = WireFilter::parse("stepIndex");
+        assert!(!f.allows(&step_with_mcp));
     }
 
     #[test]
@@ -1259,7 +1300,7 @@ mod filter_tests {
         // say which action ran and agree with what a nested selector
         // matched on.
         assert_eq!(
-            LoudWirePrinter::payload_keys(&json!({
+            LoudWirePrinter::ws_payload_keys(&json!({
                 "seqNum": "3",
                 "stepUpdate": {
                     "stepIndex": 2,
@@ -1271,10 +1312,16 @@ mod filter_tests {
         );
         // Scalar-only payloads are unqualified, exactly as before.
         assert_eq!(
-            LoudWirePrinter::payload_keys(&json!({
+            LoudWirePrinter::ws_payload_keys(&json!({
                 "trajectoryStateUpdate": {"state": "STATE_FULLY_IDLE", "trajectoryId": "t-0"},
             })),
             "trajectoryStateUpdate"
+        );
+        // HTTP bodies go through the unqualified path, so a nested object
+        // in a response body is not dressed up as an action.
+        assert_eq!(
+            LoudWirePrinter::payload_keys(&json!({"interaction": {"outputs": {}}})),
+            "interaction"
         );
     }
 

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -618,15 +618,25 @@ impl LoudWirePrinter {
 
     /// The oneof key(s) of a WebSocket payload — the part that says what
     /// the message *is*.
+    ///
+    /// The harness does send messages whose only non-envelope content is
+    /// usage (a bare `seqNum` + `usageUpdate` deserializes with no payload
+    /// at all), so an empty key list is a real message and not a bug.
+    /// Label it rather than printing a blank detail column, which in the
+    /// one format meant for skimming would read as a rendering fault.
     fn payload_keys(payload: &serde_json::Value) -> String {
         payload.as_object().map_or_else(
             || "(non-object)".to_string(),
             |m| {
-                m.keys()
-                    .filter(|k| !is_envelope_key(k))
-                    .cloned()
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                let keys: Vec<&String> = m.keys().filter(|k| !is_envelope_key(k)).collect();
+                if keys.is_empty() {
+                    "(envelope only)".to_string()
+                } else {
+                    keys.iter()
+                        .map(|k| k.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                }
             },
         )
     }

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -802,7 +802,7 @@ mod tests {
                 method: "POST".to_string(),
                 url: "https://example.com/v1beta/interactions".to_string(),
                 body: Some(serde_json::json!({
-                    "model": "gemini-3-flash-preview",
+                    "model": "gemini-3.6-flash",
                     "data": "A".repeat(200),
                 })),
             },

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -438,6 +438,7 @@ impl WireFilter {
     pub fn parse(raw: &str) -> Self {
         let mut selectors = Vec::new();
         let mut summary = false;
+        let mut keep_all = false;
         for token in raw.split(',') {
             let token = token.trim();
             if token.is_empty() {
@@ -445,19 +446,18 @@ impl WireFilter {
             }
             match token.to_ascii_lowercase().as_str() {
                 // The historical "on" values select everything.
-                "1" | "true" | "yes" | "on" | "all" => return Self::all_with_summary(summary),
+                "1" | "true" | "yes" | "on" | "all" => keep_all = true,
                 "summary" => summary = true,
                 other => selectors.push(other.to_string()),
             }
         }
-        Self { selectors, summary }
-    }
-
-    fn all_with_summary(summary: bool) -> Self {
-        Self {
-            selectors: Vec::new(),
-            summary,
+        // Deliberately after the loop rather than an early return: `summary`
+        // is a modifier, so `1,summary` and `summary,1` must mean the same
+        // thing. Returning on the "on" arm would honor only the latter.
+        if keep_all {
+            selectors.clear();
         }
+        Self { selectors, summary }
     }
 
     /// True when bodies should be collapsed to one line per event.
@@ -1090,10 +1090,18 @@ mod filter_tests {
         assert!(f.allows(&ws(json!({"toolCall": {}}))));
         assert!(!f.allows(&request()));
 
-        // Even alongside an "on" value, summary survives.
-        let f = WireFilter::parse("summary,1");
-        assert!(f.is_summary());
-        assert!(f.allows(&request()));
+        // Even alongside an "on" value, summary survives — in either order.
+        // `summary` is a modifier, so token position must not change what
+        // the value means.
+        for raw in ["summary,1", "1,summary", "stepUpdate,1,summary"] {
+            let f = WireFilter::parse(raw);
+            assert!(f.is_summary(), "{raw:?} should keep summary");
+            assert!(f.allows(&request()), "{raw:?} should keep everything");
+            assert!(
+                f.allows(&ws(json!({"toolCall": {}}))),
+                "{raw:?}: an \"on\" value overrides narrower selectors"
+            );
+        }
     }
 }
 

--- a/src/wire_streaming.rs
+++ b/src/wire_streaming.rs
@@ -472,7 +472,7 @@ impl<'de> Deserialize<'de> for StreamChunk {
 ///
 /// ```ignore
 /// let mut last_event_id = None;
-/// let mut stream = client.interaction().with_model("gemini-3-flash-preview")
+/// let mut stream = client.interaction().with_model("gemini-3.6-flash")
 ///     .with_text("Count to 100").create_stream();
 ///
 /// while let Some(result) = stream.next().await {
@@ -764,7 +764,7 @@ mod tests {
     fn test_stream_chunk_completed_roundtrip() {
         let response = InteractionResponse {
             id: Some("test-interaction-123".to_string()),
-            model: Some("gemini-3-flash-preview".to_string()),
+            model: Some("gemini-3.6-flash".to_string()),
             steps: vec![Step::model_output(vec![Content::text("The answer is 4.")])],
             status: InteractionStatus::Completed,
             ..Default::default()
@@ -815,7 +815,7 @@ mod tests {
     fn test_stream_chunk_created_roundtrip() {
         let response = InteractionResponse {
             id: Some("test-interaction-456".to_string()),
-            model: Some("gemini-3-flash-preview".to_string()),
+            model: Some("gemini-3.6-flash".to_string()),
             status: InteractionStatus::InProgress,
             ..Default::default()
         };

--- a/tests/antigravity_harness.rs
+++ b/tests/antigravity_harness.rs
@@ -620,7 +620,12 @@ async fn test_antigravity_workspace_actions_and_post_tool_success() {
 fn harness_proto_enums() -> Option<serde_json::Value> {
     const SCRIPT: &str = r#"
 import json, importlib, sys
-from google.protobuf import descriptor_pb2
+print("interpreter: " + sys.executable, file=sys.stderr)
+try:
+    from google.protobuf import descriptor_pb2
+except Exception as exc:
+    print("google.protobuf is not importable: %r" % (exc,), file=sys.stderr)
+    sys.exit(4)
 mod = None
 for path in ("google.antigravity.proto.localharness_pb2",
              "google.antigravity.connections.local.localharness_pb2"):
@@ -645,21 +650,25 @@ walk(fdp.message_type)
 print(json.dumps(out))
 "#;
     // Point the interpreter at the *same* install the tests exercise.
-    // `ANTIGRAVITY_HARNESS_PATH` sits ahead of python3's own site-packages
-    // in the crate's discovery order, so when it is set, comparing against
-    // whatever `python3` happens to import would check a different wheel
-    // than the one under test. Deriving PYTHONPATH from the resolved
-    // harness path keeps the two in sync (and makes a venv install work
-    // with the system python3).
+    // Two of the crate's four discovery modes put the wheel somewhere the
+    // system `python3` will not import from on its own — an explicit
+    // `ANTIGRAVITY_HARNESS_PATH`, and a `localharness` that a pipx / `uv
+    // tool` install dropped on `PATH`. In both, comparing against whatever
+    // `python3` happens to import would check a different wheel than the
+    // one under test, or none at all. Deriving PYTHONPATH from the
+    // *resolved* harness path (rather than from the env var alone) keeps
+    // the guard aimed at the same install for every mode that has one.
     let mut command = std::process::Command::new("python3");
-    if let Ok(harness) = std::env::var("ANTIGRAVITY_HARNESS_PATH") {
-        // .../<site-packages>/google/antigravity/bin/localharness
-        let site_packages = std::path::Path::new(&harness)
-            .ancestors()
-            .nth(4)
-            .map(std::path::Path::to_path_buf);
-        if let Some(dir) = site_packages.filter(|d| d.join("google/antigravity").is_dir()) {
-            command.env("PYTHONPATH", dir);
+    if let Some(dir) = resolved_harness_site_packages() {
+        // Prepend, never replace: an inherited PYTHONPATH may be the only
+        // thing supplying `google.protobuf` when the wheel and protobuf
+        // live in different trees. Ours goes first so it still wins.
+        let mut entries = vec![dir];
+        if let Some(inherited) = std::env::var_os("PYTHONPATH") {
+            entries.extend(std::env::split_paths(&inherited));
+        }
+        if let Ok(joined) = std::env::join_paths(entries) {
+            command.env("PYTHONPATH", joined);
         }
     }
     let output = command.args(["-c", SCRIPT]).output().ok()?;
@@ -680,12 +689,75 @@ print(json.dumps(out))
     // pass that let the 0.1.5 -> 0.1.10 rename reach a release. The module
     // path has already moved once, and the bump that moves it again is
     // exactly the bump likely to carry a rename with it.
+    //
+    // Which fix to apply depends on *why* the dump failed, so say so — the
+    // script's exit code distinguishes "the module moved again" from "this
+    // interpreter has no wheel". The stderr passthrough names the
+    // interpreter in every case.
+    let diagnosis = match output.status.code() {
+        Some(3) => {
+            "localharness_pb2 was not importable under either known module path. The wheel \
+             most likely moved it again — add the new path to the list in harness_proto_enums."
+        }
+        Some(4) => {
+            "google.protobuf was not importable, so the descriptor could not be read at all. \
+             Install the harness wheel (which depends on protobuf) into the interpreter named \
+             below."
+        }
+        _ => {
+            "the descriptor dump failed before it could emit JSON. If this interpreter has no \
+             harness wheel installed, install one; otherwise read the traceback below."
+        }
+    };
     panic!(
-        "could not import localharness_pb2 from the installed wheel, so the protocol-drift \
-         guard checked nothing. Both known module paths were tried. If the wheel moved it \
-         again, update the path list in harness_proto_enums.\npython3 stderr: {}",
+        "the protocol-drift guard checked nothing: {diagnosis}\n\
+         Expected wheel: google-antigravity=={}\n\
+         python3 stderr: {}",
+        genai_rs::antigravity::SUPPORTED_HARNESS_VERSION,
         String::from_utf8_lossy(&output.stderr).trim()
     );
+}
+
+/// The site-packages directory of the harness install the *crate* would
+/// resolve, when that is somewhere `python3` would not look on its own.
+///
+/// Mirrors `discover_harness`'s order for the two modes that can point
+/// outside the default interpreter: the explicit
+/// `ANTIGRAVITY_HARNESS_PATH`, then `localharness` on `PATH`. The
+/// python3-site-packages mode needs no PYTHONPATH by construction, and the
+/// builder-path mode is not used by these tests.
+///
+/// `None` means "let python3 use its own site-packages", which is correct
+/// whenever the resolved binary does not sit inside a recognizable wheel
+/// layout.
+fn resolved_harness_site_packages() -> Option<std::path::PathBuf> {
+    let from_path_var = || {
+        let path_var = std::env::var_os("PATH")?;
+        std::env::split_paths(&path_var)
+            .map(|dir| dir.join("localharness"))
+            .find(|candidate| candidate.is_file())
+    };
+
+    let harness = std::env::var_os("ANTIGRAVITY_HARNESS_PATH")
+        .map(std::path::PathBuf::from)
+        .filter(|p| p.is_file())
+        .or_else(from_path_var)?;
+
+    // A `PATH` hit is usually a symlink into the venv that owns the wheel,
+    // so resolve it before reading the layout — the link's own directory
+    // says nothing about where the package lives.
+    let harness = harness.canonicalize().unwrap_or(harness);
+
+    // A wheel install lays the binary out as
+    // .../<site-packages>/google/antigravity/bin/localharness, so the
+    // fourth ancestor is site-packages. Anything else (a symlink farm, a
+    // hand-built binary) fails the layout check and falls back to None
+    // rather than pointing the interpreter somewhere useless.
+    harness
+        .ancestors()
+        .nth(4)
+        .map(std::path::Path::to_path_buf)
+        .filter(|d| d.join("google/antigravity").is_dir())
 }
 
 /// Compares a harness descriptor dump against what this crate models,

--- a/tests/antigravity_harness.rs
+++ b/tests/antigravity_harness.rs
@@ -1185,6 +1185,21 @@ def walk(msgs, prefix=""):
         full = prefix + mt.name
         for e in mt.enum_type:
             out[full + "." + e.name] = sorted(v.name for v in e.value)
+        # Message fields under a "fields:" prefix so one dump carries both
+        # kinds without colliding with an enum path, in the camelCase
+        # spelling the wire uses (which is what the crate matches on).
+        #
+        # CopyToProto does not populate json_name, so derive it the way
+        # proto3 does — lowerCamelCase of the snake_case name — and fall
+        # back to json_name only if it is actually set. Reading json_name
+        # alone yields a list of empty strings, which looks exactly like
+        # "the harness sends nothing" and reports drift for every field.
+        def json_name(f):
+            if f.json_name:
+                return f.json_name
+            head, *rest = f.name.split("_")
+            return head + "".join(w.capitalize() for w in rest)
+        out["fields:" + full] = sorted(json_name(f) for f in mt.field)
         walk(mt.nested_type, full + ".")
 for e in fdp.enum_type:
     out[e.name] = sorted(v.name for v in e.value)
@@ -1219,7 +1234,7 @@ print(json.dumps(out))
             serde_json::from_slice(&output.stdout).expect("descriptor dump should be JSON");
         assert!(
             parsed.as_object().is_some_and(|m| !m.is_empty()),
-            "the harness descriptor yielded no enums at all — the guard would have \
+            "the harness descriptor yielded nothing at all — the guard would have \
              checked nothing"
         );
         return Some(parsed);
@@ -1375,6 +1390,77 @@ fn find_enum_drift(harness: &serde_json::Value, modeled: &[(&str, &[&str])]) -> 
     drift
 }
 
+/// Compares harness message *fields* against the wire names this crate
+/// reads by hand, returning one line per field that has gone missing.
+///
+/// Enum-value drift and field drift are different failure modes, and the
+/// 0.1.5 -> 0.1.10 upgrade shipped one of each: `STATE_IDLE` ->
+/// `STATE_FULLY_IDLE` (a value) and `usageMetadata` -> `usageUpdate` (a
+/// field). A guard covering only the first would have caught only half of
+/// the break it was written for.
+///
+/// Deliberately one-directional, like the enum check: a field the harness
+/// has that the crate ignores is not drift, but a field the crate reads
+/// that the harness no longer has means a `get()` silently returning
+/// `None` forever.
+fn find_field_drift(harness: &serde_json::Value, modeled: &[(&str, &[&str])]) -> Vec<String> {
+    let mut drift = Vec::new();
+    for (message, required) in modeled {
+        let key = format!("fields:{message}");
+        let Some(fields) = harness.get(&key).and_then(|v| v.as_array()) else {
+            drift.push(format!(
+                "{message}: not present in the harness descriptor — the message was \
+                 renamed or removed"
+            ));
+            continue;
+        };
+        let present: Vec<&str> = fields
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect();
+        let missing: Vec<&&str> = required.iter().filter(|f| !present.contains(f)).collect();
+        if !missing.is_empty() {
+            drift.push(format!(
+                "{message}: this crate reads {missing:?}, which the harness no longer \
+                 sends (the read silently yields None); harness has = {present:?}"
+            ));
+        }
+    }
+    drift
+}
+
+#[test]
+fn field_drift_detector_catches_the_usage_rename() {
+    // The other half of the 0.1.10 break, replayed: the crate reads
+    // `usageMetadata`, the harness renamed it to `usageUpdate`, and token
+    // accounting silently zeroed.
+    let harness = serde_json::json!({
+        "fields:OutputEvent": ["seqNum", "timestampMicros", "usageUpdate", "stepUpdate"],
+    });
+    let drift = find_field_drift(
+        &harness,
+        &[("OutputEvent", &["seqNum", "usageMetadata"] as &[&str])],
+    );
+    assert_eq!(drift.len(), 1, "expected one drift line, got {drift:?}");
+    assert!(
+        drift[0].contains("usageMetadata"),
+        "the report must name the field that vanished: {}",
+        drift[0]
+    );
+
+    // A field the harness added but the crate ignores is not drift.
+    let quiet = find_field_drift(&harness, &[("OutputEvent", &["seqNum"] as &[&str])]);
+    assert!(
+        quiet.is_empty(),
+        "extra harness fields are not drift: {quiet:?}"
+    );
+
+    // A renamed *message* is reported rather than passing vacuously.
+    let gone = find_field_drift(&harness, &[("StepUpdate", &["mcpTool"] as &[&str])]);
+    assert_eq!(gone.len(), 1);
+    assert!(gone[0].contains("not present"));
+}
+
 #[test]
 fn drift_detector_catches_the_0_1_10_rename() {
     // The exact shape of the bug this guard exists for: the harness
@@ -1467,11 +1553,52 @@ async fn test_antigravity_protocol_enums_have_not_drifted() {
         ),
     ];
 
-    let drift = find_enum_drift(&harness, &modeled);
+    let mut drift = find_enum_drift(&harness, &modeled);
+
+    // Field names the crate reads by hand rather than through serde's
+    // derive — every one of these is a `map.remove(..)` / `get(..)` on a
+    // string literal, so a rename turns into a silent `None` rather than a
+    // parse error. `usageMetadata` is listed because it is still read as
+    // the pre-0.1.10 spelling; if the harness ever drops it entirely, the
+    // alias handling is what needs revisiting.
+    let fields: Vec<(&str, &[&str])> = vec![
+        (
+            "OutputEvent",
+            &[
+                "seqNum",
+                "timestampMicros",
+                "usageUpdate",
+                "stepUpdate",
+                "trajectoryStateUpdate",
+                "toolCall",
+                "initializeConversationResponse",
+                "callHookRequest",
+                "sessionEndResponse",
+            ],
+        ),
+        // Every InputEvent arm this crate can send. `config` is
+        // deliberately absent: the init message is not an InputEvent arm,
+        // which the guard caught when this list first claimed otherwise.
+        (
+            "InputEvent",
+            &[
+                "userInput",
+                "complexUserInput",
+                "toolConfirmation",
+                "toolResponse",
+                "questionResponse",
+                "haltRequest",
+                "automatedTrigger",
+                "callHookResponse",
+                "sessionEndRequest",
+            ],
+        ),
+    ];
+    drift.extend(find_field_drift(&harness, &fields));
 
     assert!(
         drift.is_empty(),
-        "harness protocol drift detected — update the wire enums in \
+        "harness protocol drift detected — update the wire enums/fields in \
          src/antigravity/protocol.rs (and docs/ENUM_WIRE_FORMATS.md):\n  {}",
         drift.join("\n  ")
     );

--- a/tests/antigravity_harness.rs
+++ b/tests/antigravity_harness.rs
@@ -1558,9 +1558,15 @@ async fn test_antigravity_protocol_enums_have_not_drifted() {
     // Field names the crate reads by hand rather than through serde's
     // derive — every one of these is a `map.remove(..)` / `get(..)` on a
     // string literal, so a rename turns into a silent `None` rather than a
-    // parse error. `usageMetadata` is listed because it is still read as
-    // the pre-0.1.10 spelling; if the harness ever drops it entirely, the
-    // alias handling is what needs revisiting.
+    // parse error.
+    //
+    // `usageMetadata` is deliberately absent even though the crate still
+    // reads it: it is pre-0.1.10 back-compat, 0.1.10 descriptors no longer
+    // carry the field, and listing it would make this guard fail forever
+    // on a spelling we keep only for older harnesses. The guard is
+    // one-directional — it asks "can the harness still send what we read",
+    // not "do we read everything it sends" — so a legacy alias belongs
+    // outside it.
     let fields: Vec<(&str, &[&str])> = vec![
         (
             "OutputEvent",

--- a/tests/antigravity_harness.rs
+++ b/tests/antigravity_harness.rs
@@ -698,8 +698,6 @@ async fn test_antigravity_cancel_handle_halts_an_in_flight_turn() {
         return;
     };
 
-    /// How long after the turn starts the halt is sent.
-    const CANCEL_AFTER: std::time::Duration = std::time::Duration::from_secs(3);
     /// The turn must end promptly after the halt. Generous enough to
     /// absorb a slow round trip, far below both the turn timeout and how
     /// long the un-cancelled prompt would take.
@@ -719,14 +717,33 @@ async fn test_antigravity_cancel_handle_halts_an_in_flight_turn() {
 
     // Taken *before* the stream borrows the agent — the handle is the only
     // way to reach the session while a turn is in flight.
+    //
+    // The halt fires on accumulated output rather than on a timer: a fixed
+    // delay races the model, and losing that race ("it answered before we
+    // cancelled") is an inconclusive run reported as a defect. Keying off
+    // real output means the turn is provably mid-generation when the halt
+    // is sent.
+    //
+    // The threshold is deliberately not "the first delta" — the harness
+    // emits a step before the upstream request is even in flight, and
+    // halting there cancelled the POST rather than a running generation.
+    // Any real answer to this prompt clears this bar many times over, so
+    // failing to reach it means something is broken, not merely fast.
+    /// Characters of streamed text/thinking to see before halting.
+    const OUTPUT_BEFORE_CANCEL: usize = 200;
+
     let handle = agent.cancel_handle();
-    tokio::spawn(async move {
-        tokio::time::sleep(CANCEL_AFTER).await;
-        let _ = handle.cancel().await;
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+    let canceller = tokio::spawn(async move {
+        if started_rx.await.is_err() {
+            // Stream ended before generating enough to halt.
+            return false;
+        }
+        handle.cancel().await.is_ok()
     });
 
     let started = std::time::Instant::now();
-    let (finished, outcome) = {
+    let (finished, produced, outcome) = {
         let mut stream = agent
             .send_streaming(
                 "Write an extremely detailed 3000-word essay about the history of \
@@ -735,10 +752,21 @@ async fn test_antigravity_cancel_handle_halts_an_in_flight_turn() {
             .await
             .expect("stream");
 
+        let mut started_tx = Some(started_tx);
         let mut finished = false;
+        let mut produced = 0usize;
         let mut outcome = Ok(());
         while let Some(event) = stream.next().await {
             match event {
+                Ok(AgentEvent::TextDelta(chunk) | AgentEvent::ThinkingDelta(chunk)) => {
+                    produced += chunk.chars().count();
+                    // Fire once, when generation is demonstrably underway.
+                    if produced >= OUTPUT_BEFORE_CANCEL
+                        && let Some(tx) = started_tx.take()
+                    {
+                        let _ = tx.send(());
+                    }
+                }
                 Ok(AgentEvent::Finished(_)) => {
                     finished = true;
                     break;
@@ -750,9 +778,17 @@ async fn test_antigravity_cancel_handle_halts_an_in_flight_turn() {
                 }
             }
         }
-        (finished, outcome)
+        (finished, produced, outcome)
     };
     let elapsed = started.elapsed();
+    let cancel_sent = canceller.await.expect("canceller task");
+
+    assert!(
+        cancel_sent,
+        "the turn streamed only {produced} chars, below the \
+         {OUTPUT_BEFORE_CANCEL} needed before halting, so no halt was sent — \
+         this run proves nothing about cancellation"
+    );
 
     // The assertion that actually proves cancellation: the turn stopped
     // long before it would have finished on its own, and long before the
@@ -761,11 +797,6 @@ async fn test_antigravity_cancel_handle_halts_an_in_flight_turn() {
         elapsed < MUST_END_WITHIN,
         "the turn ran {elapsed:?}, past the {MUST_END_WITHIN:?} bound — the \
          halt did not stop it"
-    );
-    assert!(
-        elapsed >= CANCEL_AFTER,
-        "the turn ended in {elapsed:?}, before the halt was even sent — the \
-         model answered too fast for this test to prove anything"
     );
 
     match outcome {
@@ -786,6 +817,105 @@ async fn test_antigravity_cancel_handle_halts_an_in_flight_turn() {
         }
         Err(other) => panic!("unexpected error from a cancelled turn: {other:?}"),
     }
+
+    agent.shutdown().await.expect("shutdown");
+}
+
+/// The `on_questions` hook end to end: the harness's `ask_question`
+/// builtin must reach the hook, and the hook's answer must get back into
+/// the turn well enough for the model to act on it.
+///
+/// Without a hook the crate replies "unanswered" to every question, which
+/// never deadlocks but also never proves the reply path works — so the
+/// assertion is that the *answer* came back, not merely that a question
+/// arrived.
+#[tokio::test]
+#[ignore = "Requires API key"]
+async fn test_antigravity_on_questions_answers_reach_the_model() {
+    use genai_rs::antigravity::{AgentQuestion, QuestionAnswer, QuestionReply};
+
+    let Some(key) = api_key() else {
+        println!("Skipping: GEMINI_API_KEY not set");
+        return;
+    };
+
+    /// The questions the hook saw, so the test can assert on them after
+    /// the turn rather than from inside a sync closure.
+    type QuestionLog = std::sync::Arc<std::sync::Mutex<Vec<AgentQuestion>>>;
+    let asked: QuestionLog = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let hook_asked = std::sync::Arc::clone(&asked);
+
+    let mut agent = AntigravityAgent::builder()
+        .with_turn_timeout(std::time::Duration::from_secs(120))
+        .with_api_key(key)
+        .with_model("gemini-3.6-flash")
+        .with_system_instructions(
+            "Before answering anything ambiguous, you MUST use the ask_question \
+             tool to ask the user exactly one clarifying question with concrete \
+             choices. Then answer using their choice.",
+        )
+        // AskQuestion is write-capable, so it needs a policy to clear the
+        // spawn-time gate even though questions bypass the policy engine.
+        .with_capabilities(Capabilities::read_only().enable(BuiltinTool::AskQuestion))
+        .add_policy(policy::allow_all())
+        .on_questions(move |questions| {
+            hook_asked.lock().unwrap().extend_from_slice(questions);
+            // Answer the first choice of every question, plus a marker the
+            // model can echo. The marker is arbitrary so that a response
+            // containing it cannot have come from anywhere else.
+            QuestionReply::Answers(
+                questions
+                    .iter()
+                    .map(|q| {
+                        if q.choices.is_empty() {
+                            QuestionAnswer::Freeform("zarquon-91".to_string())
+                        } else {
+                            QuestionAnswer::Choices {
+                                selected: vec![0],
+                                freeform: Some("zarquon-91".to_string()),
+                            }
+                        }
+                    })
+                    .collect(),
+            )
+        })
+        .spawn()
+        .await
+        .expect("spawn");
+
+    let response = agent
+        .chat(
+            "I want a recommendation. Ask me one clarifying question first, \
+             then give me a one-sentence recommendation.",
+        )
+        .await
+        .expect("chat turn");
+    let text = response.text().to_string();
+    println!("final response: {text}");
+
+    let questions = std::mem::take(&mut *asked.lock().unwrap());
+    assert!(
+        !questions.is_empty(),
+        "on_questions never fired — the ask_question builtin did not reach \
+         the hook (response was: {text})"
+    );
+    for question in &questions {
+        println!(
+            "asked: {:?} choices={:?} multi={}",
+            question.question, question.choices, question.is_multi_select
+        );
+        assert!(
+            !question.question.trim().is_empty(),
+            "a question arrived with no text: {question:?}"
+        );
+    }
+
+    // The turn must have continued past the question rather than stalling
+    // on it — the reply path is what this test is really about.
+    assert!(
+        !text.trim().is_empty(),
+        "the turn produced no text after the question was answered"
+    );
 
     agent.shutdown().await.expect("shutdown");
 }

--- a/tests/antigravity_harness.rs
+++ b/tests/antigravity_harness.rs
@@ -25,6 +25,8 @@ use genai_rs::antigravity::{
 };
 use genai_rs_macros::tool;
 
+mod common;
+
 /// Returns a fixed test weather report for a city.
 #[tool(city(description = "The city to get weather for"))]
 fn antigravity_test_weather(city: String) -> String {
@@ -734,12 +736,16 @@ async fn test_antigravity_cancel_handle_halts_an_in_flight_turn() {
 
     let handle = agent.cancel_handle();
     let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+    // Three-valued on purpose: "never reached the threshold" and "the halt
+    // request itself failed" want different diagnostics, and collapsing
+    // them would point a future debugger at the model's speed when the
+    // real fault was the halt.
     let canceller = tokio::spawn(async move {
         if started_rx.await.is_err() {
             // Stream ended before generating enough to halt.
-            return false;
+            return None;
         }
-        handle.cancel().await.is_ok()
+        Some(handle.cancel().await)
     });
 
     let started = std::time::Instant::now();
@@ -781,14 +787,18 @@ async fn test_antigravity_cancel_handle_halts_an_in_flight_turn() {
         (finished, produced, outcome)
     };
     let elapsed = started.elapsed();
-    let cancel_sent = canceller.await.expect("canceller task");
-
-    assert!(
-        cancel_sent,
-        "the turn streamed only {produced} chars, below the \
-         {OUTPUT_BEFORE_CANCEL} needed before halting, so no halt was sent — \
-         this run proves nothing about cancellation"
-    );
+    match canceller.await.expect("canceller task") {
+        Some(Ok(())) => {}
+        Some(Err(err)) => panic!(
+            "the halt request itself failed after {produced} chars of output: \
+             {err:?}"
+        ),
+        None => panic!(
+            "the turn streamed only {produced} chars, below the \
+             {OUTPUT_BEFORE_CANCEL} needed before halting, so no halt was sent \
+             — this run proves nothing about cancellation"
+        ),
+    }
 
     // The assertion that actually proves cancellation: the turn stopped
     // long before it would have finished on its own, and long before the
@@ -826,9 +836,11 @@ async fn test_antigravity_cancel_handle_halts_an_in_flight_turn() {
 /// the turn well enough for the model to act on it.
 ///
 /// Without a hook the crate replies "unanswered" to every question, which
-/// never deadlocks but also never proves the reply path works — so the
-/// assertion is that the *answer* came back, not merely that a question
-/// arrived.
+/// never deadlocks but also never proves the reply path works. So the
+/// closing assertion is semantic: the final answer has to reflect the
+/// choice the hook selected. A harness that dropped every answer on the
+/// floor and let the model proceed on its own would pass a
+/// "was a question asked?" test unchanged.
 #[tokio::test]
 #[ignore = "Requires API key"]
 async fn test_antigravity_on_questions_answers_reach_the_model() {
@@ -838,6 +850,7 @@ async fn test_antigravity_on_questions_answers_reach_the_model() {
         println!("Skipping: GEMINI_API_KEY not set");
         return;
     };
+    let key_for_validation = key.clone();
 
     /// The questions the hook saw, so the test can assert on them after
     /// the turn rather than from inside a sync closure.
@@ -860,19 +873,20 @@ async fn test_antigravity_on_questions_answers_reach_the_model() {
         .add_policy(policy::allow_all())
         .on_questions(move |questions| {
             hook_asked.lock().unwrap().extend_from_slice(questions);
-            // Answer the first choice of every question, plus a marker the
-            // model can echo. The marker is arbitrary so that a response
-            // containing it cannot have come from anywhere else.
+            // Always the *last* choice, never the first: models tend to
+            // list their own preferred option first, so picking it would
+            // leave "the model ignored the answer and did what it wanted"
+            // indistinguishable from "the answer arrived".
             QuestionReply::Answers(
                 questions
                     .iter()
                     .map(|q| {
                         if q.choices.is_empty() {
-                            QuestionAnswer::Freeform("zarquon-91".to_string())
+                            QuestionAnswer::Freeform("the last option".to_string())
                         } else {
                             QuestionAnswer::Choices {
-                                selected: vec![0],
-                                freeform: Some("zarquon-91".to_string()),
+                                selected: vec![q.choices.len() - 1],
+                                freeform: None,
                             }
                         }
                     })
@@ -915,6 +929,222 @@ async fn test_antigravity_on_questions_answers_reach_the_model() {
     assert!(
         !text.trim().is_empty(),
         "the turn produced no text after the question was answered"
+    );
+
+    // ...and the answer must have *landed*. Semantic rather than a
+    // substring match, per CLAUDE.md: the model is free to phrase the
+    // recommendation however it likes, but it is not free to recommend
+    // from a category the user did not pick.
+    let selected: Vec<&str> = questions
+        .iter()
+        .filter_map(|q| q.choices.last().map(String::as_str))
+        .collect();
+    if selected.is_empty() {
+        // No multiple-choice question to check against; the freeform arm
+        // of the hook ran instead.
+        println!("note: no choice-bearing question, skipping the choice check");
+    } else {
+        let client = genai_rs::Client::builder(key_for_validation)
+            .build()
+            .expect("validation client");
+        let context = format!(
+            "The assistant asked the user a clarifying question and the user \
+             selected this option: {}",
+            selected.join(" | ")
+        );
+        common::assert_response_semantic(
+            &client,
+            &context,
+            &text,
+            "Is this response consistent with the option the user selected, \
+             rather than a different category?",
+        )
+        .await;
+    }
+
+    agent.shutdown().await.expect("shutdown");
+}
+
+/// A configured subagent must actually be *invoked*, not merely accepted
+/// at init — `test_antigravity_subagent_config_accepted_at_init` covers
+/// the config half and stops there.
+///
+/// This also re-checks a documented claim that was pinned against harness
+/// 0.1.5: `ActionInvokeSubagent::name` says the harness sends an empty
+/// message and the name is always `None`. That is exactly the kind of
+/// version-pinned claim that goes stale silently, so the test reports what
+/// 0.1.10 actually does rather than asserting the old answer.
+#[tokio::test]
+#[ignore = "Requires API key"]
+async fn test_antigravity_subagent_is_actually_invoked() {
+    use genai_rs::antigravity::Subagent;
+
+    let Some(key) = api_key() else {
+        println!("Skipping: GEMINI_API_KEY not set");
+        return;
+    };
+
+    let mut agent = AntigravityAgent::builder()
+        .with_turn_timeout(std::time::Duration::from_secs(120))
+        .with_api_key(key)
+        .with_model("gemini-3.6-flash")
+        .with_system_instructions(
+            "You have a subagent named `haiku-writer`. For any request to write \
+             a haiku you MUST delegate to it with the start_subagent tool rather \
+             than writing one yourself.",
+        )
+        .add_subagent(
+            Subagent::new("haiku-writer")
+                .with_description("Writes a haiku on any topic.")
+                .with_system_instructions("Reply with a haiku and nothing else."),
+        )
+        .with_capabilities(Capabilities::read_only().enable(BuiltinTool::StartSubagent))
+        .add_policy(policy::allow_all())
+        .spawn()
+        .await
+        .expect("spawn");
+
+    // (tool name, reported subagent name) for every action in the turn,
+    // including the subagent's own trajectory.
+    let mut actions: Vec<(String, Option<String>)> = Vec::new();
+    {
+        let mut stream = agent
+            .send_streaming("Write me a haiku about rust the programming language.")
+            .await
+            .expect("stream");
+        while let Some(event) = stream.next().await {
+            match event.expect("stream event") {
+                AgentEvent::ToolAction { action, .. } => actions.push((
+                    action.tool_name(),
+                    action.subagent_name().map(ToString::to_string),
+                )),
+                AgentEvent::Finished(_) => break,
+                _ => {}
+            }
+        }
+    }
+
+    let invocations: Vec<&(String, Option<String>)> = actions
+        .iter()
+        .filter(|(name, _)| name == "start_subagent")
+        .collect();
+    assert!(
+        !invocations.is_empty(),
+        "the model never delegated to the subagent — no start_subagent action \
+         in the turn. Saw: {actions:?}"
+    );
+
+    // Report rather than assert: the crate documents `name` as always
+    // `None` on 0.1.5, and the point of running this live is to notice if
+    // that stopped being true.
+    let named: Vec<&str> = invocations
+        .iter()
+        .filter_map(|(_, subagent)| subagent.as_deref())
+        .collect();
+    if named.is_empty() {
+        println!(
+            "invokeSubagent carried no name ({} invocation(s)) — matches the \
+             documented 0.1.5 behavior, still true on 0.1.10",
+            invocations.len()
+        );
+    } else {
+        println!(
+            "NOTE: invokeSubagent now reports names {named:?} — update the \
+             ActionInvokeSubagent docs, which say the name is always None"
+        );
+    }
+
+    agent.shutdown().await.expect("shutdown");
+}
+
+/// An MCP server configured via `add_mcp_server` must actually be reached:
+/// the harness has to spawn it, discover its tools, and call one on the
+/// model's behalf.
+///
+/// The fixture server returns a token that exists nowhere else, so a
+/// response containing it can only have come from a real round trip —
+/// which is the difference between testing the wire config and testing
+/// that MCP works.
+#[tokio::test]
+#[ignore = "Requires API key"]
+async fn test_antigravity_mcp_server_tool_is_called() {
+    use genai_rs::antigravity::McpServer;
+
+    let Some(key) = api_key() else {
+        println!("Skipping: GEMINI_API_KEY not set");
+        return;
+    };
+
+    // Same token as tests/fixtures/mcp_echo_server.py.
+    const WIDGET_CODE: &str = "wibble-3317-quux";
+
+    let fixture =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mcp_echo_server.py");
+    assert!(fixture.is_file(), "missing fixture: {}", fixture.display());
+
+    let mut agent = AntigravityAgent::builder()
+        .with_turn_timeout(std::time::Duration::from_secs(120))
+        .with_api_key(key)
+        .with_model("gemini-3.6-flash")
+        .with_system_instructions(
+            "Widget codes can only be obtained by calling the MCP tool named \
+             exactly `lookup_widget_code` on the `widgets` server. Call that \
+             tool by that exact name — do not invent a different tool name, \
+             and do not guess the code. Report the code verbatim.",
+        )
+        .add_mcp_server(
+            McpServer::stdio("python3", [fixture.to_string_lossy().to_string()])
+                .with_name("widgets"),
+        )
+        // No builtins: MCP servers are configured independently of the
+        // builtin capability set, so this leaves the MCP tool as the only
+        // thing to call. Without it the model wanders into grep/find over
+        // the whole repo when its first attempt misses (observed: a
+        // repo-wide grep that timed out and ate the turn budget).
+        .with_capabilities(Capabilities::none())
+        // MCP tools run harness-side, so they go through the policy engine
+        // like any other harness tool.
+        .add_policy(policy::allow_all())
+        .spawn()
+        .await
+        .expect("spawn with an MCP server");
+
+    let mut actions: Vec<String> = Vec::new();
+    let mut text = String::new();
+    {
+        let mut stream = agent
+            .send_streaming("What is the code for the widget named `flange`?")
+            .await
+            .expect("stream");
+        while let Some(event) = stream.next().await {
+            match event.expect("stream event") {
+                AgentEvent::ToolAction { action, .. } => actions.push(action.tool_name()),
+                AgentEvent::Finished(response) => {
+                    text = response.text().to_string();
+                    break;
+                }
+                _ => {}
+            }
+        }
+    }
+    println!("actions: {actions:?}");
+    println!("response: {text}");
+
+    // The tool-name spelling is the crate's own `mcp_<server>_<tool>`
+    // convention, which is also what a policy target has to match — so
+    // this pins the naming as well as the round trip.
+    assert!(
+        actions
+            .iter()
+            .any(|a| a == "mcp_widgets_lookup_widget_code"),
+        "no MCP tool action for the configured server; saw {actions:?}"
+    );
+
+    // Deterministic value, not LLM phrasing: the token cannot be guessed,
+    // so its presence proves the server's answer reached the model.
+    assert!(
+        text.contains(WIDGET_CODE),
+        "the response does not carry the MCP server's token {WIDGET_CODE:?}: {text}"
     );
 
     agent.shutdown().await.expect("shutdown");

--- a/tests/antigravity_harness.rs
+++ b/tests/antigravity_harness.rs
@@ -45,7 +45,7 @@ async fn test_antigravity_spawn_handshake_init_roundtrip() {
     let dir = scratch_dir("agy-init");
     let agent = AntigravityAgent::builder()
         .with_api_key("dummy-key-init-does-not-validate")
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_save_dir(dir.path().to_string_lossy())
         .with_system_instructions("test instructions")
         .add_tool(AntigravityTestWeatherCallable.declaration())
@@ -126,7 +126,7 @@ async fn test_antigravity_trigger_sends_automated_trigger_when_idle() {
     let inspector = Arc::new(WsSendCapture::default());
     let agent = AntigravityAgent::builder()
         .with_api_key("dummy-key-trigger-test")
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .add_trigger(TriggerConfig::new("tick-xyzzy", Duration::from_secs(1)))
         .add_wire_inspector(inspector.clone())
         .spawn()
@@ -165,7 +165,7 @@ async fn test_antigravity_turn_timeout_halts_harness_turn() {
     let inspector = Arc::new(WsSendCapture::default());
     let mut agent = AntigravityAgent::builder()
         .with_api_key("dummy-key-timeout-test")
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         // Far below any network round-trip: the timeout always fires before
         // the turn can produce a terminal event.
         .with_turn_timeout(Duration::from_millis(10))
@@ -209,7 +209,7 @@ async fn test_antigravity_chat_after_trigger_discards_trigger_turn() {
     let inspector = Arc::new(WsSendCapture::default());
     let mut agent = AntigravityAgent::builder()
         .with_api_key("dummy-key-trigger-chat-test")
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_turn_timeout(Duration::from_secs(15))
         .add_trigger(TriggerConfig::new("tick-quux", Duration::from_secs(1)))
         .add_wire_inspector(inspector.clone())
@@ -276,7 +276,7 @@ async fn test_antigravity_subagent_config_accepted_at_init() {
     // (no API key needed for init).
     let agent = AntigravityAgent::builder()
         .with_api_key("dummy-key-subagent-test")
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .add_tool(AntigravityTestWeatherCallable.declaration())
         .add_subagent(
             Subagent::new("weather-checker")
@@ -314,7 +314,7 @@ async fn test_antigravity_chat_basic() {
     let mut agent = AntigravityAgent::builder()
         .with_turn_timeout(std::time::Duration::from_secs(120))
         .with_api_key(key)
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_system_instructions("Answer in one short sentence.")
         .spawn()
         .await
@@ -341,7 +341,7 @@ async fn test_antigravity_custom_tool_roundtrip() {
     let mut agent = AntigravityAgent::builder()
         .with_turn_timeout(std::time::Duration::from_secs(120))
         .with_api_key(key)
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_system_instructions(
             "You must use the antigravity_test_weather tool to answer weather questions.",
         )
@@ -399,7 +399,7 @@ async fn test_antigravity_policy_denies_custom_tool() {
     let mut agent = AntigravityAgent::builder()
         .with_turn_timeout(std::time::Duration::from_secs(120))
         .with_api_key(key)
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_system_instructions(
             "Always try the antigravity_test_weather tool first for weather questions. \
              If a tool fails, say TOOL-DENIED and stop.",

--- a/tests/antigravity_harness.rs
+++ b/tests/antigravity_harness.rs
@@ -718,18 +718,49 @@ print(json.dumps(out))
     );
 }
 
+/// python3's site-packages directories, as the crate's discovery sees
+/// them. Kept in step with `python_site_dirs` in
+/// `src/antigravity/process.rs`; an empty result (no python3) simply means
+/// that discovery step matches nothing, which is what the crate does too.
+fn python_site_dirs() -> Vec<std::path::PathBuf> {
+    let output = std::process::Command::new("python3")
+        .arg("-c")
+        .arg(
+            "import site\n\
+             paths = list(getattr(site, 'getsitepackages', lambda: [])())\n\
+             usersite = getattr(site, 'getusersitepackages', lambda: None)()\n\
+             if usersite: paths.append(usersite)\n\
+             print('\\n'.join(paths))",
+        )
+        .output();
+    match output {
+        Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .map(std::path::PathBuf::from)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 /// The site-packages directory of the harness install the *crate* would
 /// resolve, when that is somewhere `python3` would not look on its own.
 ///
-/// Mirrors `discover_harness`'s order for the two modes that can point
-/// outside the default interpreter: the explicit
-/// `ANTIGRAVITY_HARNESS_PATH`, then `localharness` on `PATH`. The
-/// python3-site-packages mode needs no PYTHONPATH by construction, and the
-/// builder-path mode is not used by these tests.
+/// Mirrors `discover_harness`'s order — `ANTIGRAVITY_HARNESS_PATH`, then
+/// python3's own site-packages, then `localharness` on `PATH` — minus the
+/// builder-path mode, which these tests do not use.
+///
+/// The site-packages step is included even though it never *produces* a
+/// PYTHONPATH, because it is a precedence step: with the env var unset, a
+/// wheel in python3's site-packages, and a second `localharness` on `PATH`
+/// (pipx / `uv tool`), skipping it would prepend the `PATH` copy's
+/// site-packages and win — comparing the crate's model against the wheel
+/// the crate is *not* running.
 ///
 /// `None` means "let python3 use its own site-packages", which is correct
-/// whenever the resolved binary does not sit inside a recognizable wheel
-/// layout.
+/// both there and whenever the resolved binary does not sit inside a
+/// recognizable wheel layout.
 fn resolved_harness_site_packages() -> Option<std::path::PathBuf> {
     let from_path_var = || {
         let path_var = std::env::var_os("PATH")?;
@@ -738,10 +769,21 @@ fn resolved_harness_site_packages() -> Option<std::path::PathBuf> {
             .find(|candidate| candidate.is_file())
     };
 
-    let harness = std::env::var_os("ANTIGRAVITY_HARNESS_PATH")
+    let harness = match std::env::var_os("ANTIGRAVITY_HARNESS_PATH")
         .map(std::path::PathBuf::from)
         .filter(|p| p.is_file())
-        .or_else(from_path_var)?;
+    {
+        Some(explicit) => explicit,
+        // python3 would find its own copy before anything on PATH, so
+        // leaving PYTHONPATH alone is what keeps the two in sync.
+        None if python_site_dirs()
+            .iter()
+            .any(|d| d.join("google/antigravity/bin/localharness").is_file()) =>
+        {
+            return None;
+        }
+        None => from_path_var()?,
+    };
 
     // A `PATH` hit is usually a symlink into the venv that owns the wheel,
     // so resolve it before reading the layout — the link's own directory

--- a/tests/antigravity_harness.rs
+++ b/tests/antigravity_harness.rs
@@ -607,3 +607,186 @@ async fn test_antigravity_workspace_actions_and_post_tool_success() {
 
     agent.shutdown().await.expect("shutdown");
 }
+
+// =============================================================================
+// Protocol drift guard
+// =============================================================================
+
+/// Dumps `{proto_enum_path: [values]}` from the installed harness wheel.
+///
+/// The wheel ships the compiled `localharness_pb2`, which carries a full
+/// `FileDescriptorProto` — the authoritative list of what the harness can
+/// send. Its module path moved in 0.1.10, so both are tried.
+fn harness_proto_enums() -> Option<serde_json::Value> {
+    const SCRIPT: &str = r#"
+import json, importlib, sys
+from google.protobuf import descriptor_pb2
+mod = None
+for path in ("google.antigravity.proto.localharness_pb2",
+             "google.antigravity.connections.local.localharness_pb2"):
+    try:
+        mod = importlib.import_module(path); break
+    except Exception:
+        continue
+if mod is None:
+    sys.exit(3)
+fdp = descriptor_pb2.FileDescriptorProto()
+mod.DESCRIPTOR.CopyToProto(fdp)
+out = {}
+def walk(msgs, prefix=""):
+    for mt in msgs:
+        full = prefix + mt.name
+        for e in mt.enum_type:
+            out[full + "." + e.name] = sorted(v.name for v in e.value)
+        walk(mt.nested_type, full + ".")
+for e in fdp.enum_type:
+    out[e.name] = sorted(v.name for v in e.value)
+walk(fdp.message_type)
+print(json.dumps(out))
+"#;
+    // Prefer the interpreter that owns the wheel discovery path the crate
+    // itself uses; fall back to whatever `python3` resolves to.
+    let output = std::process::Command::new("python3")
+        .args(["-c", SCRIPT])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        println!(
+            "Skipping: could not import localharness_pb2 ({}). Install the wheel \
+             into the python3 on PATH to run this guard.",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+        return None;
+    }
+    serde_json::from_slice(&output.stdout).ok()
+}
+
+/// Compares a harness descriptor dump against what this crate models,
+/// returning one human-readable line per drifted enum.
+///
+/// Pure and synchronous so the detection logic itself is testable — a
+/// drift guard that cannot be shown to detect drift is worse than none,
+/// because it reads as coverage.
+fn find_enum_drift(harness: &serde_json::Value, modeled: &[(&str, &[&str])]) -> Vec<String> {
+    let mut drift = Vec::new();
+    for (proto_path, known) in modeled {
+        let Some(values) = harness.get(proto_path).and_then(|v| v.as_array()) else {
+            drift.push(format!(
+                "{proto_path}: not present in the harness descriptor — the message or \
+                 enum was renamed or removed"
+            ));
+            continue;
+        };
+        let unmodeled: Vec<&str> = values
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .filter(|v| !known.contains(v))
+            .collect();
+        if !unmodeled.is_empty() {
+            drift.push(format!(
+                "{proto_path}: harness can send {unmodeled:?}, which this crate does not \
+                 model (they would deserialize to Unknown and stop matching); known = {known:?}"
+            ));
+        }
+    }
+    drift
+}
+
+#[test]
+fn drift_detector_catches_the_0_1_10_rename() {
+    // The exact shape of the bug this guard exists for: the harness
+    // renamed the terminal trajectory state, and a crate that models only
+    // the old spelling must be told loudly.
+    let harness = serde_json::json!({
+        "TrajectoryStateUpdate.State": [
+            "STATE_CANCELLED", "STATE_FULLY_IDLE", "STATE_RUNNING",
+            "STATE_UNSPECIFIED", "STATE_WAITING_FOR_TASKS"
+        ]
+    });
+    let stale: &[&str] = &[
+        "STATE_UNSPECIFIED",
+        "STATE_RUNNING",
+        "STATE_IDLE",
+        "STATE_CANCELLED",
+    ];
+    let drift = find_enum_drift(&harness, &[("TrajectoryStateUpdate.State", stale)]);
+    assert_eq!(drift.len(), 1, "expected one drifted enum, got {drift:?}");
+    assert!(drift[0].contains("STATE_FULLY_IDLE"), "got: {}", drift[0]);
+    assert!(
+        drift[0].contains("STATE_WAITING_FOR_TASKS"),
+        "got: {}",
+        drift[0]
+    );
+
+    // And the current model is clean against the same descriptor.
+    let current = genai_rs::antigravity::protocol::TrajectoryState::all_wire_values();
+    assert!(find_enum_drift(&harness, &[("TrajectoryStateUpdate.State", current)]).is_empty());
+}
+
+#[test]
+fn drift_detector_flags_a_missing_enum_and_ignores_retired_values() {
+    // A message/enum that vanished from the descriptor is drift.
+    let empty = serde_json::json!({});
+    let drift = find_enum_drift(&empty, &[("StepUpdate.State", &["STATE_DONE"][..])]);
+    assert_eq!(drift.len(), 1);
+    assert!(drift[0].contains("not present"), "got: {}", drift[0]);
+
+    // A value the crate keeps but the harness no longer sends is NOT
+    // drift — that is exactly what the alias mechanism is for.
+    let harness = serde_json::json!({ "StepUpdate.State": ["STATE_DONE"] });
+    let with_alias: &[&str] = &["STATE_DONE", "STATE_RETIRED_SPELLING"];
+    assert!(find_enum_drift(&harness, &[("StepUpdate.State", with_alias)]).is_empty());
+}
+
+/// Fails when the harness's enum values drift from what this crate models.
+///
+/// This is the guard that would have caught the 0.1.5 -> 0.1.10 break on
+/// the day the wheel was bumped, instead of every agent turn silently
+/// running to its timeout. `STATE_IDLE` became `STATE_FULLY_IDLE`; because
+/// only the `Idle` variant ends a turn and the renamed value was absorbed
+/// as `Unknown`, nothing errored and nothing failed — the bridge simply
+/// stopped recognizing the end of a turn.
+///
+/// Deliberately one-directional: a value the crate knows but the harness
+/// no longer sends is fine (that is what aliases are for). A value the
+/// **harness can send** and the crate does not model is the dangerous
+/// direction, because it lands in `Unknown` and stops matching.
+#[tokio::test]
+#[ignore = "Requires localharness binary"]
+async fn test_antigravity_protocol_enums_have_not_drifted() {
+    use genai_rs::antigravity::protocol::{
+        HookDecision, LifecycleHook, LineAction, ModelType, StepSource, StepState, StepTarget,
+        TrajectoryState,
+    };
+
+    let Some(harness) = harness_proto_enums() else {
+        return;
+    };
+
+    // (proto enum path, what this crate recognizes)
+    let modeled: Vec<(&str, &[&str])> = vec![
+        ("StepUpdate.State", StepState::all_wire_values()),
+        ("StepUpdate.Source", StepSource::all_wire_values()),
+        ("StepUpdate.Target", StepTarget::all_wire_values()),
+        (
+            "TrajectoryStateUpdate.State",
+            TrajectoryState::all_wire_values(),
+        ),
+        ("ModelType", ModelType::all_wire_values()),
+        ("LifecycleHook", LifecycleHook::all_wire_values()),
+        ("PreToolResult.Decision", HookDecision::all_wire_values()),
+        (
+            "ActionEditFile.DiffLine.LineAction",
+            LineAction::all_wire_values(),
+        ),
+    ];
+
+    let drift = find_enum_drift(&harness, &modeled);
+
+    assert!(
+        drift.is_empty(),
+        "harness protocol drift detected — update the wire enums in \
+         src/antigravity/protocol.rs (and docs/ENUM_WIRE_FORMATS.md):\n  {}",
+        drift.join("\n  ")
+    );
+}

--- a/tests/antigravity_harness.rs
+++ b/tests/antigravity_harness.rs
@@ -1,12 +1,15 @@
 //! Integration tests against a real `localharness` binary.
 //!
 //! These tests need the binary from the `google-antigravity` wheel
-//! (`pip install google-antigravity==0.1.5`) discoverable via the standard
+//! (`pip install google-antigravity==0.1.10`) discoverable via the standard
 //! order (`ANTIGRAVITY_HARNESS_PATH`, python3 site-packages, `PATH`).
 //!
 //! Most tests do NOT need a Gemini API key: the harness completes its
 //! handshake and conversation init with a placeholder key (verified
-//! against harness 0.1.5). Chat tests need a real `GEMINI_API_KEY`.
+//! against harness 0.1.5 and 0.1.10). Chat tests need a real
+//! `GEMINI_API_KEY` — CI supplies one, because these are the only tests
+//! that drive a real turn end to end and therefore the only guard
+//! against a harness protocol change breaking turn completion.
 //!
 //! Run with:
 //! ```bash
@@ -416,6 +419,191 @@ async fn test_antigravity_policy_denies_custom_tool() {
         .await
         .expect("turn should complete despite the deny (model sees the error)");
     assert!(!response.text().is_empty());
+
+    agent.shutdown().await.expect("shutdown");
+}
+
+// =============================================================================
+// Session persistence (real API key required)
+// =============================================================================
+
+/// The `with_save_dir` + `conversation_id()` + `with_conversation_id` round
+/// trip, which `examples/real_world/session_resume` demonstrates.
+///
+/// Asserts the half that is easy to get silently wrong: resuming an unknown
+/// id is *not* an error, it just comes back empty — so a broken resume looks
+/// exactly like a working one unless `initial_history()` is checked.
+#[tokio::test]
+#[ignore = "Requires API key"]
+async fn test_antigravity_session_resume_restores_history() {
+    let Some(key) = api_key() else {
+        println!("Skipping: GEMINI_API_KEY not set");
+        return;
+    };
+    let save_dir = scratch_dir("agy-resume");
+    let save_path = save_dir.path().to_string_lossy().to_string();
+
+    // --- First session: plant a fact, capture the id, shut down cleanly.
+    let mut agent = AntigravityAgent::builder()
+        .with_turn_timeout(std::time::Duration::from_secs(120))
+        .with_api_key(key.clone())
+        .with_model("gemini-3.6-flash")
+        .with_system_instructions("You are a terse note-keeper. Recall facts when asked.")
+        .with_capabilities(Capabilities::none())
+        .with_save_dir(save_path.clone())
+        .spawn()
+        .await
+        .expect("spawn (fresh)");
+
+    let conversation_id = agent
+        .conversation_id()
+        .expect("harness assigns a conversation id")
+        .to_string();
+    assert!(
+        agent.initial_history().is_empty(),
+        "a fresh conversation must restore nothing"
+    );
+
+    agent
+        .chat("Remember this: the fixture code is xyzzy-42.")
+        .await
+        .expect("first turn");
+    // shutdown(), not drop: this is what makes the trajectory durable.
+    agent.shutdown().await.expect("shutdown (fresh)");
+
+    // --- Second session: same dir + id, in a brand-new agent.
+    let mut resumed = AntigravityAgent::builder()
+        .with_turn_timeout(std::time::Duration::from_secs(120))
+        .with_api_key(key)
+        .with_model("gemini-3.6-flash")
+        .with_system_instructions("You are a terse note-keeper. Recall facts when asked.")
+        .with_capabilities(Capabilities::none())
+        .with_save_dir(save_path)
+        .with_conversation_id(conversation_id.clone())
+        .spawn()
+        .await
+        .expect("spawn (resumed)");
+
+    assert_eq!(
+        resumed.conversation_id(),
+        Some(conversation_id.as_str()),
+        "resuming must keep the same conversation id"
+    );
+    let restored = resumed.initial_history().len();
+    assert!(
+        restored > 0,
+        "resume restored no history — a silently-fresh conversation is \
+         indistinguishable from a working resume without this check"
+    );
+
+    // The planted token cannot come from anywhere but restored history.
+    let response = resumed
+        .chat("What is the fixture code? Reply with just the code.")
+        .await
+        .expect("resumed turn");
+    let text = response.text().to_lowercase();
+    assert!(
+        text.contains("xyzzy-42"),
+        "resumed agent should recall the planted fact, got: {text:?}"
+    );
+
+    resumed.shutdown().await.expect("shutdown (resumed)");
+}
+
+// =============================================================================
+// Workspaces, typed tool actions, and hooks (real API key required)
+// =============================================================================
+
+/// Points the builtins at a real directory and asserts the observable
+/// surface `examples/real_world/workspace_explorer` is built on:
+/// `AgentEvent::ToolAction` actually arrives for harness-executed file
+/// tools, and `on_post_tool` reports a *successful* builtin as successful.
+///
+/// That last assertion is a regression guard: the harness sends
+/// `"error": ""` on success, which the bridge previously surfaced as
+/// `Some("")` — making `ToolOutcome::error.is_some()` true for every
+/// successful call.
+#[tokio::test]
+#[ignore = "Requires API key"]
+async fn test_antigravity_workspace_actions_and_post_tool_success() {
+    let Some(key) = api_key() else {
+        println!("Skipping: GEMINI_API_KEY not set");
+        return;
+    };
+    let workspace = scratch_dir("agy-workspace");
+    std::fs::write(
+        workspace.path().join("NOTES.md"),
+        "The build token is grue-77.\n",
+    )
+    .expect("seed workspace");
+
+    // Every post-tool outcome, so we can assert none of the successful
+    // ones were reported as errors.
+    /// (tool name, error) for each completed tool call.
+    type PostToolLog = std::sync::Arc<std::sync::Mutex<Vec<(String, Option<String>)>>>;
+    let outcomes: PostToolLog = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let hook_outcomes = std::sync::Arc::clone(&outcomes);
+
+    let mut agent = AntigravityAgent::builder()
+        .with_turn_timeout(std::time::Duration::from_secs(120))
+        .with_api_key(key)
+        .with_model("gemini-3.6-flash")
+        .with_system_instructions(
+            "Read the files in the workspace to answer. Use the file tools rather than guessing.",
+        )
+        .add_workspace(workspace.path().to_string_lossy().to_string())
+        .with_capabilities(Capabilities::read_only())
+        .on_post_tool(move |outcome| {
+            hook_outcomes
+                .lock()
+                .unwrap()
+                .push((outcome.name.clone(), outcome.error.clone()));
+        })
+        .spawn()
+        .await
+        .expect("spawn");
+
+    let mut actions: Vec<String> = Vec::new();
+    {
+        let mut stream = agent
+            .send_streaming("What is the build token? Read NOTES.md.")
+            .await
+            .expect("stream");
+        while let Some(event) = stream.next().await {
+            match event.expect("stream event") {
+                AgentEvent::ToolAction { action, .. } => actions.push(action.tool_name()),
+                AgentEvent::Finished(_) => break,
+                _ => {}
+            }
+        }
+    }
+
+    // The workspace is real, so real file tools must have run against it.
+    assert!(
+        !actions.is_empty(),
+        "expected at least one harness ToolAction against the workspace"
+    );
+    assert!(
+        actions
+            .iter()
+            .any(|a| a == "view_file" || a == "list_directory" || a == "search_directory"),
+        "expected a file-tool action, got: {actions:?}"
+    );
+
+    // Regression guard: a successful builtin must not report an error.
+    // Snapshot and release before the shutdown await.
+    let recorded: Vec<(String, Option<String>)> = std::mem::take(&mut *outcomes.lock().unwrap());
+    assert!(
+        !recorded.is_empty(),
+        "on_post_tool should fire for harness-executed builtins"
+    );
+    for (name, error) in &recorded {
+        assert!(
+            error.as_deref().is_none_or(|e| !e.trim().is_empty()),
+            "{name} reported a blank error string as a failure — the harness \
+             sends \"error\": \"\" on success and it must normalize to None"
+        );
+    }
 
     agent.shutdown().await.expect("shutdown");
 }

--- a/tests/antigravity_harness.rs
+++ b/tests/antigravity_harness.rs
@@ -608,6 +608,188 @@ async fn test_antigravity_workspace_actions_and_post_tool_success() {
     agent.shutdown().await.expect("shutdown");
 }
 
+/// `with_response_schema` must actually constrain the final output, and
+/// the result must arrive on `structured_output()` rather than only as
+/// text the caller has to re-parse.
+///
+/// The schema is deliberately not the obvious shape for the question (two
+/// renamed fields plus a number), so a response that happens to look right
+/// cannot be a coincidence of the model's default formatting.
+#[tokio::test]
+#[ignore = "Requires API key"]
+async fn test_antigravity_structured_output_follows_response_schema() {
+    let Some(key) = api_key() else {
+        println!("Skipping: GEMINI_API_KEY not set");
+        return;
+    };
+
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "capital_city": {"type": "string"},
+            "country_name": {"type": "string"},
+            "letters_in_capital": {"type": "integer"},
+        },
+        "required": ["capital_city", "country_name", "letters_in_capital"],
+    });
+
+    let mut agent = AntigravityAgent::builder()
+        .with_turn_timeout(std::time::Duration::from_secs(120))
+        .with_api_key(key)
+        .with_model("gemini-3.6-flash")
+        .with_capabilities(Capabilities::none())
+        .with_response_schema(schema)
+        .spawn()
+        .await
+        .expect("spawn");
+
+    let response = agent
+        .chat("What is the capital of France?")
+        .await
+        .expect("chat turn");
+
+    let output = response
+        .structured_output()
+        .expect("with_response_schema should produce structured_output");
+
+    // Structural, not semantic: the point is that the schema was honored,
+    // not that the model knows French geography.
+    let object = output
+        .as_object()
+        .unwrap_or_else(|| panic!("structured output should be a JSON object, got: {output}"));
+    for key in ["capital_city", "country_name", "letters_in_capital"] {
+        assert!(
+            object.contains_key(key),
+            "structured output is missing required key {key:?}: {output}"
+        );
+    }
+    assert!(
+        object["capital_city"].is_string(),
+        "capital_city should be a string: {output}"
+    );
+    assert!(
+        object["letters_in_capital"].is_i64() || object["letters_in_capital"].is_u64(),
+        "letters_in_capital should be an integer: {output}"
+    );
+
+    agent.shutdown().await.expect("shutdown");
+}
+
+/// A `CancelHandle` taken before a turn must be able to halt that turn
+/// from outside the `&mut self` borrow that `send_streaming` holds — which
+/// is the entire reason the handle exists, and is not exercised anywhere
+/// else.
+///
+/// This test also pins *how* a cancelled turn ends, which is not what the
+/// crate documented before it was run: harness 0.1.10 answers a
+/// `haltRequest` with `STATE_FULLY_IDLE`, not `STATE_CANCELLED`, so the
+/// turn resolves as a normal `Finished` carrying whatever partial output
+/// existed — it does **not** fail with `AntigravityError::Turn`. The
+/// `Cancelled` arm in the turn loop still matters for harness-initiated
+/// cancellation; it is simply not the client-halt path.
+///
+/// The prompt is long on purpose: it has to still be running when the
+/// cancel lands, or the test proves nothing.
+#[tokio::test]
+#[ignore = "Requires API key"]
+async fn test_antigravity_cancel_handle_halts_an_in_flight_turn() {
+    let Some(key) = api_key() else {
+        println!("Skipping: GEMINI_API_KEY not set");
+        return;
+    };
+
+    /// How long after the turn starts the halt is sent.
+    const CANCEL_AFTER: std::time::Duration = std::time::Duration::from_secs(3);
+    /// The turn must end promptly after the halt. Generous enough to
+    /// absorb a slow round trip, far below both the turn timeout and how
+    /// long the un-cancelled prompt would take.
+    const MUST_END_WITHIN: std::time::Duration = std::time::Duration::from_secs(30);
+
+    let mut agent = AntigravityAgent::builder()
+        // Much longer than MUST_END_WITHIN: if the halt is ignored, this
+        // test must fail on the elapsed-time assertion rather than being
+        // rescued by a timeout that looks like a pass.
+        .with_turn_timeout(std::time::Duration::from_secs(180))
+        .with_api_key(key)
+        .with_model("gemini-3.6-flash")
+        .with_capabilities(Capabilities::none())
+        .spawn()
+        .await
+        .expect("spawn");
+
+    // Taken *before* the stream borrows the agent — the handle is the only
+    // way to reach the session while a turn is in flight.
+    let handle = agent.cancel_handle();
+    tokio::spawn(async move {
+        tokio::time::sleep(CANCEL_AFTER).await;
+        let _ = handle.cancel().await;
+    });
+
+    let started = std::time::Instant::now();
+    let (finished, outcome) = {
+        let mut stream = agent
+            .send_streaming(
+                "Write an extremely detailed 3000-word essay about the history of \
+                 the bicycle. Include many sections and go slowly.",
+            )
+            .await
+            .expect("stream");
+
+        let mut finished = false;
+        let mut outcome = Ok(());
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(AgentEvent::Finished(_)) => {
+                    finished = true;
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    outcome = Err(err);
+                    break;
+                }
+            }
+        }
+        (finished, outcome)
+    };
+    let elapsed = started.elapsed();
+
+    // The assertion that actually proves cancellation: the turn stopped
+    // long before it would have finished on its own, and long before the
+    // turn timeout could have ended it.
+    assert!(
+        elapsed < MUST_END_WITHIN,
+        "the turn ran {elapsed:?}, past the {MUST_END_WITHIN:?} bound — the \
+         halt did not stop it"
+    );
+    assert!(
+        elapsed >= CANCEL_AFTER,
+        "the turn ended in {elapsed:?}, before the halt was even sent — the \
+         model answered too fast for this test to prove anything"
+    );
+
+    match outcome {
+        // The documented-and-verified shape on 0.1.10.
+        Ok(()) => assert!(
+            finished,
+            "the stream ended without a Finished event and without an error"
+        ),
+        // Not what 0.1.10 does, but the turn loop still maps a harness
+        // STATE_CANCELLED here; accept it rather than fail if the harness
+        // changes its mind, and say so loudly.
+        Err(AntigravityError::Turn(message)) => {
+            println!(
+                "note: this harness reported cancellation as a Turn error \
+                 ({message:?}) — 0.1.10 ended the turn as Finished. Update the \
+                 CancelHandle docs if this is the new behavior."
+            );
+        }
+        Err(other) => panic!("unexpected error from a cancelled turn: {other:?}"),
+    }
+
+    agent.shutdown().await.expect("shutdown");
+}
+
 // =============================================================================
 // Protocol drift guard
 // =============================================================================

--- a/tests/antigravity_harness.rs
+++ b/tests/antigravity_harness.rs
@@ -644,21 +644,48 @@ for e in fdp.enum_type:
 walk(fdp.message_type)
 print(json.dumps(out))
 "#;
-    // Prefer the interpreter that owns the wheel discovery path the crate
-    // itself uses; fall back to whatever `python3` resolves to.
-    let output = std::process::Command::new("python3")
-        .args(["-c", SCRIPT])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        println!(
-            "Skipping: could not import localharness_pb2 ({}). Install the wheel \
-             into the python3 on PATH to run this guard.",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-        return None;
+    // Point the interpreter at the *same* install the tests exercise.
+    // `ANTIGRAVITY_HARNESS_PATH` sits ahead of python3's own site-packages
+    // in the crate's discovery order, so when it is set, comparing against
+    // whatever `python3` happens to import would check a different wheel
+    // than the one under test. Deriving PYTHONPATH from the resolved
+    // harness path keeps the two in sync (and makes a venv install work
+    // with the system python3).
+    let mut command = std::process::Command::new("python3");
+    if let Ok(harness) = std::env::var("ANTIGRAVITY_HARNESS_PATH") {
+        // .../<site-packages>/google/antigravity/bin/localharness
+        let site_packages = std::path::Path::new(&harness)
+            .ancestors()
+            .nth(4)
+            .map(std::path::Path::to_path_buf);
+        if let Some(dir) = site_packages.filter(|d| d.join("google/antigravity").is_dir()) {
+            command.env("PYTHONPATH", dir);
+        }
     }
-    serde_json::from_slice(&output.stdout).ok()
+    let output = command.args(["-c", SCRIPT]).output().ok()?;
+    if output.status.success() {
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("descriptor dump should be JSON");
+        assert!(
+            parsed.as_object().is_some_and(|m| !m.is_empty()),
+            "the harness descriptor yielded no enums at all — the guard would have \
+             checked nothing"
+        );
+        return Some(parsed);
+    }
+
+    // Reaching here means the harness binary was discoverable (this test is
+    // gated on that) but its descriptor was not. Failing beats skipping:
+    // a guard that goes green when it checked nothing is the same vacuous
+    // pass that let the 0.1.5 -> 0.1.10 rename reach a release. The module
+    // path has already moved once, and the bump that moves it again is
+    // exactly the bump likely to carry a rename with it.
+    panic!(
+        "could not import localharness_pb2 from the installed wheel, so the protocol-drift \
+         guard checked nothing. Both known module paths were tried. If the wheel moved it \
+         again, update the path list in harness_proto_enums.\npython3 stderr: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
 }
 
 /// Compares a harness descriptor dump against what this crate models,
@@ -760,6 +787,9 @@ async fn test_antigravity_protocol_enums_have_not_drifted() {
     };
 
     let Some(harness) = harness_proto_enums() else {
+        // python3 itself is absent — the only remaining reason to skip.
+        // A wheel that is present but unreadable panics inside the helper.
+        println!("Skipping: python3 not available to read the harness descriptor");
         return;
     };
 

--- a/tests/api_canary_tests.rs
+++ b/tests/api_canary_tests.rs
@@ -31,7 +31,7 @@ use futures_util::StreamExt;
 use genai_rs::InteractionInput;
 
 /// Model used for all canary tests - update if model availability changes
-const CANARY_MODEL: &str = "gemini-3-flash-preview";
+const CANARY_MODEL: &str = "gemini-3.6-flash";
 
 /// Helper to check a response for unknown step types and panic with details if found
 fn assert_no_unknown_steps(response: &genai_rs::InteractionResponse, context: &str) {

--- a/tests/api_canary_tests.rs
+++ b/tests/api_canary_tests.rs
@@ -15,6 +15,11 @@
 //! These tests make 6 API calls and typically complete in 12-60 seconds total.
 //! Consider using `--test-threads=1` to avoid rate limiting.
 //!
+//! Every call goes through `retry_request!`. These canaries exist to detect
+//! *unknown content types*, so a transient 429 or 5xx failing one is a false
+//! alarm about the API's shape — and one that reads as "Google changed the
+//! protocol" when it means "the project ran out of quota".
+//!
 //! # Feature Flags
 //!
 //! These tests are SKIPPED when `strict-unknown` feature is enabled, since they
@@ -57,13 +62,15 @@ fn assert_no_unknown_steps(response: &genai_rs::InteractionResponse, context: &s
 async fn canary_basic_text_interaction() {
     let client = get_client().expect("GEMINI_API_KEY must be set");
 
-    let response = client
-        .interaction()
-        .with_model(CANARY_MODEL)
-        .with_text("Say 'hello' and nothing else.")
-        .create()
-        .await
-        .expect("API call should succeed");
+    let response = retry_request!([client] => {
+        client
+            .interaction()
+            .with_model(CANARY_MODEL)
+            .with_text("Say 'hello' and nothing else.")
+            .create()
+            .await
+    })
+    .expect("API call should succeed");
 
     assert_no_unknown_steps(&response, "basic text interaction");
 }
@@ -132,14 +139,16 @@ async fn canary_function_calling_interaction() {
         .description("Get the current time")
         .build();
 
-    let response = client
-        .interaction()
-        .with_model(CANARY_MODEL)
-        .with_text("What time is it?")
-        .add_functions(vec![get_time])
-        .create()
-        .await
-        .expect("API call should succeed");
+    let response = retry_request!([client, get_time] => {
+        client
+            .interaction()
+            .with_model(CANARY_MODEL)
+            .with_text("What time is it?")
+            .add_functions(vec![get_time.clone()])
+            .create()
+            .await
+    })
+    .expect("API call should succeed");
 
     assert_no_unknown_steps(&response, "function calling interaction");
 
@@ -163,13 +172,15 @@ async fn canary_function_calling_interaction() {
         ));
         let history = InteractionInput::Steps(steps);
 
-        let followup = client
-            .interaction()
-            .with_model(CANARY_MODEL)
-            .with_input(history)
-            .create()
-            .await
-            .expect("Follow-up API call should succeed");
+        let followup = retry_request!([client, history] => {
+            client
+                .interaction()
+                .with_model(CANARY_MODEL)
+                .with_input(history.clone())
+                .create()
+                .await
+        })
+        .expect("Follow-up API call should succeed");
 
         assert_no_unknown_steps(&followup, "function calling follow-up");
     }
@@ -229,13 +240,15 @@ async fn canary_multimodal_interaction() {
         Content::image_data(common::TINY_RED_PNG_BASE64, "image/png"),
     ]);
 
-    let response = client
-        .interaction()
-        .with_model(CANARY_MODEL)
-        .with_input(input)
-        .create()
-        .await
-        .expect("API call should succeed");
+    let response = retry_request!([client, input] => {
+        client
+            .interaction()
+            .with_model(CANARY_MODEL)
+            .with_input(input.clone())
+            .create()
+            .await
+    })
+    .expect("API call should succeed");
 
     assert_no_unknown_steps(&response, "multimodal interaction");
 }
@@ -256,14 +269,16 @@ async fn canary_thinking_model_interaction() {
         ..Default::default()
     };
 
-    let response = client
-        .interaction()
-        .with_model(CANARY_MODEL)
-        .with_text("What is 15 * 23?")
-        .with_generation_config(config)
-        .create()
-        .await
-        .expect("API call should succeed");
+    let response = retry_request!([client, config] => {
+        client
+            .interaction()
+            .with_model(CANARY_MODEL)
+            .with_text("What is 15 * 23?")
+            .with_generation_config(config.clone())
+            .create()
+            .await
+    })
+    .expect("API call should succeed");
 
     assert_no_unknown_steps(&response, "thinking model interaction");
 }

--- a/tests/api_wire_format_live_tests.rs
+++ b/tests/api_wire_format_live_tests.rs
@@ -61,7 +61,7 @@ async fn canary_basic_interaction_no_unknown_content() {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Say hello in exactly one word.")
         .create()
         .await
@@ -99,7 +99,7 @@ async fn canary_response_status_is_known() {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("What is 2+2?")
         .create()
         .await
@@ -143,7 +143,7 @@ async fn canary_function_calling_no_unknown_content() {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("What's the weather in Paris?")
         .add_functions(vec![get_weather])
         .create()
@@ -179,7 +179,7 @@ async fn canary_thinking_mode_no_unknown_content() {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("What is the square root of 144?")
         .with_thinking_level(ThinkingLevel::Low)
         .create()
@@ -213,7 +213,7 @@ async fn canary_streaming_no_unknown_chunks() {
 
     let mut stream = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Count from 1 to 5.")
         .create_stream();
 
@@ -252,7 +252,7 @@ async fn canary_google_search_no_unknown_content() {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("What is the current population of Tokyo according to recent data?")
         .with_google_search()
         .create()
@@ -286,7 +286,7 @@ async fn canary_code_execution_no_unknown_content() {
         Duration::from_secs(60),
         client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text("Calculate 123 * 456 using Python code execution.")
             .with_code_execution()
             .create(),
@@ -366,7 +366,7 @@ async fn canary_comprehensive_response_check() {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello! Please respond with a friendly greeting.")
         .create()
         .await

--- a/tests/api_wire_format_live_tests.rs
+++ b/tests/api_wire_format_live_tests.rs
@@ -29,19 +29,16 @@
 mod common;
 
 use futures_util::StreamExt;
-use genai_rs::Client;
-use std::env;
-
-/// Helper to create a client for canary tests.
-fn create_client() -> Option<Client> {
-    let api_key = env::var("GEMINI_API_KEY").ok()?;
-    Client::builder(api_key).build().ok()
-}
 
 /// Helper macro to skip tests when API key is not available.
+///
+/// Uses the shared `common::get_client` rather than a local builder: it
+/// warns when the key is set but the client fails to build, which a local
+/// `.ok()?` would render indistinguishable from an unset key — i.e. a
+/// silent skip where a canary is meant to be loud.
 macro_rules! require_api_key {
     ($client:ident) => {
-        let Some($client) = create_client() else {
+        let Some($client) = common::get_client() else {
             eprintln!("Skipping test: GEMINI_API_KEY not set");
             return;
         };
@@ -221,6 +218,10 @@ async fn canary_thinking_mode_no_unknown_content() {
 async fn canary_streaming_no_unknown_chunks() {
     require_api_key!(client);
 
+    // Not wrapped in retry_request! like its siblings: create_stream()
+    // returns a stream rather than a Result, so the whole consume-and-
+    // assert loop would have to move inside the closure. CI runs these
+    // with `nextest --retries 2`, which covers the transient case here.
     let mut stream = client
         .interaction()
         .with_model("gemini-3.6-flash")

--- a/tests/api_wire_format_live_tests.rs
+++ b/tests/api_wire_format_live_tests.rs
@@ -26,6 +26,8 @@
 //! These tests run in the `test-integration` CI job. If any canary test fails,
 //! it means the API has drifted and we need to update our types.
 
+mod common;
+
 use futures_util::StreamExt;
 use genai_rs::Client;
 use std::env;
@@ -59,13 +61,15 @@ macro_rules! require_api_key {
 async fn canary_basic_interaction_no_unknown_content() {
     require_api_key!(client);
 
-    let response = client
-        .interaction()
-        .with_model("gemini-3.6-flash")
-        .with_text("Say hello in exactly one word.")
-        .create()
-        .await
-        .expect("API call should succeed");
+    let response = retry_request!([client] => {
+        client
+            .interaction()
+            .with_model("gemini-3.6-flash")
+            .with_text("Say hello in exactly one word.")
+            .create()
+            .await
+    })
+    .expect("API call should succeed");
 
     // Check for Unknown step types in steps
     for (i, step) in response.steps.iter().enumerate() {
@@ -97,13 +101,15 @@ async fn canary_basic_interaction_no_unknown_content() {
 async fn canary_response_status_is_known() {
     require_api_key!(client);
 
-    let response = client
-        .interaction()
-        .with_model("gemini-3.6-flash")
-        .with_text("What is 2+2?")
-        .create()
-        .await
-        .expect("API call should succeed");
+    let response = retry_request!([client] => {
+        client
+            .interaction()
+            .with_model("gemini-3.6-flash")
+            .with_text("What is 2+2?")
+            .create()
+            .await
+    })
+    .expect("API call should succeed");
 
     assert!(
         !response.status.is_unknown(),
@@ -141,14 +147,16 @@ async fn canary_function_calling_no_unknown_content() {
         .required(vec!["city".to_string()])
         .build();
 
-    let response = client
-        .interaction()
-        .with_model("gemini-3.6-flash")
-        .with_text("What's the weather in Paris?")
-        .add_functions(vec![get_weather])
-        .create()
-        .await
-        .expect("API call should succeed");
+    let response = retry_request!([client, get_weather] => {
+        client
+            .interaction()
+            .with_model("gemini-3.6-flash")
+            .with_text("What's the weather in Paris?")
+            .add_functions(vec![get_weather.clone()])
+            .create()
+            .await
+    })
+    .expect("API call should succeed");
 
     // Check all output step types
     for (i, step) in response.steps.iter().enumerate() {
@@ -177,14 +185,16 @@ async fn canary_thinking_mode_no_unknown_content() {
 
     use genai_rs::ThinkingLevel;
 
-    let response = client
-        .interaction()
-        .with_model("gemini-3.6-flash")
-        .with_text("What is the square root of 144?")
-        .with_thinking_level(ThinkingLevel::Low)
-        .create()
-        .await
-        .expect("API call should succeed");
+    let response = retry_request!([client] => {
+        client
+            .interaction()
+            .with_model("gemini-3.6-flash")
+            .with_text("What is the square root of 144?")
+            .with_thinking_level(ThinkingLevel::Low)
+            .create()
+            .await
+    })
+    .expect("API call should succeed");
 
     // Check all output step types including thoughts
     for (i, step) in response.steps.iter().enumerate() {
@@ -250,14 +260,16 @@ async fn canary_streaming_no_unknown_chunks() {
 async fn canary_google_search_no_unknown_content() {
     require_api_key!(client);
 
-    let response = client
-        .interaction()
-        .with_model("gemini-3.6-flash")
-        .with_text("What is the current population of Tokyo according to recent data?")
-        .with_google_search()
-        .create()
-        .await
-        .expect("API call should succeed");
+    let response = retry_request!([client] => {
+        client
+            .interaction()
+            .with_model("gemini-3.6-flash")
+            .with_text("What is the current population of Tokyo according to recent data?")
+            .with_google_search()
+            .create()
+            .await
+    })
+    .expect("API call should succeed");
 
     // Check all output step types
     for (i, step) in response.steps.iter().enumerate() {
@@ -364,13 +376,15 @@ fn canary_builtin_tools_are_known() {
 async fn canary_comprehensive_response_check() {
     require_api_key!(client);
 
-    let response = client
-        .interaction()
-        .with_model("gemini-3.6-flash")
-        .with_text("Hello! Please respond with a friendly greeting.")
-        .create()
-        .await
-        .expect("API call should succeed");
+    let response = retry_request!([client] => {
+        client
+            .interaction()
+            .with_model("gemini-3.6-flash")
+            .with_text("Hello! Please respond with a friendly greeting.")
+            .create()
+            .await
+    })
+    .expect("API call should succeed");
 
     // Check status
     assert!(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -192,7 +192,7 @@ where
 /// ```ignore
 /// let response = retry_on_any_error(2, Duration::from_secs(2), || async {
 ///     let resp = client.interaction()
-///         .with_model("gemini-3-pro-image-preview")
+///         .with_model("gemini-3.1-flash-image")
 ///         .with_text("Generate an image of a cat")
 ///         .create()
 ///         .await?;
@@ -824,7 +824,18 @@ pub const TINY_PDF_BASE64: &str = "JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZ
 // =============================================================================
 
 /// Default model used across all tests.
-pub const DEFAULT_MODEL: &str = "gemini-3-flash-preview";
+pub const DEFAULT_MODEL: &str = "gemini-3.6-flash";
+
+/// Model for tests that send **inline (base64) video bytes**.
+///
+/// Verified live 2026-08-10: [`DEFAULT_MODEL`] rejects inline video with
+/// `400 invalid_request` while accepting video by URI — `test_video_input_from_uri`
+/// passes on it, and the three inline-video tests do not. Pinning those to a
+/// model that accepts the inline form keeps them testing *the bytes path*
+/// rather than the default model's appetite for it; every other modality
+/// (image, audio, PDF) works on the default.
+#[allow(dead_code)]
+pub const VIDEO_INLINE_MODEL: &str = "gemini-3-flash-preview";
 
 /// Creates a pre-configured interaction builder with the default model.
 ///

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -830,7 +830,8 @@ pub const DEFAULT_MODEL: &str = "gemini-3.6-flash";
 ///
 /// Verified live 2026-08-10: [`DEFAULT_MODEL`] rejects inline video with
 /// `400 invalid_request` while accepting video by URI — `test_video_input_from_uri`
-/// passes on it, and the three inline-video tests do not. Pinning those to a
+/// passes on it, and the four inline-video tests do not (three in
+/// `multimodal_tests.rs`, one in `temp_file_tests.rs`). Pinning those to a
 /// model that accepts the inline form keeps them testing *the bytes path*
 /// rather than the default model's appetite for it; every other modality
 /// (image, audio, PDF) works on the default.

--- a/tests/error_handling_tests.rs
+++ b/tests/error_handling_tests.rs
@@ -627,7 +627,7 @@ fn test_client_with_empty_api_key() {
     assert!(
         client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text("test")
             .build()
             .is_ok()
@@ -659,10 +659,7 @@ fn test_interaction_builder_missing_content() {
         .unwrap();
 
     // Building a request without content should fail
-    let result = client
-        .interaction()
-        .with_model("gemini-3-flash-preview")
-        .build();
+    let result = client.interaction().with_model("gemini-3.6-flash").build();
 
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
@@ -692,7 +689,7 @@ async fn test_invalid_api_key_returns_auth_error() {
 
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .create()
         .await;
@@ -738,7 +735,7 @@ async fn test_malformed_api_key() {
 
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Hello")
         .create()
         .await;

--- a/tests/files_api_tests.rs
+++ b/tests/files_api_tests.rs
@@ -2,6 +2,8 @@
 //!
 //! These tests verify file upload, listing, deletion, and integration with interactions.
 
+mod common;
+
 use genai_rs::{Client, Content};
 use std::time::Duration;
 
@@ -171,16 +173,18 @@ async fn test_file_in_interaction() {
     );
 
     // Use the file in an interaction
-    let response = client
-        .interaction()
-        .with_model("gemini-3.6-flash")
-        .with_content(vec![
-            Content::from_file(&ready_file),
-            Content::text("What city is mentioned in this document?"),
-        ])
-        .create()
-        .await
-        .expect("Interaction should succeed");
+    let response = retry_request!([client, ready_file] => {
+        client
+            .interaction()
+            .with_model("gemini-3.6-flash")
+            .with_content(vec![
+                Content::from_file(&ready_file),
+                Content::text("What city is mentioned in this document?"),
+            ])
+            .create()
+            .await
+    })
+    .expect("Interaction should succeed");
 
     // Verify we got a response - the model should return something
     let text = response.as_text().expect("Response should have text");
@@ -592,16 +596,18 @@ async fn test_chunked_upload_in_interaction() {
     assert!(ready_file.is_active(), "File should be active");
 
     // Use in interaction
-    let response = client
-        .interaction()
-        .with_model("gemini-3.6-flash")
-        .with_content(vec![
-            Content::from_file(&ready_file),
-            Content::text("What does the file say about a fox?"),
-        ])
-        .create()
-        .await
-        .expect("Interaction should succeed");
+    let response = retry_request!([client, ready_file] => {
+        client
+            .interaction()
+            .with_model("gemini-3.6-flash")
+            .with_content(vec![
+                Content::from_file(&ready_file),
+                Content::text("What does the file say about a fox?"),
+            ])
+            .create()
+            .await
+    })
+    .expect("Interaction should succeed");
 
     // Verify we got a response
     let text = response.as_text().expect("Response should have text");

--- a/tests/files_api_tests.rs
+++ b/tests/files_api_tests.rs
@@ -173,7 +173,7 @@ async fn test_file_in_interaction() {
     // Use the file in an interaction
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::from_file(&ready_file),
             Content::text("What city is mentioned in this document?"),
@@ -594,7 +594,7 @@ async fn test_chunked_upload_in_interaction() {
     // Use in interaction
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_content(vec![
             Content::from_file(&ready_file),
             Content::text("What does the file say about a fox?"),

--- a/tests/fixtures/mcp_echo_server.py
+++ b/tests/fixtures/mcp_echo_server.py
@@ -36,6 +36,11 @@ TOOLS = [
 ]
 
 # The marker the test greps for. Arbitrary on purpose.
+#
+# Duplicated as WIDGET_CODE in test_antigravity_mcp_server_tool_is_called
+# (tests/antigravity_harness.rs) — change both together. Getting it wrong
+# fails loudly rather than silently: the assertion prints the expected
+# token alongside the model's response.
 WIDGET_CODE = "wibble-3317-quux"
 
 

--- a/tests/fixtures/mcp_echo_server.py
+++ b/tests/fixtures/mcp_echo_server.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""A minimal stdio MCP server, used by `tests/antigravity_harness.rs`.
+
+Exposes exactly one tool, `lookup_widget_code`, whose answer is a token
+that exists nowhere else — so a response containing it can only have come
+from a real MCP round trip through the harness, not from the model.
+
+Deliberately hand-rolled JSON-RPC over stdio rather than a dependency:
+the test fixture must run on whatever `python3` the harness tests already
+require, with nothing installed.
+"""
+
+import json
+import sys
+
+PROTOCOL_VERSION = "2024-11-05"
+
+TOOLS = [
+    {
+        "name": "lookup_widget_code",
+        "description": (
+            "Look up the internal code for a widget. This is the only way to "
+            "obtain a widget code; it cannot be guessed or derived."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "widget": {
+                    "type": "string",
+                    "description": "The widget name to look up.",
+                }
+            },
+            "required": ["widget"],
+        },
+    }
+]
+
+# The marker the test greps for. Arbitrary on purpose.
+WIDGET_CODE = "wibble-3317-quux"
+
+
+def respond(msg_id, result):
+    return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+
+def error(msg_id, code, message):
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+def handle(request):
+    """Returns a response dict, or None for notifications."""
+    method = request.get("method")
+    msg_id = request.get("id")
+
+    # Notifications carry no id and must not be answered.
+    if msg_id is None:
+        return None
+
+    if method == "initialize":
+        return respond(
+            msg_id,
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "widgets", "version": "0.0.1"},
+            },
+        )
+    if method == "tools/list":
+        return respond(msg_id, {"tools": TOOLS})
+    if method == "tools/call":
+        params = request.get("params") or {}
+        if params.get("name") != "lookup_widget_code":
+            return error(msg_id, -32602, f"unknown tool: {params.get('name')!r}")
+        widget = (params.get("arguments") or {}).get("widget", "unnamed")
+        return respond(
+            msg_id,
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"The code for widget {widget!r} is {WIDGET_CODE}.",
+                    }
+                ],
+                "isError": False,
+            },
+        )
+    if method in ("ping", "shutdown"):
+        return respond(msg_id, {})
+
+    return error(msg_id, -32601, f"method not found: {method}")
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        try:
+            response = handle(request)
+        except Exception as exc:  # noqa: BLE001 - a fixture must not die silently
+            response = error(request.get("id"), -32603, f"internal error: {exc!r}")
+        if response is not None:
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/function_calling_tests.rs
+++ b/tests/function_calling_tests.rs
@@ -2295,22 +2295,40 @@ mod multiturn {
 
         let turn1_id = result1.id.clone().expect("Turn 1 should have ID");
 
-        // Turn 2: Follow-up WITHOUT resending tools
+        // Turn 2: Follow-up WITHOUT resending tools.
+        //
+        // Deliberately does NOT ask for a live weather lookup. A prompt like
+        // "what's the weather in Paris?" invites the model to call the tool it
+        // saw in turn 1 — and having not been given it, gemini-3.6-flash
+        // reliably emits a malformed call, which the API rejects with
+        // `400 Model generated invalid JSON syntax`. That failure survives
+        // retries and tells us nothing about the rule under test.
+        //
+        // Asking about the conversation instead exercises both halves of the
+        // documented inheritance contract in one turn: history IS inherited
+        // (the model can answer from turn 1), tools are NOT (no calls come
+        // back, because they were not resent).
         let result2 = retry_request!([client, turn1_id] => {
             stateful_builder(&client)
-                .with_text("What's the weather in Paris?")
+                .with_text("In one word, what topic did I say I was interested in?")
                 .with_previous_interaction(&turn1_id)
                 .create()
                 .await
         })
         .expect("Turn 2 should succeed");
 
-        // Model should NOT have any function calls since we didn't provide tools
+        // Tools are not inherited: no calls, despite turn 1 having declared one.
         let function_calls = result2.function_calls();
         assert!(
             function_calls.is_empty(),
             "Model should not make function calls when tools not provided (got {} calls)",
             function_calls.len()
+        );
+        // History IS inherited: the answer can only come from turn 1.
+        let text = result2.as_text().unwrap_or_default().to_lowercase();
+        assert!(
+            text.contains("weather"),
+            "conversation history should be inherited, got: {text:?}"
         );
     }
 

--- a/tests/function_calling_tests.rs
+++ b/tests/function_calling_tests.rs
@@ -2325,11 +2325,19 @@ mod multiturn {
             function_calls.len()
         );
         // History IS inherited: the answer can only come from turn 1.
-        let text = result2.as_text().unwrap_or_default().to_lowercase();
-        assert!(
-            text.contains("weather"),
-            "conversation history should be inherited, got: {text:?}"
-        );
+        // Semantic rather than substring — the model may answer
+        // "forecasts" or "meteorology", and a rephrase should not read as
+        // a broken inheritance contract (CLAUDE.md's guidance for
+        // non-deterministic text).
+        let text = result2.as_text().unwrap_or_default().to_string();
+        assert_response_semantic(
+            &client,
+            "The user previously said they were interested in weather data, then asked \
+             what topic they had mentioned.",
+            &text,
+            "Does this identify weather (or an equivalent term like forecasts) as the topic?",
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/tests/function_calling_tests.rs
+++ b/tests/function_calling_tests.rs
@@ -464,12 +464,14 @@ mod parallel {
                 .required(vec!["timezone".to_string()])
                 .build();
 
-            let response1 = stateful_builder(&client)
-                .with_text("Tell me BOTH the weather in Paris AND the time in CET. Call both functions.")
-                .add_functions(vec![get_weather, get_time])
-                .create()
-                .await
-                .expect("First interaction failed");
+            let response1 = retry_request!([client, get_weather, get_time] => {
+                stateful_builder(&client)
+                    .with_text("Tell me BOTH the weather in Paris AND the time in CET. Call both functions.")
+                    .add_functions(vec![get_weather.clone(), get_time.clone()])
+                    .create()
+                    .await
+            })
+            .expect("First interaction failed");
 
             let calls = response1.function_calls();
             if calls.is_empty() {
@@ -495,12 +497,15 @@ mod parallel {
 
             println!("Sending {} function result(s) WITHOUT resending tools", results.len());
 
-            let response2 = stateful_builder(&client)
-                .with_previous_interaction(response1.id.as_ref().expect("id should exist"))
-                .with_history(results)
-                .create()
-                .await
-                .expect("Parallel results turn failed - tools should not be required");
+            let prev_id = response1.id.clone().expect("id should exist");
+            let response2 = retry_request!([client, prev_id, results] => {
+                stateful_builder(&client)
+                    .with_previous_interaction(&prev_id)
+                    .with_history(results.clone())
+                    .create()
+                    .await
+            })
+            .expect("Parallel results turn failed - tools should not be required");
 
             println!("Step 2 status: {:?}", response2.status);
             if response2.has_text() {

--- a/tests/function_calling_tests.rs
+++ b/tests/function_calling_tests.rs
@@ -558,7 +558,7 @@ mod parallel {
 
                 let response2 = client
                     .interaction()
-                    .with_model("gemini-3-flash-preview")
+                    .with_model("gemini-3.6-flash")
                     .with_previous_interaction(response1.id.as_ref().expect("id required"))
                     .with_history(results)
                     .create()
@@ -628,7 +628,7 @@ mod parallel {
 
                 let response2 = client
                     .interaction()
-                    .with_model("gemini-3-flash-preview")
+                    .with_model("gemini-3.6-flash")
                     .with_previous_interaction(response1.id.as_ref().expect("id required"))
                     .with_history(results)
                     .create()
@@ -1220,7 +1220,7 @@ mod auto_execution {
 
         let result = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text("What's the weather in Seattle?")
             .add_functions(functions)
             .with_store_enabled()
@@ -1311,7 +1311,7 @@ mod stateless {
 
             let response1 = client
                 .interaction()
-                .with_model("gemini-3-flash-preview")
+                .with_model("gemini-3.6-flash")
                 .with_history(history.clone())
                 .add_functions(functions.clone())
                 .with_store_disabled()
@@ -1335,7 +1335,7 @@ mod stateless {
 
             let response2 = client
                 .interaction()
-                .with_model("gemini-3-flash-preview")
+                .with_model("gemini-3.6-flash")
                 .with_history(history.clone())
                 .add_functions(functions.clone())
                 .with_store_disabled()
@@ -1380,7 +1380,7 @@ mod stateless {
         // Stateless with thinking enabled, force function calling
         let response = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_history(history)
             .add_function(get_weather)
             .with_thinking_level(ThinkingLevel::Medium)
@@ -2200,7 +2200,7 @@ mod multiturn {
         println!("--- Turn 1: Initial request with system instruction ---");
         let result1 = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text("What's the weather in Seattle?")
             .add_functions(functions.clone())
             .with_store_enabled()
@@ -2229,7 +2229,7 @@ mod multiturn {
         println!("\n--- Turn 2: Follow-up conversation ---");
         let result2 = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text("How about in Tokyo?")
             .add_functions(functions.clone())
             .with_store_enabled()
@@ -2250,7 +2250,7 @@ mod multiturn {
         println!("\n--- Turn 3: Follow-up without function call ---");
         let result3 = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text("Based on the weather you just told me about Seattle and Tokyo, which city is warmer right now?")
             .add_functions(functions)
             .with_store_enabled()
@@ -2327,7 +2327,7 @@ mod multiturn {
         // Turn 1: Initial request with system instruction
         let response1 = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text("What's the weather in London and what time is it there?")
             .add_functions(functions.clone())
             .with_store_enabled()
@@ -2363,7 +2363,7 @@ mod multiturn {
         // Send function results back
         let response2 = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_previous_interaction(response1.id.as_ref().expect("Should have ID"))
             .with_history(results)
             .add_functions(functions.clone())
@@ -2381,7 +2381,7 @@ mod multiturn {
         // Turn 3: Follow-up
         let response3 = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text("Is it a good time to call someone there?")
             .add_functions(functions)
             .with_store_enabled()
@@ -2413,7 +2413,7 @@ mod multiturn {
                 // Turn 1: Set system instruction to always respond in haiku format
                 let response1 = client
                     .interaction()
-                    .with_model("gemini-3-flash-preview")
+                    .with_model("gemini-3.6-flash")
                     .with_text("Hello!")
                     .with_store_enabled()
                     .with_system_instruction("You are a haiku poet. Always respond in haiku format (5-7-5 syllables). Never break from this format.")
@@ -2425,7 +2425,7 @@ mod multiturn {
                 // Turn 2: Follow-up - system instruction should still be in effect
                 let response2 = client
                     .interaction()
-                    .with_model("gemini-3-flash-preview")
+                    .with_model("gemini-3.6-flash")
                     .with_text("Tell me about the ocean.")
                     .with_store_enabled()
                     .with_previous_interaction(&turn1_id)
@@ -2477,7 +2477,7 @@ mod multiturn {
         // Turn 1: Initial request streaming with auto functions
         let mut stream = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text("What's the weather in Miami?")
             .add_functions(functions.clone())
             .with_store_enabled()
@@ -2516,7 +2516,7 @@ mod multiturn {
         // Turn 2: Follow-up streaming
         let mut stream2 = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text("Compare that to New York.")
             .add_functions(functions)
             .with_store_enabled()
@@ -2576,7 +2576,7 @@ mod multiturn {
         println!("--- Turn 1: Trigger function that will fail ---");
         let response1 = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_text("Get the secret data for key 'test123'")
             .add_function(secret_function.clone())
             .with_store_enabled()
@@ -2601,7 +2601,7 @@ mod multiturn {
         println!("\n--- Sending error result ---");
         let response2 = client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_previous_interaction(response1.id.as_ref().expect("Should have ID"))
             .with_history(vec![error_result])
             .add_function(secret_function)

--- a/tests/interactions_api_tests.rs
+++ b/tests/interactions_api_tests.rs
@@ -148,11 +148,15 @@ mod basic {
             return;
         };
 
-        let response = stateful_builder(&client)
-            .with_text("Hello, world!")
-            .create()
-            .await
-            .expect("Interaction failed");
+        // The interaction is only setup for the get; a transient 429/5xx
+        // here says nothing about whether get_interaction works.
+        let response = retry_request!([client] => {
+            stateful_builder(&client)
+                .with_text("Hello, world!")
+                .create()
+                .await
+        })
+        .expect("Interaction failed");
 
         let retrieved = client
             .get_interaction(response.id.as_ref().expect("id should exist"))
@@ -172,11 +176,14 @@ mod basic {
             return;
         };
 
-        let response = stateful_builder(&client)
-            .with_text("Test interaction for deletion")
-            .create()
-            .await
-            .expect("Interaction failed");
+        // Setup for the delete, same as above.
+        let response = retry_request!([client] => {
+            stateful_builder(&client)
+                .with_text("Test interaction for deletion")
+                .create()
+                .await
+        })
+        .expect("Interaction failed");
 
         client
             .delete_interaction(response.id.as_ref().expect("id should exist"))

--- a/tests/interactions_api_tests.rs
+++ b/tests/interactions_api_tests.rs
@@ -377,7 +377,7 @@ mod streaming {
 
         with_timeout(test_timeout(), async {
             let request = InteractionRequest {
-                model: Some("gemini-3-flash-preview".to_string()),
+                model: Some("gemini-3.6-flash".to_string()),
                 agent: None,
                 agent_config: None,
                 input: InteractionInput::Text("Count from 1 to 5.".to_string()),
@@ -1024,7 +1024,13 @@ mod generation_config {
 
         let config = GenerationConfig {
             temperature: Some(0.0),
-            max_output_tokens: Some(100),
+            // Headroom, deliberately: this test is about `temperature`, not
+            // truncation. gemini-3.6-flash spends ~100 thinking tokens on
+            // even this trivial prompt (verified live 2026-08-10: ~99-102
+            // total for a 1-token answer), so the old 100-token cap made
+            // "is there any text left?" a coin flip rather than a
+            // temperature assertion.
+            max_output_tokens: Some(2000),
             top_p: None,
             thinking_level: None,
             ..Default::default()
@@ -1556,7 +1562,7 @@ mod multimodal {
             return;
         };
 
-        let model = "gemini-3-pro-image-preview";
+        let model = "gemini-3.1-flash-image";
         let prompt = "A simple red circle on a white background";
 
         println!("Generating image with model: {}", model);

--- a/tests/interactions_api_tests.rs
+++ b/tests/interactions_api_tests.rs
@@ -106,7 +106,10 @@ mod basic {
             return;
         };
 
-        with_timeout(test_timeout(), async {
+        // Extended, not the 60s default: two retried calls plus their round
+        // trips can exceed it on a slow API day, and the surface would then
+        // be an opaque harness timeout instead of the underlying error.
+        with_timeout(extended_test_timeout(), async {
             let response1 = retry_request!([client] => {
                 stateful_builder(&client)
                     .with_text("My favorite color is blue.")

--- a/tests/interactions_api_tests.rs
+++ b/tests/interactions_api_tests.rs
@@ -107,20 +107,25 @@ mod basic {
         };
 
         with_timeout(test_timeout(), async {
-            let response1 = stateful_builder(&client)
-                .with_text("My favorite color is blue.")
-                .create()
-                .await
-                .expect("First interaction failed");
+            let response1 = retry_request!([client] => {
+                stateful_builder(&client)
+                    .with_text("My favorite color is blue.")
+                    .create()
+                    .await
+            })
+            .expect("First interaction failed");
 
             assert_eq!(response1.status, InteractionStatus::Completed);
 
-            let response2 = stateful_builder(&client)
-                .with_previous_interaction(response1.id.as_ref().expect("id should exist"))
-                .with_text("What is my favorite color?")
-                .create()
-                .await
-                .expect("Second interaction failed");
+            let prev_id = response1.id.clone().expect("id should exist");
+            let response2 = retry_request!([client, prev_id] => {
+                stateful_builder(&client)
+                    .with_previous_interaction(&prev_id)
+                    .with_text("What is my favorite color?")
+                    .create()
+                    .await
+            })
+            .expect("Second interaction failed");
 
             assert_eq!(response2.status, InteractionStatus::Completed);
             assert!(
@@ -1411,21 +1416,20 @@ mod conversations {
             let mut previous_id: Option<String> = None;
 
             for (i, message) in messages.iter().enumerate() {
-                let response = match &previous_id {
-                    None => {
-                        stateful_builder(&client)
-                            .with_text(*message)
-                            .create()
-                            .await
+                // A five-turn chain gives a transient 429/5xx five chances
+                // to fail a test that is asserting about conversation
+                // memory, not about transport.
+                let message = (*message).to_string();
+                let prev = previous_id.clone();
+                let response = retry_request!([client, message, prev] => {
+                    let builder = stateful_builder(&client).with_text(&message);
+                    match &prev {
+                        None => builder.create().await,
+                        Some(prev_id) => {
+                            builder.with_previous_interaction(prev_id).create().await
+                        }
                     }
-                    Some(prev_id) => {
-                        stateful_builder(&client)
-                            .with_text(*message)
-                            .with_previous_interaction(prev_id)
-                            .create()
-                            .await
-                    }
-                }
+                })
                 .unwrap_or_else(|e| panic!("Turn {} failed: {:?}", i + 1, e));
 
                 println!("Turn {}: {:?}", i + 1, response.status);
@@ -1464,13 +1468,15 @@ mod conversations {
         let initial_prompt = "What is 15 * 7? Show your work.";
         println!("Turn 1 prompt: {}\n", initial_prompt);
 
-        let response1 = interaction_builder(&client)
-            .with_text(initial_prompt)
-            .with_thinking_level(ThinkingLevel::Medium)
-            .with_store_enabled()
-            .create()
-            .await
-            .expect("Turn 1 failed");
+        let response1 = retry_request!([client] => {
+            interaction_builder(&client)
+                .with_text(initial_prompt)
+                .with_thinking_level(ThinkingLevel::Medium)
+                .with_store_enabled()
+                .create()
+                .await
+        })
+        .expect("Turn 1 failed");
 
         assert_eq!(response1.status, InteractionStatus::Completed);
 
@@ -1491,13 +1497,15 @@ mod conversations {
 
         println!("\nTurn 2 prompt: Now divide that result by 5");
 
-        let response2 = interaction_builder(&client)
-            .with_history(history)
-            .with_thinking_level(ThinkingLevel::Low)
-            .with_store_enabled()
-            .create()
-            .await
-            .expect("Turn 2 failed");
+        let response2 = retry_request!([client, history] => {
+            interaction_builder(&client)
+                .with_history(history.clone())
+                .with_thinking_level(ThinkingLevel::Low)
+                .with_store_enabled()
+                .create()
+                .await
+        })
+        .expect("Turn 2 failed");
 
         assert_eq!(response2.status, InteractionStatus::Completed);
         assert!(response2.has_text(), "Turn 2 should have text response");

--- a/tests/multimodal_tests.rs
+++ b/tests/multimodal_tests.rs
@@ -364,6 +364,8 @@ mod video {
 
         let response = crate::retry_request!([client, contents] => {
             stateful_builder(&client)
+                // Inline video bytes — see VIDEO_INLINE_MODEL.
+                .with_model(crate::common::VIDEO_INLINE_MODEL)
                 .with_input(InteractionInput::Content(contents))
                 .create()
                 .await
@@ -556,6 +558,8 @@ mod mixed_media {
 
         let result = crate::retry_request!([client, contents] => {
             stateful_builder(&client)
+                // Inline video bytes — see VIDEO_INLINE_MODEL.
+                .with_model(crate::common::VIDEO_INLINE_MODEL)
                 .with_input(InteractionInput::Content(contents))
                 .create()
                 .await
@@ -773,7 +777,7 @@ mod file_loading {
         let response = crate::retry_request!([client, contents] => {
             client
                 .interaction()
-                .with_model("gemini-3-flash-preview")
+                .with_model("gemini-3.6-flash")
                 .with_content(contents)
                 .create()
                 .await
@@ -843,7 +847,7 @@ mod file_loading {
         let response = crate::retry_request!([client, contents] => {
             client
                 .interaction()
-                .with_model("gemini-3-flash-preview")
+                .with_model("gemini-3.6-flash")
                 .with_content(contents)
                 .create()
                 .await
@@ -913,7 +917,7 @@ mod bytes_loading {
         let response = crate::retry_request!([client, contents] => {
             client
                 .interaction()
-                .with_model("gemini-3-flash-preview")
+                .with_model("gemini-3.6-flash")
                 .with_content(contents)
                 .create()
                 .await
@@ -957,7 +961,7 @@ mod bytes_loading {
         let result = crate::retry_request!([client, contents] => {
             client
                 .interaction()
-                .with_model("gemini-3-flash-preview")
+                .with_model("gemini-3.6-flash")
                 .with_content(contents)
                 .create()
                 .await
@@ -990,7 +994,8 @@ mod bytes_loading {
         let result = crate::retry_request!([client, contents] => {
             client
                 .interaction()
-                .with_model("gemini-3-flash-preview")
+                // Inline video bytes — see VIDEO_INLINE_MODEL.
+                .with_model(crate::common::VIDEO_INLINE_MODEL)
                 .with_content(contents)
                 .create()
                 .await
@@ -1028,7 +1033,7 @@ mod bytes_loading {
         let result = crate::retry_request!([client, contents] => {
             client
                 .interaction()
-                .with_model("gemini-3-flash-preview")
+                .with_model("gemini-3.6-flash")
                 .with_content(contents)
                 .create()
                 .await

--- a/tests/multiturn_tests.rs
+++ b/tests/multiturn_tests.rs
@@ -191,13 +191,20 @@ async fn test_conversation_function_then_text() {
         .required(vec!["city".to_string()])
         .build();
 
+    // Every turn goes through retry_request! for the same reason the
+    // branch test below does: three sequential live calls give a transient
+    // 429/5xx three chances to fail the run, and a rate limit is not what
+    // this test is asserting about.
+    //
     // Turn 1: Trigger function call
-    let response1 = stateful_builder(&client)
-        .with_text("What's the weather in Tokyo?")
-        .add_function(get_weather.clone())
-        .create()
-        .await
-        .expect("Turn 1 failed");
+    let response1 = retry_request!([client, get_weather] => {
+        stateful_builder(&client)
+            .with_text("What's the weather in Tokyo?")
+            .add_function(get_weather.clone())
+            .create()
+            .await
+    })
+    .expect("Turn 1 failed");
 
     println!("Turn 1 status: {:?}", response1.status);
 
@@ -216,13 +223,16 @@ async fn test_conversation_function_then_text() {
         json!({"temperature": "25°C", "conditions": "sunny"}),
     );
 
-    let response2 = stateful_builder(&client)
-        .with_previous_interaction(response1.id.as_ref().expect("id should exist"))
-        .with_history(vec![result])
-        .add_function(get_weather.clone())
-        .create()
-        .await
-        .expect("Turn 2 failed");
+    let prev_id = response1.id.clone().expect("id should exist");
+    let response2 = retry_request!([client, prev_id, get_weather, result] => {
+        stateful_builder(&client)
+            .with_previous_interaction(&prev_id)
+            .with_history(vec![result.clone()])
+            .add_function(get_weather.clone())
+            .create()
+            .await
+    })
+    .expect("Turn 2 failed");
 
     println!("Turn 2 status: {:?}", response2.status);
     if response2.has_text() {
@@ -230,13 +240,16 @@ async fn test_conversation_function_then_text() {
     }
 
     // Turn 3: Follow-up text question (no function call expected)
-    let response3 = stateful_builder(&client)
-        .with_previous_interaction(response2.id.as_ref().expect("id should exist"))
-        .with_text("Should I bring a jacket?")
-        .add_function(get_weather)
-        .create()
-        .await
-        .expect("Turn 3 failed");
+    let prev_id = response2.id.clone().expect("id should exist");
+    let response3 = retry_request!([client, prev_id, get_weather] => {
+        stateful_builder(&client)
+            .with_previous_interaction(&prev_id)
+            .with_text("Should I bring a jacket?")
+            .add_function(get_weather.clone())
+            .create()
+            .await
+    })
+    .expect("Turn 3 failed");
 
     println!("Turn 3 status: {:?}", response3.status);
     assert!(response3.has_text(), "Turn 3 should have text response");

--- a/tests/multiturn_tests.rs
+++ b/tests/multiturn_tests.rs
@@ -494,7 +494,7 @@ async fn test_conversation_builder_fluent_api() {
 
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .conversation()
         .user("My name is Alice and I love hiking.")
         .model("Nice to meet you, Alice! Hiking is a wonderful outdoor activity.")

--- a/tests/temp_file_tests.rs
+++ b/tests/temp_file_tests.rs
@@ -495,6 +495,10 @@ async fn test_video_from_temp_file() {
 
     let response = crate::retry_request!([client, contents] => {
         stateful_builder(&client)
+            // Inline video bytes — see VIDEO_INLINE_MODEL. `video_from_file`
+            // reads the file into base64 inline data, so this is the same
+            // path the multimodal inline-video tests pin.
+            .with_model(crate::common::VIDEO_INLINE_MODEL)
             .with_input(InteractionInput::Content(contents))
             .create()
             .await

--- a/tests/tools_and_config_tests.rs
+++ b/tests/tools_and_config_tests.rs
@@ -1301,7 +1301,11 @@ mod thinking {
 
         let config = GenerationConfig {
             temperature: Some(0.7),
-            max_output_tokens: Some(500),
+            // Headroom for the same reason as the High case below: thinking
+            // draws from this budget. Minimal should need far less, which
+            // is the point of the level — but the assertion here is that
+            // the level is accepted, not that 500 tokens is enough.
+            max_output_tokens: Some(2000),
             thinking_level: Some(ThinkingLevel::Minimal),
             ..Default::default()
         };
@@ -1341,7 +1345,13 @@ mod thinking {
 
         let config = GenerationConfig {
             temperature: Some(0.7),
-            max_output_tokens: Some(1000),
+            // Headroom: thinking tokens are drawn from this same budget,
+            // and ThinkingLevel::High on a step-by-step prompt can consume
+            // 1000 on its own — which surfaced as an intermittent
+            // `Incomplete` status rather than as anything about thinking.
+            // This test is about the level being accepted and honored, not
+            // about truncation behavior.
+            max_output_tokens: Some(8000),
             thinking_level: Some(ThinkingLevel::High),
             ..Default::default()
         };

--- a/tests/tools_and_config_tests.rs
+++ b/tests/tools_and_config_tests.rs
@@ -1245,7 +1245,7 @@ mod image_generation {
             async move {
                 let response = client
                     .interaction()
-                    .with_model("gemini-3-pro-image-preview")
+                    .with_model("gemini-3.1-flash-image")
                     .with_text("Generate a simple image of a red circle on a white background.")
                     .with_response_modalities(vec!["image".to_string()])
                     .with_store_enabled()
@@ -1604,7 +1604,7 @@ mod config_fields {
         // Raw request: the typed InteractionRequest no longer carries the
         // field, so build the JSON body directly.
         let body = json!({
-            "model": "gemini-3-flash-preview",
+            "model": "gemini-3.6-flash",
             "input": "Generate a greeting in Spanish.",
             "response_mime_type": "application/json",
         });

--- a/tests/tools_and_config_tests.rs
+++ b/tests/tools_and_config_tests.rs
@@ -727,11 +727,13 @@ mod structured_output {
             "required": ["name", "age", "email"]
         });
 
-        let result = stateful_builder(&client)
-            .with_text("Generate a fake user profile with a name, age, and email address.")
-            .with_response_format(schema)
-            .create()
-            .await;
+        let result = retry_request!([client, schema] => {
+            stateful_builder(&client)
+                .with_text("Generate a fake user profile with a name, age, and email address.")
+                .with_response_format(schema.clone())
+                .create()
+                .await
+        });
 
         let response = result.expect("Structured output request should succeed");
         assert_eq!(response.status, InteractionStatus::Completed);

--- a/tests/tools_and_config_tests.rs
+++ b/tests/tools_and_config_tests.rs
@@ -1431,7 +1431,15 @@ mod sampling {
         // Low top_p = more focused/deterministic
         let config = GenerationConfig {
             temperature: Some(1.0),
-            max_output_tokens: Some(100),
+            // Headroom, deliberately: this test is about `top_p`, not
+            // truncation. gemini-3.6-flash spends ~100 thinking tokens on
+            // even this trivial prompt (verified live 2026-08-10: ~99-102
+            // total for a 1-token answer), so the old 100-token cap made
+            // "is there any text left?" a coin flip rather than a top_p
+            // assertion — the same fix as its siblings
+            // `test_generation_config_temperature` (100 -> 2000) and
+            // `test_generation_config_thinking_level_high` (1000 -> 8000).
+            max_output_tokens: Some(2000),
             top_p: Some(0.1), // Very focused
             ..Default::default()
         };

--- a/tests/webhooks_and_agents_tests.rs
+++ b/tests/webhooks_and_agents_tests.rs
@@ -167,7 +167,7 @@ async fn test_interaction_with_webhook_config() {
     // background=true is also set.
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Say hello.")
         .with_background(true)
         .with_webhook_config(
@@ -369,7 +369,7 @@ async fn test_retrieval_tool_request_accepted() {
     // on the Gemini API and this test should be upgraded.
     let result = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("What does our internal handbook say about PTO?")
         .add_tool(
             RetrievalConfig::new().with_vertex_ai_search(
@@ -412,7 +412,7 @@ async fn test_typed_text_response_format() {
     // raw-schema response_format.
     let response = client
         .interaction()
-        .with_model("gemini-3-flash-preview")
+        .with_model("gemini-3.6-flash")
         .with_text("Generate info for a person named Alice, age 30")
         .with_response_format(ResponseFormat::json_schema(serde_json::json!({
             "type": "object",
@@ -559,7 +559,7 @@ async fn test_transcription_config_accepted() {
     let response = crate::retry_request!([client] => {
         client
             .interaction()
-            .with_model("gemini-3-flash-preview")
+            .with_model("gemini-3.6-flash")
             .with_content(vec![
                 genai_rs::Content::text(
                     "Transcribe this short clip. If it is silent, say 'Silent audio.'",
@@ -607,7 +607,7 @@ async fn test_safety_settings_and_labels_vertex_gated() {
         let result = crate::retry_request!([client, knob] => {
             let builder = client
                 .interaction()
-                .with_model("gemini-3-flash-preview")
+                .with_model("gemini-3.6-flash")
                 .with_text("Say OK.");
             let builder = match knob {
                 "safety_settings" => builder.add_safety_setting(SafetySetting::new(
@@ -897,7 +897,7 @@ async fn test_triggers_list_and_gated_create() {
     // interaction is rejected with "Agent '' is invalid or not found").
     // Tolerate the gate; assert the payload schema itself was accepted.
     let interaction = InteractionRequest {
-        model: Some("gemini-3-flash-preview".to_string()),
+        model: Some("gemini-3.6-flash".to_string()),
         input: InteractionInput::Text("Say OK".to_string()),
         ..Default::default()
     };

--- a/tests/wire_format_verification_tests.rs
+++ b/tests/wire_format_verification_tests.rs
@@ -20,7 +20,8 @@ use serde_json::json;
 // ThinkingSummaries Wire Format Tests
 // CONTEXT-DEPENDENT SERIALIZATION:
 // - GenerationConfig: lowercase ("auto", "none") via Serialize impl
-// - AgentConfig: SCREAMING_CASE ("THINKING_SUMMARIES_AUTO") via to_agent_config_value()
+// - AgentConfig: lowercase ("auto") via to_agent_config_value(); the older
+//   SCREAMING_CASE spelling is still accepted on deserialize only
 // - Deserialization: SCREAMING_CASE always (what API returns)
 // =============================================================================
 
@@ -46,19 +47,13 @@ mod thinking_summaries {
     #[test]
     fn auto_to_agent_config_uses_screaming_case() {
         let value = ThinkingSummaries::Auto;
-        assert_eq!(
-            value.to_agent_config_value(),
-            json!("THINKING_SUMMARIES_AUTO")
-        );
+        assert_eq!(value.to_agent_config_value(), json!("auto"));
     }
 
     #[test]
     fn none_to_agent_config_uses_screaming_case() {
         let value = ThinkingSummaries::None;
-        assert_eq!(
-            value.to_agent_config_value(),
-            json!("THINKING_SUMMARIES_NONE")
-        );
+        assert_eq!(value.to_agent_config_value(), json!("none"));
     }
 
     // Deserialization accepts SCREAMING_CASE (what API returns)


### PR DESCRIPTION
Folds into the **0.9.0** entry rather than trailing it: 0.9.0 was tagged but the release run failed before the publish step, so nothing is on crates.io and there are no consumers to break.

Work is still landing on this branch — new antigravity worked examples and their harness tests are in progress and will be pushed here.

## 1. Harness 0.1.10 — turn completion was broken

We pinned `google-antigravity==0.1.5`; PyPI is at **0.1.10**. Two wire spellings the bridge depends on were renamed in that range, and both failed *silently*:

| Renamed | Consequence |
|---|---|
| `STATE_IDLE` → `STATE_FULLY_IDLE` | Only that value ends a turn, so **every turn ran to its full timeout** — no parse error, no failed assertion, just a bare `Timeout { operation: "agent turn" }` |
| `usageMetadata` → `usageUpdate` (now `{agents[], total}`) | Token accounting silently zeroed; additionally misreported as an unknown payload variant |

Confirmed empirically before fixing: on 0.1.10 the harness suite went **7 pass / 3 fail**, with all three model-backed turns timing out at 120s.

This is the Evergreen posture's blind spot, and it's worth stating precisely: preserving an unknown value prevents a *crash*, but when the renamed value is one the code **matches on**, preservation is exactly what makes the break invisible.

Wire enums gain alias support, so both spellings resolve to one variant while `as_wire_str` keeps emitting the canonical form — **one build drives either revision**. Also adds the non-terminal `STATE_WAITING_FOR_TASKS` introduced in 0.1.10.

Verified: **10/10 on 0.1.5 and 10/10 on 0.1.10** (chat turns complete in ~2.8s instead of hanging).

Determined by diffing the two wheels' protobuf descriptors rather than release notes — the GitHub notes don't render and `antigravity.google` is unreachable from CI.

## 2. Debug infrastructure

Motivated by how invisible the above was:

- **A stalled turn diagnoses itself.** A timeout that saw unrecognized *main-trajectory* states now names them and points at `SUPPORTED_HARNESS_VERSION`, instead of an undifferentiated stall that looks identical to latency.
- **CI's antigravity job now receives `GEMINI_API_KEY`** (with the same-repo fork guard the integration matrix uses). Its model-backed tests are the only ones driving a real turn end-to-end — without a key they self-skipped, which is why this reached a release unnoticed.
- **The version-pinning docs no longer claim newer harnesses "degrade gracefully."** True (no crash), materially misleading (every turn hung). Rewritten around this as the worked example.

## 3. Model migration

`gemini-3-flash-preview` → `gemini-3.6-flash` (581 occurrences) and `gemini-3-pro-image-preview` → `gemini-3.1-flash-image` (25). Both probed live before migrating; CLAUDE.md's convention updated.

Retesting surfaced a capability difference worth knowing: **`gemini-3.6-flash` rejects inline (base64) video** with a 400 while accepting video **by URI**. Isolated precisely — 22/25 multimodal tests pass, the 3 failures are all inline-video, and `test_video_input_from_uri` passes on it. Image, audio and PDF inline data are unaffected. Those three tests are pinned to `tests/common::VIDEO_INLINE_MODEL` so they keep testing *the bytes path* rather than the model's appetite for it.

Also raises `max_output_tokens` in `test_generation_config_temperature`: `gemini-3.6-flash` spends ~100 thinking tokens on even that trivial prompt (~99–102 total for a 1-token answer), so the old 100-token cap made "is there any text left?" a coin flip in a test that is about temperature, not truncation.

## 4. `thinking_summaries` sent a value the API rejects

`to_agent_config_value()` emitted the SCREAMING_CASE `THINKING_SUMMARIES_AUTO` / `_NONE` form. Verified live:

```
The value 'THINKING_SUMMARIES_AUTO' is not supported for
'agent_config.thinking_summaries'. Supported values: 'auto', 'none'.
```

So **any deep-research request carrying thinking summaries failed outright**. Two tests were logging this and skipping, which is how it survived. Both contexts now emit lowercase; deserialization still accepts either spelling (Evergreen). Emit-side expectations updated; deserialize-side back-compat left intact.

## Verification

All run locally against the live API and a real harness:

- `interactions_api` 37/37 · `multimodal` 25/25 · `tools_and_config` 30/30 · `agents` 4/4 · `api_canary` 6/6
- antigravity harness **10/10 on both 0.1.5 and 0.1.10**
- fmt, clippy (`--all-targets --all-features -D warnings`), and all three doc configurations (all-features, docs.rs feature set, and **default features** — the config no CI gate builds, which is how the feature-gated intra-doc links in #405 slipped through)

## Release note

After merge the `v0.9.0` tag needs moving to the new commit before re-running the release — the existing tag points at a commit that pins harness 0.1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqkKDDoTDKUp9zBk4M8WGH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqkKDDoTDKUp9zBk4M8WGH)_