### PR TITLE
Release 0.10.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,13 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
-        run: sudo apt-get update && sudo apt-get install -y mold
+        # Same stall ceiling as rust.yml's mold installs, and it matters more
+        # here: a stall holds publishing after the tag already exists. The
+        # `|| true` also matches rust.yml — a transient mirror error on
+        # `update` should not fail the release when the install can still
+        # proceed from cached lists.
+        timeout-minutes: 5
+        run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Check workspace
         run: cargo check --workspace --all-targets --all-features
       - name: Run unit tests
@@ -101,7 +107,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
-        run: sudo apt-get update && sudo apt-get install -y mold
+        # Same stall ceiling as rust.yml's mold installs, and it matters more
+        # here: a stall holds publishing after the tag already exists. The
+        # `|| true` also matches rust.yml — a transient mirror error on
+        # `update` should not fail the release when the install can still
+        # proceed from cached lists.
+        timeout-minutes: 5
+        run: sudo apt-get update || true; sudo apt-get install -y mold
 
       - name: Verify tag matches Cargo.toml version
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
+        # Bounded because an unresponsive apt mirror hangs here rather than
+        # failing: one PR run sat 98 minutes on this step and would have held
+        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
+        # ceiling only ever trips on a stall, and it trips fast enough to be
+        # worth re-running.
+        timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Check workspace
         run: cargo check --workspace --all-targets --all-features
@@ -32,6 +38,12 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
+        # Bounded because an unresponsive apt mirror hangs here rather than
+        # failing: one PR run sat 98 minutes on this step and would have held
+        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
+        # ceiling only ever trips on a stall, and it trips fast enough to be
+        # worth re-running.
+        timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Run unit tests
         run: cargo nextest run --workspace
@@ -49,6 +61,12 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
+        # Bounded because an unresponsive apt mirror hangs here rather than
+        # failing: one PR run sat 98 minutes on this step and would have held
+        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
+        # ceiling only ever trips on a stall, and it trips fast enough to be
+        # worth re-running.
+        timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Run unit tests with strict-unknown feature
         run: cargo nextest run --workspace --features strict-unknown
@@ -64,6 +82,12 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
+        # Bounded because an unresponsive apt mirror hangs here rather than
+        # failing: one PR run sat 98 minutes on this step and would have held
+        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
+        # ceiling only ever trips on a stall, and it trips fast enough to be
+        # worth re-running.
+        timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Install pinned localharness wheel
         # Version must match SUPPORTED_HARNESS_VERSION in src/antigravity/.
@@ -301,6 +325,12 @@ jobs:
         with:
           shared-key: integration-${{ matrix.group }}
       - name: Install mold linker
+        # Bounded because an unresponsive apt mirror hangs here rather than
+        # failing: one PR run sat 98 minutes on this step and would have held
+        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
+        # ceiling only ever trips on a stall, and it trips fast enough to be
+        # worth re-running.
+        timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Run integration tests (${{ matrix.group }})
         run: |
@@ -374,6 +404,12 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
+        # Bounded because an unresponsive apt mirror hangs here rather than
+        # failing: one PR run sat 98 minutes on this step and would have held
+        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
+        # ceiling only ever trips on a stall, and it trips fast enough to be
+        # worth re-running.
+        timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
@@ -386,6 +422,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
+        # Bounded because an unresponsive apt mirror hangs here rather than
+        # failing: one PR run sat 98 minutes on this step and would have held
+        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
+        # ceiling only ever trips on a stall, and it trips fast enough to be
+        # worth re-running.
+        timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Check documentation (all features)
         run: cargo doc --workspace --no-deps --all-features --document-private-items
@@ -409,6 +451,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
+        # Bounded because an unresponsive apt mirror hangs here rather than
+        # failing: one PR run sat 98 minutes on this step and would have held
+        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
+        # ceiling only ever trips on a stall, and it trips fast enough to be
+        # worth re-running.
+        timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Check workspace with MSRV
         run: cargo check --workspace
@@ -435,6 +483,8 @@ jobs:
           shared-key: ${{ matrix.os }}-${{ matrix.rust }}
       - name: Install mold linker (Linux only)
         if: runner.os == 'Linux'
+        # Same stall ceiling as the other mold installs above.
+        timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Build
         run: cargo build --workspace --release
