### PR TITLE
Move `ModalityTokens::new()` from Documented to Added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,6 +314,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `examples/file_search.rs` now provisions its own store and runs end to end,
   replacing a placeholder store ID that could never work.
 
+- **`ModalityTokens::new()`** — the type had no `Default` and no constructor,
+  so closing it above would otherwise have left `serde` as the only way to
+  produce one.
+
 ### Documented
 
 - Several live-verified File Search behaviors now in
@@ -324,10 +328,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no chunk contents (so `has_file_search_results()` can be `true` while
   `file_search_results()` is empty), and `file_search` cannot be combined with
   either `google_search` or `url_context` (`code_execution` is fine).
-
-- **`ModalityTokens::new()`** — the type had no `Default` and no constructor,
-  so closing it above would otherwise have left `serde` as the only way to
-  produce one.
 
 ### Removed
 


### PR DESCRIPTION
A new public constructor is filed under `### Documented`, which is #435's
section for doc-only changes. It belongs under `### Added`.

## How it got there

The same absorption that put Added entries under `### Removed` earlier in
this batch: a heading arriving from one branch lands between an entry and
the heading it was written for. `ModalityTokens::new()` was under `### Added`
on #446; #435's `### Documented` section merged in above it, and the entry
fell under the new heading.

## Why it matters

`.github/scripts/extract_changelog_section.sh` lifts the version section
verbatim into the GitHub release body. As it stands, a reader scanning
**Added** for new API will not find this constructor — and it is the one that
exists specifically *because* #446 closed `ModalityTokens`, so it is the entry
most likely to be looked for.

## Verification

The line multiset is unchanged, checked programmatically — only placement
moved, no prose was edited, added, or dropped. `cargo fmt --all -- --check`
passes.

## Related

This is the ninth instance of this failure class across the batch just
merged. #458 tracks the general problem and weighs two remedies: a structural
lint in the `shell-scripts` job, or a `changelog.d/` restructure that makes
the conflicts impossible rather than merely loud. That issue is worth a
decision before the next release; this PR is just the one instance that
reached `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jqCMGodSnv2THiRwzB1RK

---
_Generated by [Claude Code](https://claude.ai/code/session_015jqCMGodSnv2THiRwzB1RK)_