@@ -455,6 +505,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install mold linker
+        # Bounded because an unresponsive apt mirror hangs here rather than
+        # failing: one PR run sat 98 minutes on this step and would have held
+        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
+        # ceiling only ever trips on a stall, and it trips fast enough to be
+        # worth re-running.
+        timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Generate coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
@@ -474,6 +530,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install mold linker
+        # Bounded because an unresponsive apt mirror hangs here rather than
+        # failing: one PR run sat 98 minutes on this step and would have held
+        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
+        # ceiling only ever trips on a stall, and it trips fast enough to be
+        # worth re-running.
+        timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Clean build time
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
         # failing: one PR run sat 98 minutes on this step and would have held
         # the runner until GitHub's 6h default. Normal is ~10-20s, so this
         # ceiling only ever trips on a stall, and it trips fast enough to be
-        # worth re-running.
+        # worth re-running. The other mold installs below refer back here.
         timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Check workspace
@@ -38,11 +38,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
-        # Bounded because an unresponsive apt mirror hangs here rather than
-        # failing: one PR run sat 98 minutes on this step and would have held
-        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
-        # ceiling only ever trips on a stall, and it trips fast enough to be
-        # worth re-running.
+        # Same stall ceiling as the other mold installs above.
         timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Run unit tests
@@ -61,11 +57,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
-        # Bounded because an unresponsive apt mirror hangs here rather than
-        # failing: one PR run sat 98 minutes on this step and would have held
-        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
-        # ceiling only ever trips on a stall, and it trips fast enough to be
-        # worth re-running.
+        # Same stall ceiling as the other mold installs above.
         timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Run unit tests with strict-unknown feature
@@ -82,11 +74,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
-        # Bounded because an unresponsive apt mirror hangs here rather than
-        # failing: one PR run sat 98 minutes on this step and would have held
-        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
-        # ceiling only ever trips on a stall, and it trips fast enough to be
-        # worth re-running.
+        # Same stall ceiling as the other mold installs above.
         timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Install pinned localharness wheel
@@ -325,11 +313,7 @@ jobs:
         with:
           shared-key: integration-${{ matrix.group }}
       - name: Install mold linker
-        # Bounded because an unresponsive apt mirror hangs here rather than
-        # failing: one PR run sat 98 minutes on this step and would have held
-        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
-        # ceiling only ever trips on a stall, and it trips fast enough to be
-        # worth re-running.
+        # Same stall ceiling as the other mold installs above.
         timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Run integration tests (${{ matrix.group }})
@@ -404,11 +388,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
-        # Bounded because an unresponsive apt mirror hangs here rather than
-        # failing: one PR run sat 98 minutes on this step and would have held
-        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
-        # ceiling only ever trips on a stall, and it trips fast enough to be
-        # worth re-running.
+        # Same stall ceiling as the other mold installs above.
         timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Run clippy
@@ -422,11 +402,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
-        # Bounded because an unresponsive apt mirror hangs here rather than
-        # failing: one PR run sat 98 minutes on this step and would have held
-        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
-        # ceiling only ever trips on a stall, and it trips fast enough to be
-        # worth re-running.
+        # Same stall ceiling as the other mold installs above.
         timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Check documentation (all features)
@@ -451,11 +427,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Install mold linker
-        # Bounded because an unresponsive apt mirror hangs here rather than
-        # failing: one PR run sat 98 minutes on this step and would have held
-        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
-        # ceiling only ever trips on a stall, and it trips fast enough to be
-        # worth re-running.
+        # Same stall ceiling as the other mold installs above.
         timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Check workspace with MSRV
@@ -505,11 +477,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install mold linker
-        # Bounded because an unresponsive apt mirror hangs here rather than
-        # failing: one PR run sat 98 minutes on this step and would have held
-        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
-        # ceiling only ever trips on a stall, and it trips fast enough to be
-        # worth re-running.
+        # Same stall ceiling as the other mold installs above.
         timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Generate coverage
@@ -530,11 +498,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install mold linker
-        # Bounded because an unresponsive apt mirror hangs here rather than
-        # failing: one PR run sat 98 minutes on this step and would have held
-        # the runner until GitHub's 6h default. Normal is ~10-20s, so this
-        # ceiling only ever trips on a stall, and it trips fast enough to be
-        # worth re-running.
+        # Same stall ceiling as the other mold installs above.
         timeout-minutes: 5
         run: sudo apt-get update || true; sudo apt-get install -y mold
       - name: Clean build time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0] - 2026-08-15
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - 2026-08-15
+## [0.10.0] - 2026-08-16
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "genai-rs"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "genai-rs-macros"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 [package]
 name = "genai-rs"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"
@@ -54,7 +54,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-genai-rs-macros = { version = "0.9.0", path = "./genai-rs-macros" }
+genai-rs-macros = { version = "0.10.0", path = "./genai-rs-macros" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ live-verification notes are in
 
 ```toml
 [dependencies]
-genai-rs = "0.9"
+genai-rs = "0.10"
 tokio = { version = "1.0", features = ["full"] }
 
 # Required together, if you use the #[tool] macro
-genai-rs-macros = "0.9"  # The macro itself
+genai-rs-macros = "0.10"  # The macro itself
 async-trait = "0.1"      # Referenced by #[tool]-generated code
 serde_json = "1.0"       # Referenced by #[tool]-generated code
 

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -19,7 +19,7 @@ Enable the feature:
 
 ```toml
 [dependencies]
-genai-rs = { version = "0.9", features = ["antigravity"] }
+genai-rs = { version = "0.10", features = ["antigravity"] }
 ```
 
 Install the harness binary (it ships inside the platform-specific wheel):

--- a/genai-rs-macros/Cargo.toml
+++ b/genai-rs-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genai-rs-macros"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
Version bump for the release that lands #415, plus a CI fix this PR ran into.

## Why minor, not patch

Cargo treats the minor as the major for pre-1.0 crates. The README's
installation section tells people to write `genai-rs = "0.9"`, which matches
any 0.9.x — so a 0.9.1 would reach every existing user on their next
`cargo update` with no opt-in. 0.10.0 makes them edit the dependency line,
which is the friction a behavior break should carry.

## The break

`AgentBuilder`'s per-turn budget now defaults to `DEFAULT_TURN_TIMEOUT`
(300s) instead of unlimited. It compiles fine and fails at runtime: an agent
whose turn legitimately runs past 300s — a deep subagent tree, a long tool
chain — now gets `AntigravityError::Timeout` where it previously completed.
`without_turn_timeout()` restores the old behavior, which is itself the
admission that this is a behavior choice rather than a defect being fixed.

Everything else in the release is additive (the five model constants),
internal (the model-literal guard, the CI vacuous-pass guards), or cosmetic
(the examples move, docs).

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | `version`, and the `genai-rs-macros` dependency constraint |
| `genai-rs-macros/Cargo.toml` | `version` |
| `CHANGELOG.md` | `[Unreleased]` → `[0.10.0] - 2026-08-16` |
| `Cargo.lock` | both workspace crates, as cargo regenerated it |
| `README.md` | both installation lines → `"0.10"` |
| `docs/ANTIGRAVITY.md` | setup snippet → `"0.10"` |

The `rand = "0.9"` line in `Cargo.toml` is an unrelated dependency and is
deliberately untouched.

## CI: bound the mold install

`sudo apt-get install -y mold` runs in eleven steps across `rust.yml` and two
more in `release.yml`, and none was bounded. A stalled apt mirror does not
fail the command, it hangs — and with no ceiling the runner is held until
GitHub's 6h default.

This PR hit exactly that: the Test Suite job sat **98 minutes** on that step
and never reached the tests, while every other job went green, so the PR
showed one pending check with nothing to read. A cancel and re-run cleared it
in 9 seconds.

All thirteen steps now carry `timeout-minutes: 5` — normally 10–20s, so the
ceiling only trips on a stall, and the failure names the step instead of
stalling silently. Step-level rather than job-level, matching the existing
timeout on the antigravity example smoke-run: it points at the step that
actually hangs and leaves the long jobs their full budget.

`release.yml` also used `apt-get update && install`, so a transient mirror
error would fail the release outright where `rust.yml` proceeds; it now uses
`|| true;` to match. That relaxation is scoped to `update` alone — the
install remains the last command under `bash -e`, so a genuinely missing
package still fails loudly.

No CHANGELOG entry for the CI work — CI-only, per the repo's convention.

## Verification

Run against the bump tree locally: `cargo fmt --check` clean, `cargo clippy
--workspace --all-targets --all-features -- -D warnings` clean, **1198/1198
tests passing**, `RUSTDOCFLAGS="-D warnings" cargo doc` clean. In CI, the
full suite is green on `6a0f03d` including all five integration groups and
both doctest steps; the workflow change is validated by CI running it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqkKDDoTDKUp9zBk4M8WGH